### PR TITLE
Gate PRs on live deployment e2e

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,10 @@ env:
     market/DOM.cc letovo-soc-net/social.cc letovo-soc-net/achivements.cc
     letovo-soc-net/page_server.cc letovo-soc-net/authors.cc letovo-soc-net/chat.cc
     letovo-soc-net/chat_ws.cc
+  BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-server
+  FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-all-frontend
+  REGISTRATION_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-registration-server
+  LIVE_E2E_BASE_URL: ${{ vars.LIVE_E2E_BASE_URL || 'https://ya.sergeiscv.ru' }}
 
 jobs:
   backend-pr:
@@ -47,6 +51,7 @@ jobs:
             MAIN_FILE=server.cpp
             TEST_FILE=test.cpp
             BUILD_FILES=${{ env.BACKEND_BUILD_FILES }}
+            LETOVO_BUILD_SHA=${{ github.sha }}
           tags: letovo-server:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -64,12 +69,92 @@ jobs:
             MAIN_FILE=registration_server.cpp
             TEST_FILE=test.cpp
             BUILD_FILES=${{ env.BACKEND_BUILD_FILES }}
+            LETOVO_BUILD_SHA=${{ github.sha }}
           tags: letovo-registration-server:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Inspect registration backend image
         run: docker image inspect letovo-registration-server:${{ github.sha }} >/dev/null
