### PR TITLE
fix(ci): update frontend release sha in production compose

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -229,7 +229,7 @@ jobs:
           set -euo pipefail
           remote="${LETOVO_PROD_DEPLOY_USER}@${LETOVO_PROD_DEPLOY_HOST}"
           ssh -i ~/.ssh/letovo-production-release "$remote" \
-            "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
+            "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
           set -euo pipefail
           test -f "$COMPOSE_FILE"
           state_dir="/tmp/letovo-production-release-${RUN_ID}"
@@ -251,6 +251,7 @@ jobs:
             -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${BACKEND_IMAGE}#" \
             -e "s#image: ghcr.io/letovo-dev/letovo-registration-server:.*#image: ${REGISTRATION_IMAGE}#" \
             -e "s#image: .*letovo.*front.*:.*#image: ${FRONTEND_IMAGE}#" \
+            -e "s#LETOVO_BUILD_SHA: \".*\"#LETOVO_BUILD_SHA: \"${RELEASE_SHA}\"#" \
             "$COMPOSE_FILE" > "$candidate"
 
           cp "$candidate" "$COMPOSE_FILE"

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -111,6 +111,8 @@ def test_production_release_is_manual_deploy_with_required_live_e2e_gate():
     assert "gzip -dc | docker load" in workflow
     assert "docker compose -p \"$PROJECT_NAME\" -f \"$COMPOSE_FILE\" pull" not in workflow
     assert "docker image inspect \"$BACKEND_IMAGE\" >/dev/null" in workflow
+    assert "RELEASE_SHA='${{ steps.release.outputs.release_sha }}'" in workflow
+    assert 's#LETOVO_BUILD_SHA: \\".*\\"#LETOVO_BUILD_SHA: \\"${RELEASE_SHA}\\"#' in workflow
     assert "cp \"$candidate\" \"$COMPOSE_FILE\"" in workflow
     assert "Run production live e2e" in workflow
     assert 'LIVE_E2E_REQUIRE_AUTH: "true"' in workflow


### PR DESCRIPTION
## Summary
- Fix production release deploy step so it updates the `LETOVO_BUILD_SHA` compose override for `letovo-front`.
- Add a workflow contract assertion for the release SHA propagation.

## Verification
- `python3 -m pytest test/test_live_e2e_workflow_contract.py::test_production_release_is_manual_deploy_with_required_live_e2e_gate test/test_live_e2e_workflow_contract.py::test_production_release_backend_build_files_match_main_ci -q`

## Context
The first production release test run deployed the new images, but live e2e waited for frontend metadata SHA and saw the old compose override (`17e92db...`), then rolled back.
