### PR TITLE
Fix post text migration predicate

### DIFF
--- a/docs/post_text_escaping_migration.sql
+++ b/docs/post_text_escaping_migration.sql
@@ -11,8 +11,8 @@ SET "text" = replace(
 WHERE "post_path" IS NULL
   AND "text" IS NOT NULL
   AND (
-    "text" LIKE '%' || chr(92) || 'n' || '%'
-    OR "text" LIKE '%' || chr(92) || '"' || '%'
+    strpos("text", chr(92) || 'n') > 0
+    OR strpos("text", chr(92) || '"') > 0
   );
 
 COMMIT;


### PR DESCRIPTION
## Summary
- use strpos() instead of LIKE for literal backslash sequence checks in post_text_escaping_migration.sql
- avoid PostgreSQL LIKE backslash escape semantics when finding stored \n / \" sequences

## Live check
- fixed the remaining live comment row post_id=2105 with literal \n
## Tests
- pytest -q test/test_post_text_escaping.py test/test_social_news_date_filter.py