### PR TITLE
Fix nullable article update payloads

### DIFF
--- a/src/letovo-soc-net/page_server.cc
+++ b/src/letovo-soc-net/page_server.cc
@@ -67,22 +67,48 @@ namespace {
         if (!body.HasMember(key)) {
             return std::nullopt;
         }
+        if (body[key].IsNull()) {
+            return std::nullopt;
+        }
         if (!body[key].IsString()) {
             return std::nullopt;
         }
         return std::string(body[key].GetString());
     }
 
+    bool json_string_member_has_invalid_type(const rapidjson::Document& body, const char* key) {
+        return body.HasMember(key) && !body[key].IsString() && !body[key].IsNull();
+    }
+
     std::string row_string_or_empty(const pqxx::row& row, const char* key) {
-        return row[key].is_null() ? "" : row[key].as<std::string>();
+        for (const auto& field : row) {
+            if (std::string(field.name()) == key) {
+                return field.is_null() ? "" : field.as<std::string>();
+            }
+        }
+        return "";
     }
 
     int row_int_or_zero(const pqxx::row& row, const char* key) {
-        return row[key].is_null() ? 0 : row[key].as<int>();
+        for (const auto& field : row) {
+            if (std::string(field.name()) == key) {
+                return field.is_null() ? 0 : field.as<int>();
+            }
+        }
+        return 0;
+    }
+
+    bool row_bool_or_default(const pqxx::row& row, const char* key, bool default_value) {
+        for (const auto& field : row) {
+            if (std::string(field.name()) == key) {
+                return field.is_null() ? default_value : field.as<bool>();
+            }
+        }
+        return default_value;
     }
 
     bool row_bool_or_false(const pqxx::row& row, const char* key) {
-        return !row[key].is_null() && row[key].as<bool>();
+        return row_bool_or_default(row, key, false);
     }
 
     void normalize_article_categories(std::unique_ptr<cp::AsyncConnection>& con) {
@@ -288,7 +314,7 @@ namespace page::server {
                 return req->create_response(restinio::status_bad_gateway()).done();
             }
 
-            if (result[0]["is_secret"].as<bool>() == true || result[0]["is_published"].as<bool>() == false) {
+            if (row_bool_or_false(result[0], "is_secret") || !row_bool_or_default(result[0], "is_published", true)) {
                 logger_ptr->info( [endpoint]{return fmt::format("page request from {} is secret", endpoint);});
                 return req->create_response(restinio::status_not_found()).done();
             }
@@ -661,10 +687,10 @@ namespace page::server {
                 }
                 auto request_author = json_string_member(new_body, "author");
                 if(new_body.HasMember("author")) {
-                    if (!request_author.has_value()) {
+                    if (json_string_member_has_invalid_type(new_body, "author")) {
                         return req->create_response(restinio::status_bad_request()).done();
                     }
-                    if (authors::check_if_avaluable_author(auth::get_username(token, pool_ptr), *request_author, pool_ptr)) {
+                    if (request_author.has_value() && authors::check_if_avaluable_author(auth::get_username(token, pool_ptr), *request_author, pool_ptr)) {
                         author = *request_author;
                         assist::fix_new_lines(author);
                     } else {
@@ -684,8 +710,8 @@ namespace page::server {
 
                 auto category_name = json_string_member(new_body, "category_name");
                 auto post_path = json_string_member(new_body, "post_path");
-                if ((new_body.HasMember("category_name") && !category_name.has_value()) ||
-                    (new_body.HasMember("post_path") && !post_path.has_value())) {
+                if (json_string_member_has_invalid_type(new_body, "category_name") ||
+                    json_string_member_has_invalid_type(new_body, "post_path")) {
                     return req->create_response(restinio::status_bad_request()).done();
                 }
 

--- a/test/e2e/live-platform-smoke.mjs
+++ b/test/e2e/live-platform-smoke.mjs
@@ -235,6 +235,95 @@ async function createSmokePost(page, mediaPath) {
   assert(remove.text === 'ok', `Post cleanup returned unexpected body: ${remove.text}`);
 }
 
+async function editSmokeArticle(page) {
+  const marker = `live-e2e-article-${Date.now()}`;
+  const categoryName = 'Медиа';
+  let postId = undefined;
+
+  try {
+    const create = await fetchAuthenticated(page, '/letovo-api/post/add_page', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        post_path: `/media/${marker}.md`,
+        category_name: categoryName,
+        title: `Live e2e article ${marker}`,
+        is_secret: 'f',
+      }),
+    });
+
+    assert(create.status === 200, `Article create returned HTTP ${create.status}: ${create.text}`);
+    const createJson = parseJsonResponse(create, 'Article create API');
+    assert(
+      Array.isArray(createJson.result) && createJson.result.length > 0,
+      `Article create response did not include a result row: ${create.text}`,
+    );
+    postId = Number(createJson.result[0].post_id);
+    assert(Number.isInteger(postId), `Article create response returned no post_id: ${create.text}`);
+
+    const updatedTitle = `Live e2e article updated ${marker}`;
+    const updatedPath = `/media/${marker}-updated.md`;
+    const update = await fetchAuthenticated(page, '/letovo-api/post/update', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        post_id: String(postId),
+        is_secret: 'f',
+        likes: '0',
+        dislikes: '0',
+        saved_count: '0',
+        title: updatedTitle,
+        author: null,
+        parent_id: null,
+        text: '',
+        category_name: categoryName,
+        post_path: updatedPath,
+      }),
+    });
+
+    assert(update.status === 200, `Article update returned HTTP ${update.status}: ${update.text}`);
+    const updateJson = parseJsonResponse(update, 'Article update API');
+    assert(
+      Array.isArray(updateJson.result) && updateJson.result.length > 0,
+      `Article update response did not include a result row: ${update.text}`,
+    );
+    assert(
+      updateJson.result[0].title === updatedTitle,
+      `Article update returned unexpected title: ${update.text}`,
+    );
+    assert(
+      updateJson.result[0].post_path === updatedPath,
+      `Article update returned unexpected post_path: ${update.text}`,
+    );
+    assert(
+      updateJson.result[0].category_name === categoryName,
+      `Article update returned unexpected category_name: ${update.text}`,
+    );
+
+    const read = await fetchText(`/letovo-api/post/${postId}`);
+    assert(read.status === 200, `Article read returned HTTP ${read.status}: ${read.text}`);
+    const readJson = parseJsonResponse(read, 'Article read API');
+    assert(
+      Array.isArray(readJson.result) && readJson.result.length > 0,
+      `Article read response did not include a result row: ${read.text}`,
+    );
+    assert(
+      readJson.result[0].title === updatedTitle,
+      `Article read returned unexpected title: ${read.text}`,
+    );
+  } finally {
+    if (postId !== undefined) {
+      const remove = await fetchAuthenticated(page, '/letovo-api/post/delete', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ post_id: postId }),
+      });
+      assert(remove.status === 200, `Article cleanup returned HTTP ${remove.status}: ${remove.text}`);
+      assert(remove.text === 'ok', `Article cleanup returned unexpected body: ${remove.text}`);
+    }
+  }
+}
+
 async function probeDeployment() {
   const root = await fetchText('/');
   assert(root.status === 200, `Expected / to return 200, got ${root.status}`);
@@ -340,6 +429,7 @@ async function checkAuthenticatedBrowserFlow(page) {
   await assertAdminSession(page);
   await assertUploaderSession(page);
   await checkMoneyTransfer(page, secondaryUsername);
+  await editSmokeArticle(page);
   const mediaPath = await uploadSmokeFile(page);
   await createSmokePost(page, mediaPath);
 

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -82,6 +82,9 @@ def test_live_e2e_uses_condition_polling_and_browser_level_checks():
     assert "async function checkMoneyTransfer" in script
     assert "async function uploadSmokeFile" in script
     assert "async function createSmokePost" in script
+    assert "async function editSmokeArticle" in script
+    assert "author: null" in script
+    assert "Article update returned HTTP" in script
     assert "LIVE_E2E_REQUIRE_EXTENDED === 'true'" in script
     assert "LIVE_E2E_REQUIRE_EXTENDED=true requires LIVE_E2E_REQUIRE_AUTH=true" in script
 

--- a/test/test_pages.py
+++ b/test/test_pages.py
@@ -263,6 +263,52 @@ def test_update_authorless_article_from_md_editor_payload_returns_updated_row(ad
     assert result[0]["post_path"] == "/media/issue_77_article_updated.md"
 
 
+def test_update_authorless_article_accepts_nullable_md_editor_payload(admin_token):
+    page_id = _create_test_article(admin_token, "issue 77 nullable author article")
+
+    response = requests.put(
+        f"{BASE_URL}/post/update",
+        json={
+            "post_id": str(page_id),
+            "is_secret": "f",
+            "likes": "0",
+            "dislikes": "0",
+            "saved_count": "0",
+            "title": "issue 77 nullable article updated",
+            "author": None,
+            "parent_id": None,
+            "date": "2026-07-01 15:40:32",
+            "text": "",
+            "category_name": "Issue77NullableUpdated",
+            "post_path": "/media/issue_77_nullable_article_updated.md",
+        },
+        headers={"Bearer": admin_token},
+        verify=False
+    )
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert len(result) == 1
+    assert result[0]["post_id"] == str(page_id)
+    assert result[0]["title"] == "issue 77 nullable article updated"
+    assert result[0]["category_name"] == "Issue77NullableUpdated"
+    assert result[0]["post_path"] == "/media/issue_77_nullable_article_updated.md"
+    assert result[0]["author"] == ""
+
+
+def test_get_authorless_article_returns_controlled_response(admin_token):
+    page_id = _create_test_article(admin_token, "issue 77 get authorless article")
+
+    response = requests.get(f"{BASE_URL}/post/{page_id}", verify=False)
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert len(result) == 1
+    assert result[0]["post_id"] == str(page_id)
+    assert result[0]["title"] == "issue 77 get authorless article"
+    assert result[0]["author"] is None
+
+
 def test_update_post_rejects_malformed_post_id_without_upstream_close(admin_token):
     response = requests.put(
         f"{BASE_URL}/post/update",


### PR DESCRIPTION
## Summary
- accept optional article fields sent as null in /post/update instead of treating author: null as a bad request
- harden /post/:id row reads so missing legacy fields do not close the upstream before a response
- update the frontend submodule to letovo-dev/letovo-all-frontend#21 so md-editor omits nullable optional fields
- add regressions for nullable md-editor update payloads and authorless article reads

Fixes #77.

## Tests
- npm --prefix frontend run test:article-payload
- python3 -c "import ast, pathlib; ast.parse(pathlib.Path('test/test_pages.py').read_text())"
- git diff --check

Note: live backend route tests require a running local server and admin credentials; no local server was listening on :8080 in this workspace.