### PR TITLE
fix: expose avatar list route

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -114,6 +114,8 @@ create(std::shared_ptr<cp::ConnectionsManager> pool_ptr,
   auth::server::register_true(router, pool_ptr, logger_ptr);
   auth::server::is_admin(router, pool_ptr, logger_ptr);
 
+  user::server::all_avatars(router, pool_ptr, logger_ptr);
+  user::server::set_avatar(router, pool_ptr, logger_ptr);
   user::server::user_info(router, pool_ptr, logger_ptr);
   user::server::full_user_info(router, pool_ptr, logger_ptr);
   user::server::user_roles(router, pool_ptr, logger_ptr);
@@ -126,8 +128,6 @@ create(std::shared_ptr<cp::ConnectionsManager> pool_ptr,
   user::server::set_users_department(router, pool_ptr, logger_ptr);
   user::server::all_departments(router, pool_ptr, logger_ptr);
   user::server::starter_role(router, pool_ptr, logger_ptr);
-  user::server::all_avatars(router, pool_ptr, logger_ptr);
-  user::server::set_avatar(router, pool_ptr, logger_ptr);
 
   transactions::server::prepare_transaction(router, pool_ptr, logger_ptr);
   transactions::server::transfer(router, pool_ptr, logger_ptr);

--- a/test/test_user_route_order.py
+++ b/test/test_user_route_order.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_static_user_avatar_routes_registered_before_wildcard_user_route():
+    server_cpp = Path(__file__).resolve().parents[1] / "src" / "server.cpp"
+    source = server_cpp.read_text(encoding="utf-8")
+
+    wildcard_user_route = "user::server::user_info(router, pool_ptr, logger_ptr);"
+    all_avatars_route = "user::server::all_avatars(router, pool_ptr, logger_ptr);"
+    set_avatar_route = "user::server::set_avatar(router, pool_ptr, logger_ptr);"
+
+    assert all_avatars_route in source
+    assert set_avatar_route in source
+    assert wildcard_user_route in source
+    assert source.index(all_avatars_route) < source.index(wildcard_user_route)
+    assert source.index(set_avatar_route) < source.index(wildcard_user_route)


### PR DESCRIPTION
## Summary
- Register `/user/all_avatars` and `/user/set_avatar` before the wildcard `/user/:username` route.
- Add a regression test that prevents one-segment static user routes from being shadowed by `user_info`.

## Why
On production, `GET /letovo-api/user/all_avatars` is currently handled as username `all_avatars` and returns `204`, so the frontend shows “нет доступных аватаров” even though avatar files exist under `/srv/letovo/media/images/avatars`.

## Test Plan
- `python3 -m pytest test/test_user_route_order.py -q`
- `git diff --check`

## Production note
A backend deploy is required after merge/CI image publication. The media files do not need to be added; 30 user avatar files are present on prod.