### PR TITLE
Fix admin negative transaction checks

### DIFF
--- a/test/test_market.py
+++ b/test/test_market.py
@@ -5,6 +5,7 @@ Covers all 4 transaction endpoints with various scenarios.
 import requests
 import pytest
 import time
+import os
 
 BASE_URL = "http://0.0.0.0:8080"
 
@@ -52,6 +53,30 @@ def receiver_user():
         "login": "scv",
         "password": None,
         "token": None
+    }
+
+
+@pytest.fixture(scope="module")
+def admin_user():
+    """Use explicitly provided admin credentials for privileged transaction tests"""
+    login = os.environ.get("LETOVO_ADMIN_LOGIN")
+    password = os.environ.get("LETOVO_ADMIN_PASSWORD")
+    if not login or not password:
+        pytest.skip("LETOVO_ADMIN_LOGIN/LETOVO_ADMIN_PASSWORD are required")
+
+    response = requests.post(
+        f"{BASE_URL}/auth/login",
+        json={"login": login, "password": password},
+        verify=False
+    )
+
+    assert response.status_code == 200, "Failed to login admin test user"
+    token = response.headers.get("Authorization")
+    assert token, "Failed to get admin token"
+
+    return {
+        "login": login,
+        "token": token
     }
 
 
@@ -178,6 +203,22 @@ def test_prepare_transaction_zero_amount(sender_user, receiver_user):
     )
     # Should succeed as 0 is valid
     assert response.status_code in [200, 409]
+
+
+def test_prepare_negative_transaction_as_admin(admin_user, sender_user):
+    """Admins can prepare negative transactions without receiver balance checks."""
+    response = requests.post(
+        f"{BASE_URL}/transactions/prepare",
+        headers={"Bearer": admin_user["token"]},
+        json={
+            "receiver": sender_user["login"],
+            "amount": -1000000000
+        },
+        verify=False
+    )
+
+    assert response.status_code == 200
+    assert response.text
 
 
 def test_prepare_transaction_nonexistent_receiver(sender_user):

--- a/test/test_transaction_rules.py
+++ b/test/test_transaction_rules.py
@@ -1,0 +1,34 @@
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_admin_negative_transaction_ignores_receiver_balance(tmp_path):
+    """The market rules allow admins to prepare negative transactions."""
+    repo_root = Path(__file__).resolve().parents[1]
+    source = tmp_path / "transaction_rules_check.cpp"
+    binary = tmp_path / "transaction_rules_check"
+
+    source.write_text(
+        textwrap.dedent(
+            f"""
+            #include "{repo_root / "src/market/transaction_rules.h"}"
+
+            int main() {{
+                if (!transactions::can_transfer_amount(10000, -1000000000, true)) {{
+                    return 1;
+                }}
+                if (transactions::can_transfer_amount(10000, -1, false)) {{
+                    return 2;
+                }}
+                return 0;
+            }}
+            """
+        )
+    )
+
+    subprocess.run(
+        ["g++", "-std=c++20", str(source), "-o", str(binary)],
+        check=True,
+    )
+    subprocess.run([str(binary)], check=True)


### PR DESCRIPTION
## Summary
- update market submodule to the admin negative transaction fix
- add a unit regression test for the shared transaction amount rule
- add an optional API regression test for admin negative transaction prepare using LETOVO_ADMIN_LOGIN/LETOVO_ADMIN_PASSWORD

Depends on: https://github.com/letovo-dev/market/pull/3

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider test/test_transaction_rules.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider test/test_transaction_rules.py test/test_market.py::test_prepare_negative_transaction_as_admin
- cmake --build . --target server_starter