+
+  publish-pr-candidate:
+    if: github.event_name == 'pull_request'
+    needs: [backend-pr, frontend-verify]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Refuse forked pull requests
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "Live deployment e2e publishes immutable PR images, so forked PRs are not supported."
+          exit 1
+
+      - name: Checkout code with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ssh-key: ${{ secrets.SUBMODULE_SSH_KEY }}
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push PR backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src
+          push: true
+          build-args: |
+            MAIN_FILE=server.cpp
+            TEST_FILE=test.cpp
+            BUILD_FILES=${{ env.BACKEND_BUILD_FILES }}
+            LETOVO_BUILD_SHA=${{ github.sha }}
+          tags: ${{ env.BACKEND_IMAGE }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push PR registration backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src
+          push: true
+          build-args: |
+            MAIN_FILE=registration_server.cpp
+            TEST_FILE=test.cpp
+            BUILD_FILES=${{ env.BACKEND_BUILD_FILES }}
+            LETOVO_BUILD_SHA=${{ github.sha }}
+          tags: ${{ env.REGISTRATION_IMAGE }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push PR frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/dockerfile
+          push: true
+          build-args: |
+            LETOVO_BUILD_SHA=${{ github.sha }}
+            NEXT_PUBLIC_BASE_URL=${{ env.LIVE_E2E_BASE_URL }}/letovo-api
+            NEXT_PUBLIC_BASE_URL_UPLOAD=${{ env.LIVE_E2E_BASE_URL }}/letovo-api/upload/
+            NEXT_PUBLIC_BASE_URL_MEDIA=${{ env.LIVE_E2E_BASE_URL }}/letovo-api/media/get
+            NEXT_PUBLIC_UPLOAD_URL=${{ env.LIVE_E2E_BASE_URL }}/letovo-api/upload/
+            NEXT_PUBLIC_BASE_URL_CLEAR=${{ env.LIVE_E2E_BASE_URL }}
+          tags: ${{ env.FRONTEND_IMAGE }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   publish-main:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -107,6 +192,7 @@ jobs:
             MAIN_FILE=server.cpp
             TEST_FILE=test.cpp
             BUILD_FILES=${{ env.BACKEND_BUILD_FILES }}
+            LETOVO_BUILD_SHA=${{ github.sha }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/letovo-server:latest
             ghcr.io/${{ github.repository_owner }}/letovo-server:${{ github.sha }}
@@ -122,9 +208,24 @@ jobs:
             MAIN_FILE=registration_server.cpp
             TEST_FILE=test.cpp
             BUILD_FILES=${{ env.BACKEND_BUILD_FILES }}
+            LETOVO_BUILD_SHA=${{ github.sha }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/letovo-registration-server:latest
             ghcr.io/${{ github.repository_owner }}/letovo-registration-server:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/dockerfile
+          push: true
+          build-args: |
+            LETOVO_BUILD_SHA=${{ github.sha }}
+          tags: |
+            ${{ env.FRONTEND_IMAGE }}:latest
+            ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -162,3 +263,139 @@ jobs:
             echo "Found forbidden frontend route or host in built bundle"
             exit 1
           fi
+
+  live-deployment-e2e:
+    if: github.event_name == 'pull_request'
+    needs: [publish-pr-candidate]
+    runs-on: ubuntu-latest
+    concurrency:
+      group: live-deployment-e2e
+      cancel-in-progress: false
+    env:
+      PLAYWRIGHT_VERSION: "1.55.1"
+      LIVE_E2E_WAIT_TIMEOUT_SECONDS: ${{ vars.LIVE_E2E_WAIT_TIMEOUT_SECONDS || '600' }}
+      LIVE_E2E_REQUIRE_AUTH: "true"
+      LIVE_E2E_REQUIRE_EXTENDED: ${{ vars.LIVE_E2E_REQUIRE_EXTENDED || 'false' }}
+      LIVE_E2E_EXPECTED_BACKEND_SHA: ${{ github.sha }}
+      LIVE_E2E_EXPECTED_FRONTEND_SHA: ${{ github.sha }}
+      LETOVO_E2E_DEPLOY_HOST: ${{ vars.LETOVO_E2E_DEPLOY_HOST || 'ya.sergeiscv.ru' }}
+      LETOVO_E2E_DEPLOY_USER: ${{ secrets.LETOVO_E2E_DEPLOY_USER }}
+      LETOVO_E2E_DEPLOY_SSH_KEY: ${{ secrets.LETOVO_E2E_DEPLOY_SSH_KEY }}
+      LETOVO_E2E_DEPLOY_COMPOSE: ${{ vars.LETOVO_E2E_DEPLOY_COMPOSE || '/mnt/docker-compose.yaml' }}
+      LETOVO_E2E_DEPLOY_PROJECT: ${{ vars.LETOVO_E2E_DEPLOY_PROJECT || 'mnt' }}
+    steps:
+      - name: Set PR candidate image names
+        run: |
+          set -euo pipefail
+          tag="pr-${{ github.event.pull_request.number }}-${{ github.sha }}"
+          {
+            echo "BACKEND_CANDIDATE_IMAGE=${BACKEND_IMAGE}:${tag}"
+            echo "REGISTRATION_CANDIDATE_IMAGE=${REGISTRATION_IMAGE}:${tag}"
+            echo "FRONTEND_CANDIDATE_IMAGE=${FRONTEND_IMAGE}:${tag}"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate live e2e deployment secrets
+        run: |
+          set -euo pipefail
+          test -n "$LETOVO_E2E_DEPLOY_USER" || { echo "LETOVO_E2E_DEPLOY_USER secret is required"; exit 1; }
+          test -n "$LETOVO_E2E_DEPLOY_SSH_KEY" || { echo "LETOVO_E2E_DEPLOY_SSH_KEY secret is required"; exit 1; }
+          test -n "$BACKEND_CANDIDATE_IMAGE" || { echo "backend candidate image is required"; exit 1; }
+          test -n "$REGISTRATION_CANDIDATE_IMAGE" || { echo "registration candidate image is required"; exit 1; }
+          test -n "$FRONTEND_CANDIDATE_IMAGE" || { echo "frontend candidate image is required"; exit 1; }
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure deployment SSH
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$LETOVO_E2E_DEPLOY_SSH_KEY" > ~/.ssh/live-e2e
+          chmod 600 ~/.ssh/live-e2e
+          ssh-keyscan -H "$LETOVO_E2E_DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: Deploy PR candidate images to live e2e
+        run: |
+          set -euo pipefail
+          remote="${LETOVO_E2E_DEPLOY_USER}@${LETOVO_E2E_DEPLOY_HOST}"
+          ssh -i ~/.ssh/live-e2e "$remote" \
+            "BACKEND_IMAGE='$BACKEND_CANDIDATE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_CANDIDATE_IMAGE' FRONTEND_IMAGE='$FRONTEND_CANDIDATE_IMAGE' COMPOSE_FILE='$LETOVO_E2E_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_E2E_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
+          set -euo pipefail
+          test -f "$COMPOSE_FILE"
+          state_dir="/tmp/letovo-live-e2e-${RUN_ID}"
+          mkdir -p "$state_dir"
+          restore="$state_dir/restore.env"
+          candidate="$state_dir/docker-compose.yaml"
+
+          docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
+          docker inspect -f 'letovo-registration-server={{.Config.Image}}' letovo-registration-server >> "$restore"
+          docker inspect -f 'letovo-front={{.Config.Image}}' letovo-front >> "$restore"
+
+          sed \
+            -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${BACKEND_IMAGE}#" \
+            -e "s#image: ghcr.io/letovo-dev/letovo-registration-server:.*#image: ${REGISTRATION_IMAGE}#" \
+            -e "s#image: ghcr.io/letovo-dev/letovo.*frontend:.*#image: ${FRONTEND_IMAGE}#" \
+            "$COMPOSE_FILE" > "$candidate"
+
+          docker compose -p "$PROJECT_NAME" -f "$candidate" pull letovo-server letovo-registration-server letovo-front
+          docker compose -p "$PROJECT_NAME" -f "$candidate" up -d letovo-server letovo-registration-server letovo-front
+          test "$(docker inspect -f '{{.Config.Image}}' letovo-server)" = "$BACKEND_IMAGE"
+          test "$(docker inspect -f '{{.Config.Image}}' letovo-registration-server)" = "$REGISTRATION_IMAGE"
+          test "$(docker inspect -f '{{.Config.Image}}' letovo-front)" = "$FRONTEND_IMAGE"
+          REMOTE
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Playwright runtime
+        run: |
+          set -euo pipefail
+          export PLAYWRIGHT_PACKAGE_DIR="$RUNNER_TEMP/letovo-live-e2e"
+          mkdir -p "$PLAYWRIGHT_PACKAGE_DIR"
+          cd "$PLAYWRIGHT_PACKAGE_DIR"
+          npm init -y
+          npm install "playwright@${PLAYWRIGHT_VERSION}"
+          "$PLAYWRIGHT_PACKAGE_DIR/node_modules/.bin/playwright" install --with-deps chromium
+          echo "PLAYWRIGHT_PACKAGE_DIR=$PLAYWRIGHT_PACKAGE_DIR" >> "$GITHUB_ENV"
+
+      - name: Run live browser smoke
+        env:
+          LETOVO_E2E_USERNAME: ${{ secrets.LETOVO_E2E_USERNAME }}
+          LETOVO_E2E_PASSWORD: ${{ secrets.LETOVO_E2E_PASSWORD }}
+          LETOVO_E2E_SECONDARY_USERNAME: ${{ secrets.LETOVO_E2E_SECONDARY_USERNAME }}
+          LETOVO_E2E_SECONDARY_PASSWORD: ${{ secrets.LETOVO_E2E_SECONDARY_PASSWORD }}
+        run: node $GITHUB_WORKSPACE/test/e2e/live-platform-smoke.mjs
+
+      - name: Restore live deployment images
+        if: always()
+        run: |
+          set -euo pipefail
+          test -f ~/.ssh/live-e2e || exit 0
+          remote="${LETOVO_E2E_DEPLOY_USER}@${LETOVO_E2E_DEPLOY_HOST}"
+          ssh -i ~/.ssh/live-e2e "$remote" \
+            "COMPOSE_FILE='$LETOVO_E2E_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_E2E_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
+          set -euo pipefail
+          state_dir="/tmp/letovo-live-e2e-${RUN_ID}"
+          restore="$state_dir/restore.env"
+          test -f "$restore" || exit 0
+
+          backend_image="$(awk -F= '$1 == "letovo-server" { print $2 }' "$restore" | tail -n 1)"
+          registration_image="$(awk -F= '$1 == "letovo-registration-server" { print $2 }' "$restore" | tail -n 1)"
+          frontend_image="$(awk -F= '$1 == "letovo-front" { print $2 }' "$restore" | tail -n 1)"
+          test -n "$backend_image"
+          test -n "$registration_image"
+          test -n "$frontend_image"
+
+          candidate="$state_dir/docker-compose.restore.yaml"
+          sed \
+            -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${backend_image}#" \
+            -e "s#image: ghcr.io/letovo-dev/letovo-registration-server:.*#image: ${registration_image}#" \
+            -e "s#image: ghcr.io/letovo-dev/letovo.*frontend:.*#image: ${frontend_image}#" \
+            "$COMPOSE_FILE" > "$candidate"
+
+          docker compose -p "$PROJECT_NAME" -f "$candidate" pull letovo-server letovo-registration-server letovo-front || true
+          docker compose -p "$PROJECT_NAME" -f "$candidate" up -d letovo-server letovo-registration-server letovo-front
+          rm -rf "$state_dir"
+          REMOTE

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -19,6 +19,10 @@ on:
         description: Require mutating transfer/upload/post checks with secondary e2e secrets
         required: false
         default: "false"
+      expected_sha:
+        description: Optional backend/frontend deployment SHA to require before smoke checks pass
+        required: false
+        default: ""
   workflow_run:
     workflows: ["build and verify"]
     types: [completed]
@@ -32,6 +36,8 @@ env:
   LIVE_E2E_WAIT_TIMEOUT_SECONDS: ${{ inputs.wait_timeout_seconds || '600' }}
   LIVE_E2E_REQUIRE_AUTH: ${{ inputs.require_auth || 'false' }}
   LIVE_E2E_REQUIRE_EXTENDED: ${{ inputs.require_extended || 'false' }}
+  LIVE_E2E_EXPECTED_BACKEND_SHA: ${{ inputs.expected_sha || github.event.workflow_run.head_sha || '' }}
+  LIVE_E2E_EXPECTED_FRONTEND_SHA: ${{ inputs.expected_sha || github.event.workflow_run.head_sha || '' }}
 
 jobs:
   live-e2e:

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
         command: --interval 60 --cleanup --include-restarting --label-enable
 
     letovo-front:
-        image: ghcr.io/letovo-dev/letovo-frontend:latest
+        image: ghcr.io/letovo-dev/letovo-all-frontend:latest
         container_name: letovo-front
         restart: unless-stopped
         depends_on:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -54,6 +54,9 @@ RUN apt update && apt install -y \
 
 WORKDIR /app
 
+ARG LETOVO_BUILD_SHA=unknown
+ENV LETOVO_BUILD_SHA=${LETOVO_BUILD_SHA}
+
 COPY --from=builder /app/build/server_starter .
 
 EXPOSE 8080

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,7 +1,9 @@
 #include "rapidjson/document.h"
+#include <cstdlib>
 #include <iostream>
 #include <restinio/all.hpp>
 #include <restinio/tls.hpp>
+#include <string>
 
 // do i need this?
 #include <fmt/format.h>
@@ -34,6 +36,20 @@ using namespace restinio;
 
 namespace rr = restinio::router;
 using router_t = rr::express_router_t<>;
+
+void deployment_metadata(std::unique_ptr<restinio::router::express_router_t<>> &router) {
+  router.get()->http_get("/deployment/metadata", [](auto req, auto) {
+    const char *sha = std::getenv("LETOVO_BUILD_SHA");
+    std::string body = fmt::format(
+        R"({{"sha":"{}"}})",
+        sha && sha[0] ? sha : "unknown");
+    return req->create_response()
+        .set_body(body)
+        .append_header(restinio::http_field::content_type,
+                       "application/json; charset=utf-8")
+        .done();
+  });
+}
 
 void hi(std::unique_ptr<restinio::router::express_router_t<>> &router,
         std::shared_ptr<cp::ConnectionsManager> &pool_ptr,
@@ -83,6 +99,7 @@ create(std::shared_ptr<cp::ConnectionsManager> pool_ptr,
        std::shared_ptr<ws::TopicAuthorizer> authorizer_ptr) {
   auto router = std::make_unique<router::express_router_t<>>();
 
+  deployment_metadata(router);
   hi(router, pool_ptr, logger_ptr);
 
   page::server::get_page_content(router, pool_ptr, logger_ptr);

--- a/test/e2e/live-platform-smoke.mjs
+++ b/test/e2e/live-platform-smoke.mjs
@@ -10,6 +10,8 @@ const waitTimeoutMs = Number(process.env.LIVE_E2E_WAIT_TIMEOUT_SECONDS || 600) *
 const pollIntervalMs = 10_000;
 const requireAuth = process.env.LIVE_E2E_REQUIRE_AUTH === 'true';
 const requireExtended = process.env.LIVE_E2E_REQUIRE_EXTENDED === 'true';
+const expectedBackendSha = process.env.LIVE_E2E_EXPECTED_BACKEND_SHA || '';
+const expectedFrontendSha = process.env.LIVE_E2E_EXPECTED_FRONTEND_SHA || '';
 const username = process.env.LETOVO_E2E_USERNAME || '';
 const password = process.env.LETOVO_E2E_PASSWORD || '';
 const secondaryUsername = process.env.LETOVO_E2E_SECONDARY_USERNAME || '';
@@ -36,6 +38,20 @@ async function fetchText(path) {
   } finally {
     clearTimeout(timer);
   }
+}
+
+async function assertDeploymentMetadata(path, expectedSha, description) {
+  if (!expectedSha) {
+    return;
+  }
+
+  const response = await fetchText(path);
+  assert(response.status === 200, `${description} metadata returned HTTP ${response.status}`);
+  const metadata = parseJsonResponse(response, `${description} metadata`);
+  assert(
+    metadata.sha === expectedSha,
+    `${description} metadata sha ${metadata.sha || '<empty>'} does not match ${expectedSha}`,
+  );
 }
 
 function parseJsonResponse(response, description) {
@@ -77,12 +93,16 @@ async function loginAs(page, login, loginPassword) {
   await page.locator('#form_login').fill(login);
   await page.locator('#form_password').fill(loginPassword);
 
-  const loginResponsePromise = page.waitForResponse(response =>
-    response.url().includes('/letovo-api/auth/login'),
-  );
+  const loginResponsePromise = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return url.pathname.endsWith('/auth/login');
+  }, { timeout: 60_000 });
   await page.getByRole('button', { name: 'Войти' }).click();
   const loginResponse = await loginResponsePromise;
-  assert(loginResponse.status() === 200, `Login API returned HTTP ${loginResponse.status()}`);
+  assert(
+    loginResponse.status() === 200,
+    `Login API ${loginResponse.url()} returned HTTP ${loginResponse.status()}`,
+  );
 
   await page.waitForURL(/\/(user|registration)(\/|$)/, { timeout: 20_000 });
 }
@@ -229,6 +249,17 @@ async function probeDeployment() {
   assert(
     api.status === 501,
     `Expected /letovo-api/auth/login GET to return 501, got ${api.status}`,
+  );
+
+  await assertDeploymentMetadata(
+    '/letovo-api/deployment/metadata',
+    expectedBackendSha,
+    'Backend deployment',
+  );
+  await assertDeploymentMetadata(
+    '/api/deployment/metadata',
+    expectedFrontendSha,
+    'Frontend deployment',
   );
 
   return true;

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -3,8 +3,13 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "live-e2e.yml"
+BUILD_WORKFLOW = ROOT / ".github" / "workflows" / "docker-image.yml"
 LIVE_SCRIPT = ROOT / "test" / "e2e" / "live-platform-smoke.mjs"
 COMPOSE = ROOT / "docs" / "docker-compose.yaml"
+BACKEND_DOCKERFILE = ROOT / "src" / "Dockerfile"
+FRONTEND_DOCKERFILE = ROOT / "frontend" / "dockerfile"
+SERVER = ROOT / "src" / "server.cpp"
+FRONTEND_METADATA_ROUTE = ROOT / "frontend" / "src" / "app" / "api" / "deployment" / "metadata" / "route.ts"
 
 
 def _read(path: Path) -> str:
@@ -25,17 +30,53 @@ def test_live_e2e_workflow_runs_after_deployable_images_are_published():
     assert "LIVE_E2E_REQUIRE_EXTENDED" in workflow
     assert "inputs.require_extended || 'false'" in workflow
     assert "node $GITHUB_WORKSPACE/test/e2e/live-platform-smoke.mjs" in workflow
+    assert "expected_sha:" in workflow
+    assert "github.event.workflow_run.head_sha" in workflow
+
+
+def test_pr_build_publishes_candidate_images_before_live_e2e_gate():
+    workflow = _read(BUILD_WORKFLOW)
+
+    assert "publish-pr-candidate:" in workflow
+    assert "needs: [backend-pr, frontend-verify]" in workflow
+    assert "pr-${{ github.event.pull_request.number }}-${{ github.sha }}" in workflow
+    assert "Build and push PR backend image" in workflow
+    assert "Build and push PR registration backend image" in workflow
+    assert "Build and push PR frontend image" in workflow
+    assert "LETOVO_BUILD_SHA=${{ github.sha }}" in workflow
+    assert "NEXT_PUBLIC_BASE_URL=${{ env.LIVE_E2E_BASE_URL }}/letovo-api" in workflow
+    assert "NEXT_PUBLIC_BASE_URL_UPLOAD=${{ env.LIVE_E2E_BASE_URL }}/letovo-api/upload/" in workflow
+    assert "NEXT_PUBLIC_BASE_URL_MEDIA=${{ env.LIVE_E2E_BASE_URL }}/letovo-api/media/get" in workflow
+    assert "live-deployment-e2e:" in workflow
+    assert "needs: [publish-pr-candidate]" in workflow
+    assert 'LIVE_E2E_REQUIRE_AUTH: "true"' in workflow
+    assert "LIVE_E2E_EXPECTED_BACKEND_SHA: ${{ github.sha }}" in workflow
+    assert "LIVE_E2E_EXPECTED_FRONTEND_SHA: ${{ github.sha }}" in workflow
+    assert "concurrency:" in workflow
+    assert "LETOVO_E2E_DEPLOY_HOST" in workflow
+    assert "LETOVO_E2E_DEPLOY_USER" in workflow
+    assert "LETOVO_E2E_DEPLOY_SSH_KEY" in workflow
+    assert "LETOVO_E2E_DEPLOY_PROJECT" in workflow
+    assert "Deploy PR candidate images to live e2e" in workflow
+    assert "docker compose -p \"$PROJECT_NAME\" -f \"$candidate\" up -d letovo-server letovo-registration-server letovo-front" in workflow
+    assert "Restore live deployment images" in workflow
 
 
 def test_live_e2e_uses_condition_polling_and_browser_level_checks():
     script = _read(LIVE_SCRIPT)
 
     assert "async function waitForLiveDeployment" in script
+    assert "LIVE_E2E_EXPECTED_BACKEND_SHA" in script
+    assert "LIVE_E2E_EXPECTED_FRONTEND_SHA" in script
+    assert "async function assertDeploymentMetadata" in script
+    assert "/letovo-api/deployment/metadata" in script
+    assert "/api/deployment/metadata" in script
     assert "Expected /letovo-api/auth/login GET to return 501" in script
     assert "page.goto(`${baseUrl}/login`" in script
     assert "page.locator('#form_login')" in script
     assert "page.locator('#form_password')" in script
     assert "page.getByRole('button', { name: 'Войти' })" in script
+    assert "url.pathname.endsWith('/auth/login')" in script
     assert "JSON.parse(response.text)" in script
     assert "sessionJson.status === 't'" in script
     assert "async function checkMoneyTransfer" in script
@@ -48,6 +89,24 @@ def test_live_e2e_uses_condition_polling_and_browser_level_checks():
 def test_checked_in_compose_matches_watchtower_frontend_image_contract():
     compose = _read(COMPOSE)
 
-    assert "image: ghcr.io/letovo-dev/letovo-frontend:latest" in compose
+    assert "image: ghcr.io/letovo-dev/letovo-all-frontend:latest" in compose
     assert "com.centurylinklabs.watchtower.enable=true" in compose
     assert 'ports:\n          - "127.0.0.1:3000:3000"' in compose
+
+
+def test_images_expose_deployment_metadata_sha():
+    backend_dockerfile = _read(BACKEND_DOCKERFILE)
+    frontend_dockerfile = _read(FRONTEND_DOCKERFILE)
+    server = _read(SERVER)
+    frontend_route = _read(FRONTEND_METADATA_ROUTE)
+
+    assert "ARG LETOVO_BUILD_SHA=unknown" in backend_dockerfile
+    assert "ENV LETOVO_BUILD_SHA=${LETOVO_BUILD_SHA}" in backend_dockerfile
+    assert 'http_get("/deployment/metadata"' in server
+    assert 'R"({{"sha":"{}"}})"' in server
+    assert "ARG LETOVO_BUILD_SHA=unknown" in frontend_dockerfile
+    assert "LETOVO_BUILD_SHA=${LETOVO_BUILD_SHA}" in frontend_dockerfile
+    assert "ARG NEXT_PUBLIC_BASE_URL=" in frontend_dockerfile
+    assert "ARG NEXT_PUBLIC_BASE_URL_UPLOAD=" in frontend_dockerfile
+    assert "ARG NEXT_PUBLIC_BASE_URL_MEDIA=" in frontend_dockerfile
+    assert "process.env.LETOVO_BUILD_SHA" in frontend_route


### PR DESCRIPTION
## Что сделано

- Добавил публикацию immutable PR-образов backend, registration-backend и frontend с тегом `pr-<номер-pr>-<sha>` после успешных PR-checks.
- Перевел PR frontend-образ на пакет `ghcr.io/letovo-dev/letovo-all-frontend`, чтобы GitHub Actions мог публиковать PR-теги без конфликта с правами старого GHCR-пакета.
- Добавил live e2e build args для frontend PR-образа: `NEXT_PUBLIC_BASE_URL`, upload/media URLs и clear base теперь указывают на `ya.sergeiscv.ru`, поэтому браузерный smoke проверяет именно PR-стенд.
- Добавил PR-check `live-deployment-e2e`: он через SSH деплоит PR-образы на `ya.sergeiscv.ru`, запускает browser smoke и всегда восстанавливает предыдущие live-образы.
- Зафиксировал compose project name `mnt` для live deploy/restore, чтобы временный compose-файл обновлял существующие контейнеры, а не пытался создать контейнеры с занятыми именами.
- Добавил сериализацию live-деплоя через `concurrency`, чтобы параллельные PR не перетирали e2e-стенд.
- Добавил build metadata: backend отдает `/letovo-api/deployment/metadata`, frontend отдает `/api/deployment/metadata`; live e2e ждет, пока оба сервиса начнут отдавать ожидаемый SHA PR.
- Расширил post-merge/manual `live deployment e2e`, чтобы он тоже мог проверять ожидаемый SHA.
- Обновил frontend submodule до коммитов с metadata endpoint и поддержкой live e2e frontend API overrides.
- Настроил deploy-доступ для GitHub Actions: добавлен dedicated SSH key `letovo-live-e2e-github-actions`, secrets `LETOVO_E2E_DEPLOY_USER` и `LETOVO_E2E_DEPLOY_SSH_KEY`.
- Обновил ruleset `scv check`: обязательными стали `backend-pr`, `frontend-verify` и `live-deployment-e2e` со strict status checks.

## Проверка

- `python3 -m pytest test/test_live_e2e_workflow_contract.py`
- YAML parse для `.github/workflows/docker-image.yml` и `.github/workflows/live-e2e.yml`
- `npm run build` в frontend submodule
- `docker build` frontend image с live e2e `NEXT_PUBLIC_*` build args
- Проверил dedicated SSH key на `ya.sergeiscv.ru` и доступность `docker compose`.
- GitHub Actions run `28511229628`: `backend-pr`, `frontend-verify`, `publish-pr-candidate` и `live-deployment-e2e` прошли успешно.
- После live e2e проверил, что `ya.sergeiscv.ru` восстановлен на `:latest` образы и временных `letovo-live-e2e-*` сетей не осталось.

Fixes #73