### PR TITLE
ci: add live deployment e2e smoke

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -1,0 +1,65 @@
+name: live deployment e2e
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Public test deployment URL
+        required: false
+        default: https://ya.sergeiscv.ru
+      wait_timeout_seconds:
+        description: Max time to wait for watchtower/nginx to serve the deployment
+        required: false
+        default: "600"
+      require_auth:
+        description: Require authenticated browser/API checks with LETOVO_E2E_* secrets
+        required: false
+        default: "false"
+  workflow_run:
+    workflows: ["build and verify"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+env:
+  PLAYWRIGHT_VERSION: "1.55.1"
+  LIVE_E2E_BASE_URL: ${{ inputs.base_url || 'https://ya.sergeiscv.ru' }}
+  LIVE_E2E_WAIT_TIMEOUT_SECONDS: ${{ inputs.wait_timeout_seconds || '600' }}
+  LIVE_E2E_REQUIRE_AUTH: ${{ inputs.require_auth || 'false' }}
+
+jobs:
+  live-e2e:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Playwright runtime
+        run: |
+          set -euo pipefail
+          export PLAYWRIGHT_PACKAGE_DIR="$RUNNER_TEMP/letovo-live-e2e"
+          mkdir -p "$PLAYWRIGHT_PACKAGE_DIR"
+          cd "$PLAYWRIGHT_PACKAGE_DIR"
+          npm init -y
+          npm install "playwright@${PLAYWRIGHT_VERSION}"
+          "$PLAYWRIGHT_PACKAGE_DIR/node_modules/.bin/playwright" install --with-deps chromium
+          echo "PLAYWRIGHT_PACKAGE_DIR=$PLAYWRIGHT_PACKAGE_DIR" >> "$GITHUB_ENV"
+
+      - name: Run live browser smoke
+        env:
+          LETOVO_E2E_USERNAME: ${{ secrets.LETOVO_E2E_USERNAME }}
+          LETOVO_E2E_PASSWORD: ${{ secrets.LETOVO_E2E_PASSWORD }}
+        run: node $GITHUB_WORKSPACE/test/e2e/live-platform-smoke.mjs

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -24,25 +24,38 @@ services:
           - /mnt/server-media:/app/pages
           - /mnt/server-configs:/app/configs
         labels:
-          - "com.centurylinklabs.watchtower.enable=true"
+          - "com.centurylinklabs.watchtower.enable=false"
 
     watchtower:
         image: containrrr/watchtower
         restart: unless-stopped
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
-        command: --interval 300 --cleanup --include-restarting --label-enable --registry-auth
+          - /home/sergei-scv/.docker/config.json:/config.json:ro
+        command: --interval 60 --cleanup --include-restarting --label-enable
 
     letovo-front:
-        image: letovo-front:latest
+        image: ghcr.io/letovo-dev/letovo-frontend:latest
         container_name: letovo-front
         restart: unless-stopped
         depends_on:
           - letovo-server
         ports:
-          - "3000:3000"
+          - "127.0.0.1:3000:3000"
         env_file:
-          - /home/zahar/letovo/front-env
+          - /mnt/letovo-front.env
+        init: true
+        cap_drop:
+          - ALL
+        security_opt:
+          - no-new-privileges:true
+        labels:
+          - "com.centurylinklabs.watchtower.enable=true"
+        logging:
+          driver: json-file
+          options:
+            max-size: "100m"
+            max-file: "10"
 
     letovo-flask-uploader:
         image: flask-uploader:latest

--- a/test/e2e/live-platform-smoke.mjs
+++ b/test/e2e/live-platform-smoke.mjs
@@ -1,0 +1,148 @@
+import { createRequire } from 'node:module';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const packageDir = process.env.PLAYWRIGHT_PACKAGE_DIR || process.cwd();
+const require = createRequire(`${packageDir.replace(/\/+$/, '')}/package.json`);
+const { chromium } = require('playwright');
+
+const baseUrl = (process.env.LIVE_E2E_BASE_URL || 'https://ya.sergeiscv.ru').replace(/\/+$/, '');
+const waitTimeoutMs = Number(process.env.LIVE_E2E_WAIT_TIMEOUT_SECONDS || 600) * 1000;
+const pollIntervalMs = 10_000;
+const requireAuth = process.env.LIVE_E2E_REQUIRE_AUTH === 'true';
+const username = process.env.LETOVO_E2E_USERNAME || '';
+const password = process.env.LETOVO_E2E_PASSWORD || '';
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function fetchText(path) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetch(`${baseUrl}${path}`, {
+      redirect: 'manual',
+      signal: controller.signal,
+    });
+    return {
+      status: response.status,
+      text: await response.text(),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function probeDeployment() {
+  const root = await fetchText('/');
+  assert(root.status === 200, `Expected / to return 200, got ${root.status}`);
+  assert(root.text.includes('<title>Letovo</title>'), 'Expected / to serve the Letovo frontend');
+
+  const login = await fetchText('/login');
+  assert(login.status === 200, `Expected /login to return 200, got ${login.status}`);
+  assert(login.text.includes('id="form_login"'), 'Expected /login to render the login input');
+  assert(login.text.includes('id="form_password"'), 'Expected /login to render the password input');
+
+  const api = await fetchText('/letovo-api/auth/login');
+  assert(
+    api.status === 501,
+    `Expected /letovo-api/auth/login GET to return 501, got ${api.status}`,
+  );
+
+  return true;
+}
+
+async function waitForLiveDeployment() {
+  const startedAt = Date.now();
+  let lastError = undefined;
+
+  while (Date.now() - startedAt <= waitTimeoutMs) {
+    try {
+      await probeDeployment();
+      return;
+    } catch (error) {
+      lastError = error;
+      console.log(`Live deployment is not ready yet: ${error.message}`);
+      await delay(pollIntervalMs);
+    }
+  }
+
+  throw new Error(
+    `Timed out waiting for live deployment after ${waitTimeoutMs}ms: ${lastError?.message}`,
+  );
+}
+
+async function checkPublicBrowserFlow(page) {
+  await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded' });
+  assert((await page.title()) === 'Letovo', 'Expected root page title to be Letovo');
+
+  await page.goto(`${baseUrl}/login`, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle');
+  const loginInput = page.locator('#form_login');
+  const passwordInput = page.locator('#form_password');
+  const submitButton = page.getByRole('button', { name: 'Войти' });
+
+  await loginInput.waitFor({ state: 'visible' });
+  await passwordInput.waitFor({ state: 'visible' });
+  await submitButton.waitFor({ state: 'visible' });
+  assert(await submitButton.isDisabled(), 'Expected login button to be disabled before input');
+
+  await loginInput.click();
+  await loginInput.pressSequentially('smoke-user');
+  await passwordInput.click();
+  await passwordInput.pressSequentially('smoke-password');
+  await page.waitForFunction(() => {
+    const submit = document.querySelector('button[type="submit"]');
+    return submit && !submit.disabled;
+  });
+}
+
+async function checkAuthenticatedBrowserFlow(page) {
+  if (!username || !password) {
+    assert(
+      !requireAuth,
+      'LIVE_E2E_REQUIRE_AUTH=true requires LETOVO_E2E_USERNAME and LETOVO_E2E_PASSWORD',
+    );
+    console.log('Skipping authenticated flow because LETOVO_E2E_* secrets are not configured.');
+    return;
+  }
+
+  await page.goto(`${baseUrl}/login`, { waitUntil: 'domcontentloaded' });
+  await page.locator('#form_login').fill(username);
+  await page.locator('#form_password').fill(password);
+
+  const loginResponsePromise = page.waitForResponse(response =>
+    response.url().includes('/letovo-api/auth/login'),
+  );
+  await page.getByRole('button', { name: 'Войти' }).click();
+  const loginResponse = await loginResponsePromise;
+  assert(loginResponse.status() === 200, `Login API returned HTTP ${loginResponse.status()}`);
+
+  await page.waitForURL(/\/(user|registration)(\/|$)/, { timeout: 20_000 });
+  const session = await page.evaluate(async () => {
+    const response = await fetch('/letovo-api/auth/amiauthed/', { credentials: 'include' });
+    const text = await response.text();
+    return { status: response.status, text };
+  });
+
+  assert(session.status === 200, `Session API returned HTTP ${session.status}`);
+  assert(session.text.includes('"status":"t"'), 'Session API did not confirm authenticated state');
+}
+
+async function main() {
+  await waitForLiveDeployment();
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1366, height: 900 } });
+
+  try {
+    await checkPublicBrowserFlow(page);
+    await checkAuthenticatedBrowserFlow(page);
+  } finally {
+    await browser.close();
+  }
+}
+
+await main();

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "live-e2e.yml"
+LIVE_SCRIPT = ROOT / "test" / "e2e" / "live-platform-smoke.mjs"
+COMPOSE = ROOT / "docs" / "docker-compose.yaml"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_live_e2e_workflow_runs_after_deployable_images_are_published():
+    workflow = _read(WORKFLOW)
+
+    assert "workflow_dispatch:" in workflow
+    assert "workflow_run:" in workflow
+    assert "workflows: [\"build and verify\"]" in workflow
+    assert "github.event.workflow_run.conclusion == 'success'" in workflow
+    assert "LIVE_E2E_BASE_URL" in workflow
+    assert "LIVE_E2E_WAIT_TIMEOUT_SECONDS" in workflow
+    assert "node $GITHUB_WORKSPACE/test/e2e/live-platform-smoke.mjs" in workflow
+
+
+def test_live_e2e_uses_condition_polling_and_browser_level_checks():
+    script = _read(LIVE_SCRIPT)
+
+    assert "async function waitForLiveDeployment" in script
+    assert "Expected /letovo-api/auth/login GET to return 501" in script
+    assert "page.goto(`${baseUrl}/login`" in script
+    assert "page.locator('#form_login')" in script
+    assert "page.locator('#form_password')" in script
+    assert "page.getByRole('button', { name: 'Войти' })" in script
+
+
+def test_checked_in_compose_matches_watchtower_frontend_image_contract():
+    compose = _read(COMPOSE)
+
+    assert "image: ghcr.io/letovo-dev/letovo-frontend:latest" in compose
+    assert "com.centurylinklabs.watchtower.enable=true" in compose
+    assert 'ports:\n          - "127.0.0.1:3000:3000"' in compose


### PR DESCRIPTION
## Summary
- Add a live deployment E2E workflow that runs manually and after successful main image publishing.
- Add a Playwright smoke script that condition-polls ya.sergeiscv.ru, checks frontend pages, /letovo-api routing, and optional authenticated login/session checks via LETOVO_E2E_* secrets.
- Align checked-in docker-compose with the live watchtower frontend image contract.

Fixes #68

## Test plan
- python3 -m pytest test/test_live_e2e_workflow_contract.py frontend/test/test_frontend_api_contracts.py frontend/test/test_production_domain_config.py -q
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/live-e2e.yml"); YAML.load_file("docs/docker-compose.yaml"); puts "ok"'
- node --check test/e2e/live-platform-smoke.mjs
- LIVE_E2E_BASE_URL=https://ya.sergeiscv.ru LIVE_E2E_WAIT_TIMEOUT_SECONDS=30 node test/e2e/live-platform-smoke.mjs (with local Playwright runtime; authenticated flow skipped locally because LETOVO_E2E_* secrets are not configured)