### PR TITLE
Fix article update 502 response

### DIFF
--- a/src/letovo-soc-net/page_server.cc
+++ b/src/letovo-soc-net/page_server.cc
@@ -702,23 +702,42 @@ namespace page::server {
                     post_path.has_value() ? *post_path : row_string_or_empty(old_post[0], "post_path"),
                     pool_ptr, logger_ptr
                 );
+                logger_ptr->info([post_id] { return fmt::format("post {} database row updated", *post_id); });
 
                 std::vector<std::string> media_paths;
                 page::med_to_vec(new_body, media_paths);
                 if (!media_paths.empty()) {
                     page::add_media(*post_id, media_paths, pool_ptr, logger_ptr);
+                    logger_ptr->info([post_id] { return fmt::format("post {} media updated", *post_id); });
                 }
 
-                std::string username = auth::get_username(token, pool_ptr);
+                pqxx::result updated_post = page::get_page_content(*post_id, pool_ptr);
+                if (updated_post.empty()) {
+                    logger_ptr->error([post_id] {
+                        return fmt::format("post {} disappeared after update", *post_id);
+                    });
+                    return req->create_response(restinio::status_internal_server_error()).done();
+                }
+
+                pqxx::result response_post = updated_post;
+                if (row_string_or_empty(updated_post[0], "post_path").empty()) {
+                    std::string username = auth::get_username(token, pool_ptr);
+                    response_post = social::get_post(
+                        std::to_string(*post_id),
+                        username,
+                        security::can_read_secret_posts(username, pool_ptr),
+                        pool_ptr);
+                    if (response_post.empty()) {
+                        logger_ptr->error([post_id] {
+                            return fmt::format("post {} social response is empty after update", *post_id);
+                        });
+                        response_post = updated_post;
+                    }
+                }
+
                 return req->create_response(restinio::status_ok())
                     .append_header("Content-Type", "application/json; charset=utf-8")
-                    .set_body(cp::serialize_with_shift_day(
-                        social::get_post(
-                            std::to_string(*post_id),
-                            username,
-                            security::can_read_secret_posts(username, pool_ptr),
-                            pool_ptr),
-                        pool_ptr))
+                    .set_body(cp::serialize_with_shift_day(response_post, pool_ptr))
                     .done();
             } catch (const std::exception& e) {
                 logger_ptr->error([post_id, e] {

--- a/test/test_pages.py
+++ b/test/test_pages.py
@@ -224,6 +224,43 @@ def test_update_article_payload_returns_controlled_response(admin_token):
     )
 
     assert response.status_code == 200
+    result = response.json()["result"]
+    assert len(result) == 1
+    assert result[0]["post_id"] == str(page_id)
+    assert result[0]["title"] == "issue 54 article updated"
+    assert result[0]["category_name"] == "Issue54Updated"
+    assert result[0]["post_path"] == "/media/issue_54_article_updated.md"
+
+
+def test_update_authorless_article_from_md_editor_payload_returns_updated_row(admin_token):
+    page_id = _create_test_article(admin_token, "issue 77 authorless article")
+
+    response = requests.put(
+        f"{BASE_URL}/post/update",
+        json={
+            "post_id": str(page_id),
+            "is_secret": "f",
+            "likes": "0",
+            "dislikes": "0",
+            "saved_count": "0",
+            "title": "issue 77 article updated",
+            "author": "",
+            "text": "",
+            "category_name": "Issue77Updated",
+            "post_path": "/media/issue_77_article_updated.md",
+        },
+        headers={"Bearer": admin_token},
+        verify=False
+    )
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert len(result) == 1
+    assert result[0]["post_id"] == str(page_id)
+    assert result[0]["title"] == "issue 77 article updated"
+    assert result[0]["author"] == ""
+    assert result[0]["category_name"] == "Issue77Updated"
+    assert result[0]["post_path"] == "/media/issue_77_article_updated.md"
 
 
 def test_update_post_rejects_malformed_post_id_without_upstream_close(admin_token):


### PR DESCRIPTION
## Summary
- Return updated article rows directly after /post/update for article records instead of routing the response through the social feed join
- Preserve the existing enriched social response for normal news post updates
- Add regression assertions for authorless md-editor article updates

## Verification
- cmake --build . --target server_starter
- git diff --check
- python3 -m pytest test/test_pages.py -k 'update_article_payload_returns_controlled_response or update_authorless_article_from_md_editor_payload_returns_updated_row' -q -rs (skipped: LETOVO_ADMIN_LOGIN/LETOVO_ADMIN_PASSWORD are required)

Fixes #77