### PR TITLE
Fix article delete/update 502s

### DIFF
--- a/src/letovo-soc-net/page_server.cc
+++ b/src/letovo-soc-net/page_server.cc
@@ -1,7 +1,89 @@
 #include "page_server.h"
 #include "../basic/security.h"
 
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
+#include <optional>
+
 namespace {
+
+    bool parse_int_string(const char* value, int& out) {
+        if (value == nullptr || value[0] == '\0') {
+            return false;
+        }
+
+        char* end = nullptr;
+        errno = 0;
+        long parsed = std::strtol(value, &end, 10);
+        if (errno != 0 || end == value || *end != '\0') {
+            return false;
+        }
+        if (parsed < std::numeric_limits<int>::min() || parsed > std::numeric_limits<int>::max()) {
+            return false;
+        }
+
+        out = static_cast<int>(parsed);
+        return true;
+    }
+
+    std::optional<int> json_int_value(const rapidjson::Value& value) {
+        if (value.IsInt()) {
+            return value.GetInt();
+        }
+        if (value.IsString()) {
+            int parsed = 0;
+            if (parse_int_string(value.GetString(), parsed)) {
+                return parsed;
+            }
+        }
+        return std::nullopt;
+    }
+
+    std::optional<int> json_int_member(const rapidjson::Document& body, const char* key) {
+        if (!body.HasMember(key)) {
+            return std::nullopt;
+        }
+        return json_int_value(body[key]);
+    }
+
+    std::optional<bool> json_bool_value(const rapidjson::Value& value) {
+        if (value.IsBool()) {
+            return value.GetBool();
+        }
+        if (value.IsString()) {
+            std::string str = value.GetString();
+            if (str == "t" || str == "true" || str == "1") {
+                return true;
+            }
+            if (str == "f" || str == "false" || str == "0") {
+                return false;
+            }
+        }
+        return std::nullopt;
+    }
+
+    std::optional<std::string> json_string_member(const rapidjson::Document& body, const char* key) {
+        if (!body.HasMember(key)) {
+            return std::nullopt;
+        }
+        if (!body[key].IsString()) {
+            return std::nullopt;
+        }
+        return std::string(body[key].GetString());
+    }
+
+    std::string row_string_or_empty(const pqxx::row& row, const char* key) {
+        return row[key].is_null() ? "" : row[key].as<std::string>();
+    }
+
+    int row_int_or_zero(const pqxx::row& row, const char* key) {
+        return row[key].is_null() ? 0 : row[key].as<int>();
+    }
+
+    bool row_bool_or_false(const pqxx::row& row, const char* key) {
+        return !row[key].is_null() && row[key].as<bool>();
+    }
 
     void normalize_article_categories(std::unique_ptr<cp::AsyncConnection>& con) {
         con->execute(R"SQL(
@@ -484,20 +566,39 @@ namespace page::server {
             // TODO: can delete if author
             rapidjson::Document new_body;
             new_body.Parse(req->body().c_str());
-            if (!new_body.HasMember("post_id")) {
-                return req->create_response(restinio::status_non_authoritative_information()).done();
-            }
-            std::string post_author = page::get_page_content(new_body["post_id"].GetInt(), pool_ptr)[0]["author"].as<std::string>();
-            if (!authors::check_if_avaluable_author(auth::get_username(token, pool_ptr), post_author, pool_ptr)) {
-                logger_ptr->info([]{return "not admin";});
-                return req->create_response(restinio::status_unauthorized()).set_body("not your post - do not touch it!").done();
+            if (new_body.HasParseError() || !new_body.IsObject()) {
+                return req->create_response(restinio::status_bad_request()).done();
             }
 
-            page::delete_post(new_body["post_id"].GetInt(), pool_ptr, logger_ptr);
-            return req->create_response(restinio::status_ok())
-                .append_header("Content-Type", "text/plain; charset=utf-8")
-                .set_body("ok")
-                .done();
+            auto post_id = json_int_member(new_body, "post_id");
+            if (!post_id.has_value() || *post_id <= 0) {
+                return req->create_response(restinio::status_bad_request()).done();
+            }
+
+            try {
+                pqxx::result post = page::get_page_content(*post_id, pool_ptr);
+                if (post.empty()) {
+                    return req->create_response(restinio::status_not_found()).done();
+                }
+
+                std::string post_author = row_string_or_empty(post[0], "author");
+                std::string username = auth::get_username(token, pool_ptr);
+                if (!authors::check_if_avaluable_author(username, post_author, pool_ptr)) {
+                    logger_ptr->info([]{return "not admin";});
+                    return req->create_response(restinio::status_unauthorized()).set_body("not your post - do not touch it!").done();
+                }
+
+                page::delete_post(*post_id, pool_ptr, logger_ptr);
+                return req->create_response(restinio::status_ok())
+                    .append_header("Content-Type", "text/plain; charset=utf-8")
+                    .set_body("ok")
+                    .done();
+            } catch (const std::exception& e) {
+                logger_ptr->error([post_id, e] {
+                    return fmt::format("error deleting post {}: {}", *post_id, e.what());
+                });
+                return req->create_response(restinio::status_internal_server_error()).done();
+            }
         });
     }   
     
@@ -517,63 +618,111 @@ namespace page::server {
             }
             rapidjson::Document new_body;
             new_body.Parse(req->body().c_str());
-            auto old_post = page::get_page_content(stoi(new_body["post_id"].GetString()), pool_ptr);
-            logger_ptr->info( [post_id = new_body["post_id"].GetString()]{return fmt::format("update post with id {}", post_id);});
-            std::string text, title, author;
-            if(new_body.HasMember("text")) {
-                text = new_body["text"].GetString();
-                assist::fix_new_lines(text);
-            } else {
-                text = old_post[0]["text"].as<std::string>();
+            if (new_body.HasParseError() || !new_body.IsObject()) {
+                return req->create_response(restinio::status_bad_request()).done();
             }
-            if(new_body.HasMember("title")) {
-                title = new_body["title"].GetString();
-                assist::fix_new_lines(title);
-            } else {
-                title = old_post[0]["title"].as<std::string>();
+
+            auto post_id = json_int_member(new_body, "post_id");
+            if (!post_id.has_value() || *post_id <= 0) {
+                return req->create_response(restinio::status_bad_request()).done();
             }
-            if(new_body.HasMember("author") && authors::check_if_avaluable_author(auth::get_username(token, pool_ptr), new_body["author"].GetString(), pool_ptr)) {
-                author = new_body["author"].GetString();
-                assist::fix_new_lines(author);
-            } else {
-                author = old_post[0]["author"].as<std::string>();
-            }
+
             try {
-                // std::string text = new_body.HasMember("text") ? new_body["text"].GetString() : old_post[0]["text"].as<std::string>();
-                // assist::fix_new_lines(text);
+                auto old_post = page::get_page_content(*post_id, pool_ptr);
+                if (old_post.empty()) {
+                    return req->create_response(restinio::status_not_found()).done();
+                }
+
+                logger_ptr->info([post_id] { return fmt::format("update post with id {}", *post_id); });
+
+                std::string text, title, author;
+                auto request_text = json_string_member(new_body, "text");
+                if(new_body.HasMember("text")) {
+                    if (!request_text.has_value()) {
+                        return req->create_response(restinio::status_bad_request()).done();
+                    }
+                    text = *request_text;
+                    assist::fix_new_lines(text);
+                } else {
+                    text = row_string_or_empty(old_post[0], "text");
+                }
+                auto request_title = json_string_member(new_body, "title");
+                if(new_body.HasMember("title")) {
+                    if (!request_title.has_value()) {
+                        return req->create_response(restinio::status_bad_request()).done();
+                    }
+                    title = *request_title;
+                    assist::fix_new_lines(title);
+                } else {
+                    title = row_string_or_empty(old_post[0], "title");
+                }
+                auto request_author = json_string_member(new_body, "author");
+                if(new_body.HasMember("author")) {
+                    if (!request_author.has_value()) {
+                        return req->create_response(restinio::status_bad_request()).done();
+                    }
+                    if (authors::check_if_avaluable_author(auth::get_username(token, pool_ptr), *request_author, pool_ptr)) {
+                        author = *request_author;
+                        assist::fix_new_lines(author);
+                    } else {
+                        author = row_string_or_empty(old_post[0], "author");
+                    }
+                } else {
+                    author = row_string_or_empty(old_post[0], "author");
+                }
+
+                auto is_secret = new_body.HasMember("is_secret") ? json_bool_value(new_body["is_secret"]) : std::optional<bool>(row_bool_or_false(old_post[0], "is_secret"));
+                auto likes = new_body.HasMember("likes") ? json_int_value(new_body["likes"]) : std::optional<int>(row_int_or_zero(old_post[0], "likes"));
+                auto dislikes = new_body.HasMember("dislikes") ? json_int_value(new_body["dislikes"]) : std::optional<int>(row_int_or_zero(old_post[0], "dislikes"));
+                auto saved_count = new_body.HasMember("saved_count") ? json_int_value(new_body["saved_count"]) : std::optional<int>(row_int_or_zero(old_post[0], "saved_count"));
+                if (!is_secret.has_value() || !likes.has_value() || !dislikes.has_value() || !saved_count.has_value()) {
+                    return req->create_response(restinio::status_bad_request()).done();
+                }
+
+                auto category_name = json_string_member(new_body, "category_name");
+                auto post_path = json_string_member(new_body, "post_path");
+                if ((new_body.HasMember("category_name") && !category_name.has_value()) ||
+                    (new_body.HasMember("post_path") && !post_path.has_value())) {
+                    return req->create_response(restinio::status_bad_request()).done();
+                }
+
                 page::update_post(
-                    new_body.HasMember("post_id") ? stoi(new_body["post_id"].GetString()) : old_post[0]["post_id"].as<int>(),
-                    new_body.HasMember("is_secret") ? new_body["is_secret"].GetString()[0] == 't' : old_post[0]["is_secret"].as<bool>(),
-                    new_body.HasMember("likes") ? stoi(new_body["likes"].GetString()) : old_post[0]["likes"].as<int>(),
-                    new_body.HasMember("dislikes") ? stoi(new_body["dislikes"].GetString()) : old_post[0]["dislikes"].as<int>(),
-                    new_body.HasMember("saved_count") ? stoi(new_body["saved_count"].GetString()) : old_post[0]["saved_count"].as<int>(),
+                    *post_id,
+                    *is_secret,
+                    *likes,
+                    *dislikes,
+                    *saved_count,
                     title,
                     author,
                     text,
-                    new_body.HasMember("category_name") && new_body["category_name"].IsString() ? new_body["category_name"].GetString() : old_post[0]["category_name"].as<std::string>(),
-                    new_body.HasMember("post_path") && new_body["post_path"].IsString() ? new_body["post_path"].GetString() : (old_post[0]["post_path"].is_null() ? "" : old_post[0]["post_path"].as<std::string>()),
+                    category_name.has_value() ? *category_name : row_string_or_empty(old_post[0], "category_name"),
+                    post_path.has_value() ? *post_path : row_string_or_empty(old_post[0], "post_path"),
                     pool_ptr, logger_ptr
                 );
+
+                std::vector<std::string> media_paths;
+                page::med_to_vec(new_body, media_paths);
+                if (!media_paths.empty()) {
+                    page::add_media(*post_id, media_paths, pool_ptr, logger_ptr);
+                }
+
+                std::string username = auth::get_username(token, pool_ptr);
+                return req->create_response(restinio::status_ok())
+                    .append_header("Content-Type", "application/json; charset=utf-8")
+                    .set_body(cp::serialize_with_shift_day(
+                        social::get_post(
+                            std::to_string(*post_id),
+                            username,
+                            security::can_read_secret_posts(username, pool_ptr),
+                            pool_ptr),
+                        pool_ptr))
+                    .done();
             } catch (const std::exception& e) {
-                logger_ptr->error( [e]{return fmt::format("error updating post: {}", e.what());});
+                logger_ptr->error([post_id, e] {
+                    return fmt::format("error updating post {}: {}", *post_id, e.what());
+                });
                 return req->create_response(restinio::status_internal_server_error()).done();
             }
-            std::vector<std::string> media_paths;
-            page::med_to_vec(new_body, media_paths);
-            if (!media_paths.empty()) {
-                page::add_media(stoi(new_body["post_id"].GetString()), media_paths, pool_ptr, logger_ptr);
-            }
-
-            return req->create_response(restinio::status_ok())
-                .append_header("Content-Type", "application/json; charset=utf-8")
-                .set_body(cp::serialize_with_shift_day(
-                    social::get_post(
-                        new_body["post_id"].GetString(),
-                        auth::get_username(token, pool_ptr),
-                        security::can_read_secret_posts(auth::get_username(token, pool_ptr), pool_ptr),
-                        pool_ptr),
-                    pool_ptr))
-                .done();
         });
     }
 

--- a/src/letovo-soc-net/page_server.cc
+++ b/src/letovo-soc-net/page_server.cc
@@ -583,7 +583,10 @@ namespace page::server {
 
                 std::string post_author = row_string_or_empty(post[0], "author");
                 std::string username = auth::get_username(token, pool_ptr);
-                if (!authors::check_if_avaluable_author(username, post_author, pool_ptr)) {
+                bool can_delete = post_author.empty()
+                    ? auth::is_admin(token, pool_ptr)
+                    : authors::check_if_avaluable_author(username, post_author, pool_ptr);
+                if (!can_delete) {
                     logger_ptr->info([]{return "not admin";});
                     return req->create_response(restinio::status_unauthorized()).set_body("not your post - do not touch it!").done();
                 }

--- a/test/test_pages.py
+++ b/test/test_pages.py
@@ -1,5 +1,6 @@
 import pytest
 import requests
+import os
 
 
 BASE_URL = "http://0.0.0.0:8080"
@@ -22,6 +23,58 @@ def auth_token():
         token = data.get("token", "")
     assert token, "Failed to get auth token"
     return token
+
+
+@pytest.fixture(scope="module")
+def admin_token():
+    login = os.environ.get("LETOVO_ADMIN_LOGIN")
+    password = os.environ.get("LETOVO_ADMIN_PASSWORD")
+    if not login or not password:
+        pytest.skip("LETOVO_ADMIN_LOGIN/LETOVO_ADMIN_PASSWORD are required")
+
+    response = requests.post(
+        f"{BASE_URL}/auth/login",
+        json={"login": login, "password": password},
+        verify=False
+    )
+    assert response.status_code == 200, "Failed to login admin test user"
+    token = response.headers.get("Authorization")
+    assert token, "Failed to get admin token"
+    return token
+
+
+def _create_test_post(auth_token, title="issue 54 test post"):
+    response = requests.post(
+        f"{BASE_URL}/post/add_page_content",
+        json={
+            "is_secret": False,
+            "is_published": True,
+            "likes": 0,
+            "title": title,
+            "author": TEST_USER,
+            "text": "issue 54 regression",
+            "token": auth_token,
+        },
+        verify=False
+    )
+    assert response.status_code == 200
+    return response.json()["result"][0]["post_id"]
+
+
+def _create_test_article(admin_token, title="issue 54 article"):
+    response = requests.post(
+        f"{BASE_URL}/post/add_page",
+        json={
+            "post_path": f"/media/{title.replace(' ', '_')}.md",
+            "category_name": "Issue54",
+            "title": title,
+            "is_secret": "f",
+        },
+        headers={"Bearer": admin_token},
+        verify=False
+    )
+    assert response.status_code == 200
+    return response.json()["result"][0]["post_id"]
 
 
 @pytest.mark.order1
@@ -95,3 +148,76 @@ def test_update_likes(auth_token):
     response = requests.get(url, verify=False)
     assert response.status_code == 200
     assert response.json()["result"][0]["likes"] == "101"
+
+
+def test_delete_post_accepts_string_post_id(auth_token):
+    page_id = _create_test_post(auth_token, "issue 54 delete string id")
+
+    response = requests.delete(
+        f"{BASE_URL}/post/delete",
+        json={"post_id": str(page_id)},
+        headers={"Bearer": auth_token},
+        verify=False
+    )
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+def test_delete_post_accepts_numeric_post_id(auth_token):
+    page_id = _create_test_post(auth_token, "issue 54 delete numeric id")
+
+    response = requests.delete(
+        f"{BASE_URL}/post/delete",
+        json={"post_id": int(page_id)},
+        headers={"Bearer": auth_token},
+        verify=False
+    )
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+def test_delete_post_rejects_malformed_post_id_without_upstream_close(auth_token):
+    response = requests.delete(
+        f"{BASE_URL}/post/delete",
+        json={"post_id": "not-a-number"},
+        headers={"Bearer": auth_token},
+        verify=False
+    )
+
+    assert response.status_code == 400
+
+
+def test_update_article_payload_returns_controlled_response(admin_token):
+    page_id = _create_test_article(admin_token)
+
+    response = requests.put(
+        f"{BASE_URL}/post/update",
+        json={
+            "post_id": str(page_id),
+            "is_secret": "f",
+            "likes": 0,
+            "dislikes": "0",
+            "saved_count": 0,
+            "title": "issue 54 article updated",
+            "text": "",
+            "category_name": "Issue54Updated",
+            "post_path": "/media/issue_54_article_updated.md",
+        },
+        headers={"Bearer": admin_token},
+        verify=False
+    )
+
+    assert response.status_code == 200
+
+
+def test_update_post_rejects_malformed_post_id_without_upstream_close(admin_token):
+    response = requests.put(
+        f"{BASE_URL}/post/update",
+        json={"post_id": "not-a-number"},
+        headers={"Bearer": admin_token},
+        verify=False
+    )
+
+    assert response.status_code == 400

--- a/test/test_pages.py
+++ b/test/test_pages.py
@@ -178,6 +178,20 @@ def test_delete_post_accepts_numeric_post_id(auth_token):
     assert response.text == "ok"
 
 
+def test_delete_article_allows_admin_when_author_is_empty(admin_token):
+    page_id = _create_test_article(admin_token, "issue 54 delete authorless article")
+
+    response = requests.delete(
+        f"{BASE_URL}/post/delete",
+        json={"post_id": str(page_id)},
+        headers={"Bearer": admin_token},
+        verify=False
+    )
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
 def test_delete_post_rejects_malformed_post_id_without_upstream_close(auth_token):
     response = requests.delete(
         f"{BASE_URL}/post/delete",


### PR DESCRIPTION
## Summary
- accept numeric and string post_id values for /post/delete and /post/update
- validate JSON field types before RapidJSON GetInt/GetString calls so malformed payloads return 400
- wrap update response construction so serialization/social lookup failures return controlled 500s instead of closing the upstream connection
- normalize frontend article mutation payloads and bump the frontend submodule to letovo-dev/letovo-all-frontend@6a344a1

Closes #54

## Verification
- npm run test:article-payload
- python3 -m pytest -q frontend/test/test_frontend_api_contracts.py -p no:cacheprovider
- BUILD_FILES=... MAIN_FILE=server.cpp cmake -S src -B /tmp/letovo-issue54-build
- cmake --build /tmp/letovo-issue54-build -j2
- python3 -m pytest --collect-only -q test/test_pages.py -p no:cacheprovider