### PR TITLE
ci: add manual production release workflow

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1,0 +1,323 @@
+name: production release
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Public production URL for post-deploy e2e
+        required: true
+        default: https://letovocorp.ru
+      wait_timeout_seconds:
+        description: Max time to wait for production to serve the release
+        required: false
+        default: "600"
+      require_extended:
+        description: Run mutating authenticated e2e checks after deployment
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: production-release
+  cancel-in-progress: false
+
+env:
+  BACKEND_BUILD_FILES: >-
+    basic/auth.cc basic/security.cc basic/utils.cc basic/pqxx_cp.cc basic/hash.cc
+    basic/assist_funcs.cc basic/url_parser.cc basic/user_data.cc basic/checks.cc
+    basic/media.cc basic/media_cash.cc basic/qr_worker.cc basic/ws_topic_authorizer.cc
+    basic/ws_event_bus.cc basic/ws_endpoint.cc market/transactions.cc market/actives.cc
+    market/DOM.cc letovo-soc-net/social.cc letovo-soc-net/achivements.cc
+    letovo-soc-net/page_server.cc letovo-soc-net/authors.cc letovo-soc-net/chat.cc
+    letovo-soc-net/chat_ws.cc
+  BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-server
+  FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-all-frontend
+  REGISTRATION_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-registration-server
+  PLAYWRIGHT_VERSION: "1.55.1"
+  LIVE_E2E_BASE_URL: https://letovocorp.ru
+  LIVE_E2E_WAIT_TIMEOUT_SECONDS: ${{ inputs.wait_timeout_seconds }}
+  LIVE_E2E_REQUIRE_AUTH: "true"
+  LIVE_E2E_REQUIRE_EXTENDED: ${{ inputs.require_extended }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout main with submodules
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          submodules: recursive
+          ssh-key: ${{ secrets.SUBMODULE_SSH_KEY }}
+          persist-credentials: false
+
+      - name: Resolve release images
+        id: release
+        env:
+          INPUT_BASE_URL: ${{ inputs.base_url }}
+        run: |
+          set -euo pipefail
+          release_sha="$(git rev-parse HEAD)"
+          base_url="${INPUT_BASE_URL%/}"
+          base_url="${base_url%/}"
+          if [[ "$base_url" == *$'\r'* || "$base_url" == *$'\n'* ]]; then
+            echo "base_url must not contain CR/LF"
+            exit 1
+          fi
+          if [ "$base_url" != "https://letovocorp.ru" ]; then
+            echo "base_url must be https://letovocorp.ru for production releases"
+            exit 1
+          fi
+          {
+            echo "RELEASE_SHA=$release_sha"
+            echo "RELEASE_IMAGE_TAG=$release_sha"
+            echo "LIVE_E2E_BASE_URL=$base_url"
+            echo "BACKEND_RELEASE_IMAGE=${BACKEND_IMAGE}:${release_sha}"
+            echo "REGISTRATION_RELEASE_IMAGE=${REGISTRATION_IMAGE}:${release_sha}"
+            echo "FRONTEND_RELEASE_IMAGE=${FRONTEND_IMAGE}:${release_sha}"
+            echo "LIVE_E2E_EXPECTED_BACKEND_SHA=$release_sha"
+            echo "LIVE_E2E_EXPECTED_FRONTEND_SHA=$release_sha"
+          } >> "$GITHUB_ENV"
+          {
+            echo "release_sha=$release_sha"
+            echo "image_tag=$release_sha"
+            echo "base_url=$base_url"
+            echo "backend_image=${BACKEND_IMAGE}:${release_sha}"
+            echo "registration_image=${REGISTRATION_IMAGE}:${release_sha}"
+            echo "frontend_image=${FRONTEND_IMAGE}:${release_sha}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate production deployment secrets
+        env:
+          LETOVO_PROD_DEPLOY_HOST: ${{ vars.LETOVO_PROD_DEPLOY_HOST || '84.201.185.37' }}
+          LETOVO_PROD_DEPLOY_USER: ${{ secrets.LETOVO_PROD_DEPLOY_USER }}
+          LETOVO_PROD_DEPLOY_SSH_KEY: ${{ secrets.LETOVO_PROD_DEPLOY_SSH_KEY }}
+          LETOVO_PROD_DEPLOY_COMPOSE: ${{ vars.LETOVO_PROD_DEPLOY_COMPOSE || '/srv/letovo/compose/docker-compose.yaml' }}
+          LETOVO_PROD_DEPLOY_PROJECT: ${{ vars.LETOVO_PROD_DEPLOY_PROJECT || 'compose' }}
+        run: |
+          set -euo pipefail
+          test -n "$LETOVO_PROD_DEPLOY_USER" || { echo "LETOVO_PROD_DEPLOY_USER secret is required"; exit 1; }
+          test -n "$LETOVO_PROD_DEPLOY_SSH_KEY" || { echo "LETOVO_PROD_DEPLOY_SSH_KEY secret is required"; exit 1; }
+          test -n "$LETOVO_PROD_DEPLOY_HOST" || { echo "LETOVO_PROD_DEPLOY_HOST is required"; exit 1; }
+          test -n "$LETOVO_PROD_DEPLOY_COMPOSE" || { echo "LETOVO_PROD_DEPLOY_COMPOSE is required"; exit 1; }
+          test -n "$LETOVO_PROD_DEPLOY_PROJECT" || { echo "LETOVO_PROD_DEPLOY_PROJECT is required"; exit 1; }
+          test "$LIVE_E2E_REQUIRE_AUTH" = "true"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js for frontend route scan
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Scan production frontend bundle routes
+        working-directory: frontend
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
+          NEXT_PUBLIC_BASE_URL: ${{ steps.release.outputs.base_url }}/letovo-api
+          NEXT_PUBLIC_BASE_URL_UPLOAD: ${{ steps.release.outputs.base_url }}/letovo-api/upload/
+          NEXT_PUBLIC_BASE_URL_MEDIA: ${{ steps.release.outputs.base_url }}/letovo-api/media/get
+          NEXT_PUBLIC_UPLOAD_URL: ${{ steps.release.outputs.base_url }}/letovo-api/upload/
+          NEXT_PUBLIC_BASE_URL_CLEAR: ${{ steps.release.outputs.base_url }}
+          LETOVO_BUILD_SHA: ${{ steps.release.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run build
+          if grep -R -I -n -E 'ya\.sergeiscv\.ru|/undefined/auth|/letovo-api/letovo-api' .next; then
+            echo "Found forbidden frontend route or host in built production bundle"
+            exit 1
+          fi
+
+      - name: Build and push production backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src
+          push: true
+          build-args: |
+            MAIN_FILE=server.cpp
+            TEST_FILE=test.cpp
+            BUILD_FILES=${{ env.BACKEND_BUILD_FILES }}
+            LETOVO_BUILD_SHA=${{ steps.release.outputs.release_sha }}
+          tags: ${{ steps.release.outputs.backend_image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push production registration image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src
+          push: true
+          build-args: |
+            MAIN_FILE=registration_server.cpp
+            TEST_FILE=test.cpp
+            BUILD_FILES=${{ env.BACKEND_BUILD_FILES }}
+            LETOVO_BUILD_SHA=${{ steps.release.outputs.release_sha }}
+          tags: ${{ steps.release.outputs.registration_image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push production frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/dockerfile
+          push: true
+          build-args: |
+            LETOVO_BUILD_SHA=${{ steps.release.outputs.release_sha }}
+            NEXT_PUBLIC_BASE_URL=${{ steps.release.outputs.base_url }}/letovo-api
+            NEXT_PUBLIC_BASE_URL_UPLOAD=${{ steps.release.outputs.base_url }}/letovo-api/upload/
+            NEXT_PUBLIC_BASE_URL_MEDIA=${{ steps.release.outputs.base_url }}/letovo-api/media/get
+            NEXT_PUBLIC_UPLOAD_URL=${{ steps.release.outputs.base_url }}/letovo-api/upload/
+            NEXT_PUBLIC_BASE_URL_CLEAR=${{ steps.release.outputs.base_url }}
+          tags: ${{ steps.release.outputs.frontend_image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Configure production SSH
+        env:
+          LETOVO_PROD_DEPLOY_HOST: ${{ vars.LETOVO_PROD_DEPLOY_HOST || '84.201.185.37' }}
+          LETOVO_PROD_DEPLOY_SSH_KEY: ${{ secrets.LETOVO_PROD_DEPLOY_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$LETOVO_PROD_DEPLOY_SSH_KEY" > ~/.ssh/letovo-production-release
+          chmod 600 ~/.ssh/letovo-production-release
+          ssh-keyscan -H "$LETOVO_PROD_DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: Transfer production images to host
+        env:
+          LETOVO_PROD_DEPLOY_HOST: ${{ vars.LETOVO_PROD_DEPLOY_HOST || '84.201.185.37' }}
+          LETOVO_PROD_DEPLOY_USER: ${{ secrets.LETOVO_PROD_DEPLOY_USER }}
+        run: |
+          set -euo pipefail
+          remote="${LETOVO_PROD_DEPLOY_USER}@${LETOVO_PROD_DEPLOY_HOST}"
+          images=(
+            "$BACKEND_RELEASE_IMAGE"
+            "$REGISTRATION_RELEASE_IMAGE"
+            "$FRONTEND_RELEASE_IMAGE"
+          )
+          for image in "${images[@]}"; do
+            docker pull "$image"
+          done
+          docker save "${images[@]}" | gzip -1 | ssh -i ~/.ssh/letovo-production-release "$remote" 'gzip -dc | docker load'
+
+      - name: Deploy production images
+        env:
+          LETOVO_PROD_DEPLOY_HOST: ${{ vars.LETOVO_PROD_DEPLOY_HOST || '84.201.185.37' }}
+          LETOVO_PROD_DEPLOY_USER: ${{ secrets.LETOVO_PROD_DEPLOY_USER }}
+          LETOVO_PROD_DEPLOY_COMPOSE: ${{ vars.LETOVO_PROD_DEPLOY_COMPOSE || '/srv/letovo/compose/docker-compose.yaml' }}
+          LETOVO_PROD_DEPLOY_PROJECT: ${{ vars.LETOVO_PROD_DEPLOY_PROJECT || 'compose' }}
+        run: |
+          set -euo pipefail
+          remote="${LETOVO_PROD_DEPLOY_USER}@${LETOVO_PROD_DEPLOY_HOST}"
+          ssh -i ~/.ssh/letovo-production-release "$remote" \
+            "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
+          set -euo pipefail
+          test -f "$COMPOSE_FILE"
+          state_dir="/tmp/letovo-production-release-${RUN_ID}"
+          mkdir -p "$state_dir"
+          restore="$state_dir/restore.env"
+          compose_backup="$state_dir/docker-compose.yaml.before-release"
+          candidate="$state_dir/docker-compose.yaml"
+
+          docker image inspect "$BACKEND_IMAGE" >/dev/null
+          docker image inspect "$REGISTRATION_IMAGE" >/dev/null
+          docker image inspect "$FRONTEND_IMAGE" >/dev/null
+
+          cp "$COMPOSE_FILE" "$compose_backup"
+          docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
+          docker inspect -f 'letovo-registration-server={{.Config.Image}}' letovo-registration-server >> "$restore"
+          docker inspect -f 'letovo-front={{.Config.Image}}' letovo-front >> "$restore"
+
+          sed \
+            -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${BACKEND_IMAGE}#" \
+            -e "s#image: ghcr.io/letovo-dev/letovo-registration-server:.*#image: ${REGISTRATION_IMAGE}#" \
+            -e "s#image: .*letovo.*front.*:.*#image: ${FRONTEND_IMAGE}#" \
+            "$COMPOSE_FILE" > "$candidate"
+
+          cp "$candidate" "$COMPOSE_FILE"
+          docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d letovo-server letovo-registration-server letovo-front
+          test "$(docker inspect -f '{{.Config.Image}}' letovo-server)" = "$BACKEND_IMAGE"
+          test "$(docker inspect -f '{{.Config.Image}}' letovo-registration-server)" = "$REGISTRATION_IMAGE"
+          test "$(docker inspect -f '{{.Config.Image}}' letovo-front)" = "$FRONTEND_IMAGE"
+          REMOTE
+
+      - name: Set up Node.js for live e2e
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Playwright runtime
+        run: |
+          set -euo pipefail
+          export PLAYWRIGHT_PACKAGE_DIR="$RUNNER_TEMP/letovo-live-e2e"
+          mkdir -p "$PLAYWRIGHT_PACKAGE_DIR"
+          cd "$PLAYWRIGHT_PACKAGE_DIR"
+          npm init -y
+          npm install "playwright@${PLAYWRIGHT_VERSION}"
+          "$PLAYWRIGHT_PACKAGE_DIR/node_modules/.bin/playwright" install --with-deps chromium
+          echo "PLAYWRIGHT_PACKAGE_DIR=$PLAYWRIGHT_PACKAGE_DIR" >> "$GITHUB_ENV"
+
+      - name: Run production live e2e
+        env:
+          LETOVO_E2E_USERNAME: ${{ secrets.LETOVO_E2E_USERNAME }}
+          LETOVO_E2E_PASSWORD: ${{ secrets.LETOVO_E2E_PASSWORD }}
+          LETOVO_E2E_SECONDARY_USERNAME: ${{ secrets.LETOVO_E2E_SECONDARY_USERNAME }}
+          LETOVO_E2E_SECONDARY_PASSWORD: ${{ secrets.LETOVO_E2E_SECONDARY_PASSWORD }}
+        run: node $GITHUB_WORKSPACE/test/e2e/live-platform-smoke.mjs
+
+      - name: Roll back production images on failure
+        if: failure()
+        env:
+          LETOVO_PROD_DEPLOY_HOST: ${{ vars.LETOVO_PROD_DEPLOY_HOST || '84.201.185.37' }}
+          LETOVO_PROD_DEPLOY_USER: ${{ secrets.LETOVO_PROD_DEPLOY_USER }}
+          LETOVO_PROD_DEPLOY_COMPOSE: ${{ vars.LETOVO_PROD_DEPLOY_COMPOSE || '/srv/letovo/compose/docker-compose.yaml' }}
+          LETOVO_PROD_DEPLOY_PROJECT: ${{ vars.LETOVO_PROD_DEPLOY_PROJECT || 'compose' }}
+        run: |
+          set -euo pipefail
+          test -f ~/.ssh/letovo-production-release || exit 0
+          remote="${LETOVO_PROD_DEPLOY_USER}@${LETOVO_PROD_DEPLOY_HOST}"
+          ssh -i ~/.ssh/letovo-production-release "$remote" \
+            "COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
+          set -euo pipefail
+          state_dir="/tmp/letovo-production-release-${RUN_ID}"
+          restore="$state_dir/restore.env"
+          compose_backup="$state_dir/docker-compose.yaml.before-release"
+          test -f "$restore" || exit 0
+          test -f "$compose_backup" || exit 0
+
+          cp "$compose_backup" "$COMPOSE_FILE"
+          backend_image="$(awk -F= '$1 == "letovo-server" { print $2 }' "$restore" | tail -n 1)"
+          registration_image="$(awk -F= '$1 == "letovo-registration-server" { print $2 }' "$restore" | tail -n 1)"
+          frontend_image="$(awk -F= '$1 == "letovo-front" { print $2 }' "$restore" | tail -n 1)"
+          test -n "$backend_image"
+          test -n "$registration_image"
+          test -n "$frontend_image"
+          docker image inspect "$backend_image" >/dev/null
+          docker image inspect "$registration_image" >/dev/null
+          docker image inspect "$frontend_image" >/dev/null
+
+          docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d letovo-server letovo-registration-server letovo-front
+          test "$(docker inspect -f '{{.Config.Image}}' letovo-server)" = "$backend_image"
+          test "$(docker inspect -f '{{.Config.Image}}' letovo-registration-server)" = "$registration_image"
+          test "$(docker inspect -f '{{.Config.Image}}' letovo-front)" = "$frontend_image"
+          rm -rf "$state_dir"
+          REMOTE

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -1,9 +1,11 @@
+import re
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "live-e2e.yml"
 BUILD_WORKFLOW = ROOT / ".github" / "workflows" / "docker-image.yml"
+PRODUCTION_RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "production-release.yml"
 LIVE_SCRIPT = ROOT / "test" / "e2e" / "live-platform-smoke.mjs"
 COMPOSE = ROOT / "docs" / "docker-compose.yaml"
 BACKEND_DOCKERFILE = ROOT / "src" / "Dockerfile"
@@ -14,6 +16,18 @@ FRONTEND_METADATA_ROUTE = ROOT / "frontend" / "src" / "app" / "api" / "deploymen
 
 def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def _backend_build_files(workflow: str) -> list[str]:
+    match = re.search(r"BACKEND_BUILD_FILES: >-\n((?:    .+\n)+)", workflow)
+    assert match
+    return match.group(1).split()
+
+
+def _workflow_env(workflow: str) -> str:
+    match = re.search(r"\nenv:\n((?:  .+\n)+)\njobs:", workflow)
+    assert match
+    return match.group(1)
 
 
 def test_live_e2e_workflow_runs_after_deployable_images_are_published():
@@ -60,6 +74,52 @@ def test_pr_build_publishes_candidate_images_before_live_e2e_gate():
     assert "Deploy PR candidate images to live e2e" in workflow
     assert "docker compose -p \"$PROJECT_NAME\" -f \"$candidate\" up -d letovo-server letovo-registration-server letovo-front" in workflow
     assert "Restore live deployment images" in workflow
+
+
+def test_production_release_is_manual_deploy_with_required_live_e2e_gate():
+    workflow = _read(PRODUCTION_RELEASE_WORKFLOW)
+
+    assert "workflow_dispatch:" in workflow
+    assert "target_ref:" not in workflow
+    assert "ref: main" in workflow
+    assert "default: https://letovocorp.ru" in workflow
+    assert "environment: production" in workflow
+    assert "concurrency:" in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "/srv/letovo/compose/docker-compose.yaml" in workflow
+    assert "LETOVO_PROD_DEPLOY_PROJECT || 'compose'" in workflow
+    assert "BACKEND_RELEASE_IMAGE=${BACKEND_IMAGE}:${release_sha}" in workflow
+    assert "REGISTRATION_RELEASE_IMAGE=${REGISTRATION_IMAGE}:${release_sha}" in workflow
+    assert "FRONTEND_RELEASE_IMAGE=${FRONTEND_IMAGE}:${release_sha}" in workflow
+    assert "INPUT_BASE_URL: ${{ inputs.base_url }}" in workflow
+    assert "base_url=\"${INPUT_BASE_URL%/}\"" in workflow
+    assert "base_url=\"${{ inputs.base_url }}\"" not in workflow
+    assert "base_url must be https://letovocorp.ru for production releases" in workflow
+    assert "NEXT_PUBLIC_BASE_URL=${{ steps.release.outputs.base_url }}/letovo-api" in workflow
+    assert "ya\\.sergeiscv\\.ru|/undefined/auth|/letovo-api/letovo-api" in workflow
+    assert "Build and push production backend image" in workflow
+    assert "Build and push production registration image" in workflow
+    assert "Build and push production frontend image" in workflow
+    assert "LETOVO_PROD_DEPLOY_HOST" in workflow
+    assert "LETOVO_PROD_DEPLOY_USER" in workflow
+    assert "LETOVO_PROD_DEPLOY_SSH_KEY" in workflow
+    workflow_env = _workflow_env(workflow)
+    assert "LETOVO_PROD_DEPLOY_USER" not in workflow_env
+    assert "LETOVO_PROD_DEPLOY_SSH_KEY" not in workflow_env
+    assert "Transfer production images to host" in workflow
+    assert "docker save \"${images[@]}\" | gzip -1 | ssh" in workflow
+    assert "gzip -dc | docker load" in workflow
+    assert "docker compose -p \"$PROJECT_NAME\" -f \"$COMPOSE_FILE\" pull" not in workflow
+    assert "docker image inspect \"$BACKEND_IMAGE\" >/dev/null" in workflow
+    assert "cp \"$candidate\" \"$COMPOSE_FILE\"" in workflow
+    assert "Run production live e2e" in workflow
+    assert 'LIVE_E2E_REQUIRE_AUTH: "true"' in workflow
+    assert "LIVE_E2E_EXPECTED_BACKEND_SHA=$release_sha" in workflow
+    assert "Roll back production images on failure" in workflow
+
+
+def test_production_release_backend_build_files_match_main_ci():
+    assert _backend_build_files(_read(PRODUCTION_RELEASE_WORKFLOW)) == _backend_build_files(_read(BUILD_WORKFLOW))
 
 
 def test_live_e2e_uses_condition_polling_and_browser_level_checks():


### PR DESCRIPTION
## Summary
- add a manual production release workflow for letovocorp.ru
- build and push immutable backend, registration, and frontend images from protected main using the resolved SHA tag
- stream the authenticated GHCR images from the GitHub runner to production with docker save/load before mutating compose, then deploy through the production compose file
- require authenticated live e2e after deploy and roll back images/compose if deploy or e2e fails
- scope production SSH credentials only to validation/SSH/deploy/rollback steps, not npm/build steps
- lock the release contract with workflow tests, including production defaults, backend build-file drift against main CI, no arbitrary target_ref, no direct production docker compose pull, safe base_url handling, and no workflow-level deploy SSH secret

Fixes #81

## Validation
- python3 -m pytest test/test_live_e2e_workflow_contract.py -q
- python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/production-release.yml').read_text())"
- git diff --check

## Required GitHub configuration
- secret: LETOVO_PROD_DEPLOY_USER
- secret: LETOVO_PROD_DEPLOY_SSH_KEY
- optional var: LETOVO_PROD_DEPLOY_HOST, defaults to 84.201.185.37
- optional var: LETOVO_PROD_DEPLOY_COMPOSE, defaults to /srv/letovo/compose/docker-compose.yaml
- optional var: LETOVO_PROD_DEPLOY_PROJECT, defaults to compose
- existing e2e secrets: LETOVO_E2E_USERNAME, LETOVO_E2E_PASSWORD, and secondary credentials if require_extended=true