### PR TITLE
Store post text with real newlines

### DIFF
--- a/docs/post_text_escaping_migration.sql
+++ b/docs/post_text_escaping_migration.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+-- Fix old social news posts and comments that were stored with manually escaped
+-- newlines/quotes before JSON serialization.
+UPDATE "posts"
+SET "text" = replace(
+    replace("text", chr(92) || 'n', E'\n'),
+    chr(92) || '"',
+    '"'
+)
+WHERE "post_path" IS NULL
+  AND "text" IS NOT NULL
+  AND (
+    "text" LIKE '%' || chr(92) || 'n' || '%'
+    OR "text" LIKE '%' || chr(92) || '"' || '%'
+  );
+
+COMMIT;

--- a/src/basic/assist_funcs.cc
+++ b/src/basic/assist_funcs.cc
@@ -188,23 +188,20 @@ void create_mdx_from_template_file(
 }
 
 void fix_new_lines(std::string &content) {
-  size_t pos = 0;
+  std::string normalized;
+  normalized.reserve(content.size());
 
-  std::string from = "\n";
-  std::string to = "\\n";
-
-  while ((pos = content.find(from, pos)) != std::string::npos) {
-    content.replace(pos, from.length(), to);
-    pos += to.length();
+  for (size_t i = 0; i < content.size(); ++i) {
+    if (content[i] == '\r') {
+      if (i + 1 < content.size() && content[i + 1] == '\n') {
+        ++i;
+      }
+      normalized += '\n';
+    } else {
+      normalized += content[i];
+    }
   }
 
-  from = "\"";
-  to = "\\\"";
-
-  pos = 0;
-  while ((pos = content.find(from, pos)) != std::string::npos) {
-    content.replace(pos, from.length(), to);
-    pos += to.length();
-  }
+  content = normalized;
 }
 } // namespace assist

--- a/test/test_post_text_escaping.py
+++ b/test/test_post_text_escaping.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path):
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def function_body(source, signature):
+    start = source.index(signature)
+    brace = source.index("{", start)
+    depth = 0
+    for pos in range(brace, len(source)):
+        if source[pos] == "{":
+            depth += 1
+        elif source[pos] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace : pos + 1]
+    raise AssertionError(f"Function body not found for {signature}")
+
+
+def test_post_text_keeps_real_newlines_until_json_serialization():
+    assist_source = read("src/basic/assist_funcs.cc")
+    social_header = read("src/letovo-soc-net/social.h")
+    social_source = read("src/letovo-soc-net/social.cc")
+    serializer_source = read("src/basic/pqxx_cp.cc")
+    fix_new_lines = function_body(assist_source, "void fix_new_lines")
+    add_comment = function_body(social_source, "int add_comment")
+
+    assert 'to = "\\\\n"' not in fix_new_lines
+    assert 'to = "\\\\\\\""' not in fix_new_lines
+    assert "content.replace" not in fix_new_lines
+    assert "normalized += '\\n'" in fix_new_lines
+    assert "escape_newlines" not in social_header
+    assert "escape_newlines" not in social_source
+    assert "{comment, post_id, username}" in add_comment
+    assert 'out += "\\\\n"' in serializer_source


### PR DESCRIPTION
## Summary
- stop manually escaping post text/title/author newlines before storing posts
- update letovo-soc-net submodule to remove duplicate comment newline escaping
- add docs/post_text_escaping_migration.sql to repair existing social news posts and comments in posts.text
- add a regression test that keeps manual escaping out of the write path while preserving JSON serialization escaping

Submodule PR: https://github.com/letovo-dev/letovo-soc-net/pull/1

## Tests
- pytest -q test/test_post_text_escaping.py test/test_social_news_date_filter.py