### PR TITLE
fix: include payment metadata in user full endpoint

### DIFF
--- a/src/basic/user_data.cc
+++ b/src/basic/user_data.cc
@@ -1,4 +1,25 @@
 #include "user_data.h"
+#include "../market/transactions.h"
+
+namespace {
+
+std::string append_user_payments_fields(const std::string &user_serialized,
+                                        const std::string &payments_json) {
+  if (user_serialized.empty() || user_serialized.back() != '}') {
+    return user_serialized;
+  }
+  std::string body = user_serialized;
+  body.pop_back();
+  if (payments_json.size() >= 2 && payments_json.front() == '{' &&
+      payments_json.back() == '}') {
+    body += ',';
+    body.append(payments_json.begin() + 1, payments_json.end() - 1);
+  }
+  body += '}';
+  return body;
+}
+
+} // namespace
 
 namespace user {
 pqxx::result role(int role_id,
@@ -507,9 +528,13 @@ void full_user_info(
               .set_body("user not found")
               .done();
         }
+
+        std::string response_body = append_user_payments_fields(
+            cp::serialize(result),
+            transactions::last_incoming_outgoing_payments_json(username, pool_ptr));
         return req->create_response()
             .append_header("Content-Type", "application/json; charset=utf-8")
-            .set_body(cp::serialize(result))
+            .set_body(response_body)
             .done();
       });
 }

--- a/test/test_user_full_payments_metadata.py
+++ b/test/test_user_full_payments_metadata.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+USER_DATA_CC = REPO_ROOT / "src" / "basic" / "user_data.cc"
+TRANSACTIONS_CC = REPO_ROOT / "src" / "market" / "transactions.cc"
+
+
+def test_user_full_endpoint_includes_last_payment_metadata():
+    """The profile refresh endpoint should expose the same payment metadata as login."""
+    source = USER_DATA_CC.read_text()
+    handler_start = source.index("void full_user_info(")
+    handler_end = source.index("void user_roles(", handler_start)
+    handler = source[handler_start:handler_end]
+
+    assert "append_user_payments_fields" in handler
+    assert "transactions::last_incoming_outgoing_payments_json(username, pool_ptr)" in handler
+    assert ".set_body(response_body)" in handler
+
+    transactions_source = TRANSACTIONS_CC.read_text()
+    assert "'last_incoming_payment'" in transactions_source
+    assert "'last_outgoing_payment'" in transactions_source


### PR DESCRIPTION
## Summary
- include last_incoming_payment and last_outgoing_payment metadata in /user/full/:username responses
- reuse the existing transactions::last_incoming_outgoing_payments_json source of truth used by login
- add a focused regression test that verifies the /user/full handler wires payment metadata into its response body

## Test Plan
- python3 -m pytest test/test_user_full_payments_metadata.py -q
- python3 -m py_compile test/test_user_full_payments_metadata.py
- docker syntax/compile check for touched translation unit: g++ -std=c++20 -I. -Ibuild/_deps/jwt-cpp-src/include -Ibuild/_deps/nlohmann_json-src/include -fsyntax-only basic/user_data.cc
- docker build --target builder --build-arg MAIN_FILE=server.cpp --build-arg BUILD_FILES='basic/auth.cc basic/utils.cc basic/pqxx_cp.cc basic/hash.cc basic/assist_funcs.cc basic/url_parser.cc basic/user_data.cc basic/checks.cc basic/media.cc basic/media_cash.cc basic/qr_worker.cc basic/ws_topic_authorizer.cc basic/ws_event_bus.cc basic/ws_endpoint.cc market/transactions.cc market/actives.cc market/DOM.cc letovo-soc-net/social.cc letovo-soc-net/achivements.cc letovo-soc-net/page_server.cc letovo-soc-net/authors.cc letovo-soc-net/chat.cc letovo-soc-net/chat_ws.cc' -t letovo-server-verify:user-full-payments src

Note: the first long Docker build was manually killed during image export after it had already logged Built target server_starter; a repeated cached Docker builder build then completed with exit code 0.