### PR TITLE
Fix chat contact search role

### DIFF
--- a/docs/chat_search_role_migration.sql
+++ b/docs/chat_search_role_migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "role" ADD COLUMN IF NOT EXISTS chat_search BOOLEAN DEFAULT false;

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -680,7 +680,8 @@ CREATE TABLE public.role (
     write_posts boolean,
     admin boolean,
     moder boolean,
-    main_page boolean
+    main_page boolean,
+    chat_search boolean DEFAULT false
 );
 
 

--- a/src/letovo-soc-net/chat.cc
+++ b/src/letovo-soc-net/chat.cc
@@ -30,9 +30,27 @@ namespace chat {
         return !result.empty();
     }
 
+    bool has_chat_search_role(const std::string& username,
+                              std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+        cp::SafeCon con{pool_ptr};
+        std::vector<std::string> params = {username};
+        pqxx::result result = con->execute_params(
+            "SELECT 1 FROM \"role\" r "
+            "WHERE r.username = $1 "
+            "  AND COALESCE((to_jsonb(r)->>'chat_search')::boolean, false) = true "
+            "LIMIT 1;", params);
+        return !result.empty();
+    }
+
+    bool can_search_all_chats(const std::string& username,
+                              std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+        return auth::is_rights_by_username(username, pool_ptr, "admin") ||
+               has_chat_search_role(username, pool_ptr);
+    }
+
     // `a` is the user attempting to chat with `b`. Symmetric except for the
-    // admin shortcut (admins may message anyone). An admin-set `block` override
-    // always wins, including over an admin sender.
+    // privileged shortcut (admins and chat_search users may message anyone).
+    // An admin-set `block` override always wins, including over privileged senders.
     bool can_chat(const std::string& a, const std::string& b,
                   std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
         std::string user_a = a < b ? a : b;
@@ -51,17 +69,19 @@ namespace chat {
             }
         }
 
-        if (is_chattable(b, pool_ptr)) return true;            // chat with chattable users
-        if (conversation_exists(a, b, pool_ptr)) return true;  // continue an existing dialog
-        return auth::is_rights_by_username(a, pool_ptr, "admin"); // admins can text anyone
+        if (is_chattable(b, pool_ptr)) return true;             // chat with chattable users
+        if (has_chat_search_role(b, pool_ptr)) return true;     // chat-search users are discoverable
+        if (conversation_exists(a, b, pool_ptr)) return true;   // continue an existing dialog
+        return can_search_all_chats(a, pool_ptr);
     }
 
-    pqxx::result get_chattable_users(const std::string& current_user, bool requester_is_admin,
+    pqxx::result get_chattable_users(const std::string& current_user,
+                                     bool requester_can_search_all,
                                      std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
         cp::SafeCon con{pool_ptr};
-        // $2 = requester is admin: admins see every user they may chat with (i.e.
-        // everyone except `block`-overridden pairs), still sorted by recency.
-        std::vector<std::string> params = {current_user, requester_is_admin ? "true" : "false"};
+        // $2 = requester can search all chats: admins and role.chat_search users
+        // see every user they may chat with, except `block`-overridden pairs.
+        std::vector<std::string> params = {current_user, requester_can_search_all ? "true" : "false"};
         pqxx::result result = con->execute_params(
             "SELECT u.username, u.display_name, u.avatar_pic, "
             "  dm.message_text AS last_message, dm.sent_at AS last_message_time "
@@ -69,6 +89,7 @@ namespace chat {
             "LEFT JOIN chat_override co "
             "  ON co.user_a = LEAST(u.username, $1) "
             " AND co.user_b = GREATEST(u.username, $1) "
+            "LEFT JOIN \"role\" ur ON ur.username = u.username "
             "LEFT JOIN LATERAL ("
             "  SELECT message_text, sent_at FROM direct_message "
             "  WHERE ((sender = u.username AND receiver = $1) "
@@ -82,6 +103,7 @@ namespace chat {
             "       $2::boolean "
             "    OR co.override_type = 'allow' "
             "    OR u.chattable = true "
+            "    OR COALESCE((to_jsonb(ur)->>'chat_search')::boolean, false) = true "
             "    OR dm.sent_at IS NOT NULL "
             "  ) "
             "ORDER BY dm.sent_at DESC NULLS LAST, u.username;", params);
@@ -216,8 +238,8 @@ namespace chat::server {
             if (username.empty()) {
                 return req->create_response(restinio::status_unauthorized()).done();
             }
-            bool requester_is_admin = auth::is_admin(token, pool_ptr);
-            pqxx::result result = chat::get_chattable_users(username, requester_is_admin, pool_ptr);
+            bool requester_can_search_all = chat::can_search_all_chats(username, pool_ptr);
+            pqxx::result result = chat::get_chattable_users(username, requester_can_search_all, pool_ptr);
             return req->create_response()
                 .set_body(cp::serialize(result))
                 .append_header("Content-Type", "application/json; charset=utf-8")

--- a/src/letovo-soc-net/chat.h
+++ b/src/letovo-soc-net/chat.h
@@ -18,7 +18,14 @@ namespace chat {
     bool can_chat(const std::string& a, const std::string& b,
                   std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
-    pqxx::result get_chattable_users(const std::string& current_user, bool requester_is_admin,
+    bool has_chat_search_role(const std::string& username,
+                              std::shared_ptr<cp::ConnectionsManager> pool_ptr);
+
+    bool can_search_all_chats(const std::string& username,
+                              std::shared_ptr<cp::ConnectionsManager> pool_ptr);
+
+    pqxx::result get_chattable_users(const std::string& current_user,
+                                     bool requester_can_search_all,
                                      std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
     pqxx::result get_messages(const std::string& user1, const std::string& user2,

--- a/test/test_chat.py
+++ b/test/test_chat.py
@@ -396,6 +396,17 @@ def _set_user_rights(username, rights):
         cur.execute('UPDATE "user" SET userrights=%s WHERE username=%s;', (rights, username))
 
 
+def _set_chat_search_role(username, value):
+    with _db() as c, c.cursor() as cur:
+        cur.execute('ALTER TABLE "role" ADD COLUMN IF NOT EXISTS chat_search BOOLEAN DEFAULT false;')
+        cur.execute(
+            'INSERT INTO "role" (username, write_posts, admin, moder, main_page, chat_search) '
+            'VALUES (%s, false, false, false, false, %s) '
+            'ON CONFLICT (username) DO UPDATE SET chat_search = EXCLUDED.chat_search;',
+            (username, value),
+        )
+
+
 def test_set_permission_admin_only():
     _ensure_second_user()
     resp = requests.post(f"{URL}/chat/permission",
@@ -527,6 +538,7 @@ def test_block_override_wins_over_existing_dialog():
 
 
 ADMIN_LIST_PROBE_USER = "test_chat_admin_probe"
+CHAT_SEARCH_TARGET_USER = "test_chat_search_target"
 
 
 def test_get_chats_admin_sees_every_user_but_non_admin_does_not():
@@ -540,6 +552,7 @@ def test_get_chats_admin_sees_every_user_but_non_admin_does_not():
         )
     _clear_override(USERNAME, ADMIN_LIST_PROBE_USER)
     _clear_override(NON_ADMIN_USER, ADMIN_LIST_PROBE_USER)
+    _set_chat_search_role(ADMIN_LIST_PROBE_USER, False)
 
     admin_chats = requests.get(f"{URL}/chats/", headers=auth_headers(), verify=False)
     assert admin_chats.status_code == 200
@@ -548,6 +561,98 @@ def test_get_chats_admin_sees_every_user_but_non_admin_does_not():
     non_admin_chats = requests.get(f"{URL}/chats/", headers=non_admin_headers(), verify=False)
     assert non_admin_chats.status_code == 200
     assert ADMIN_LIST_PROBE_USER not in [u["username"] for u in non_admin_chats.json()["result"]]
+
+
+def test_get_chats_chat_search_role_sees_non_chattable_users_without_admin():
+    # A chat-search requester is not an admin, but can search the full contact list.
+    with _db() as c, c.cursor() as cur:
+        cur.execute(
+            'INSERT INTO "user" (username, passwdhash, chattable, userrights) '
+            "VALUES (%s, %s, false, 'user') ON CONFLICT (username) DO UPDATE "
+            "SET chattable = false;",
+            (ADMIN_LIST_PROBE_USER, "x"),
+        )
+    _clear_override(NON_ADMIN_USER, ADMIN_LIST_PROBE_USER)
+    _set_chat_search_role(NON_ADMIN_USER, True)
+    try:
+        response = requests.get(f"{URL}/chats/", headers=non_admin_headers(), verify=False)
+        assert response.status_code == 200
+        assert ADMIN_LIST_PROBE_USER in [u["username"] for u in response.json()["result"]]
+    finally:
+        _set_chat_search_role(NON_ADMIN_USER, False)
+
+
+def test_get_chats_includes_chat_search_role_user_for_regular_requester():
+    # A chat-search target is discoverable even when user.chattable is false.
+    with _db() as c, c.cursor() as cur:
+        cur.execute(
+            'INSERT INTO "user" (username, passwdhash, chattable, userrights) '
+            "VALUES (%s, %s, false, 'user') ON CONFLICT (username) DO UPDATE "
+            "SET chattable = false;",
+            (CHAT_SEARCH_TARGET_USER, "x"),
+        )
+    _clear_override(NON_ADMIN_USER, CHAT_SEARCH_TARGET_USER)
+    _set_chat_search_role(CHAT_SEARCH_TARGET_USER, True)
+    try:
+        response = requests.get(f"{URL}/chats/", headers=non_admin_headers(), verify=False)
+        assert response.status_code == 200
+        assert CHAT_SEARCH_TARGET_USER in [u["username"] for u in response.json()["result"]]
+    finally:
+        _set_chat_search_role(CHAT_SEARCH_TARGET_USER, False)
+
+
+def test_chat_search_role_can_text_non_chattable_stranger():
+    _ensure_third_user_non_chattable()
+    _clear_override(NON_ADMIN_USER, THIRD_USER)
+    _set_chat_search_role(NON_ADMIN_USER, True)
+    try:
+        resp = _send_via_api(
+            THIRD_USER,
+            "chat-search user reaching out",
+            token=non_admin_headers()["Bearer"],
+        )
+        assert resp.status_code == 200, resp.text
+    finally:
+        _set_chat_search_role(NON_ADMIN_USER, False)
+
+
+def test_regular_user_can_text_chat_search_role_user():
+    with _db() as c, c.cursor() as cur:
+        cur.execute(
+            'INSERT INTO "user" (username, passwdhash, chattable, userrights) '
+            "VALUES (%s, %s, false, 'user') ON CONFLICT (username) DO UPDATE "
+            "SET chattable = false;",
+            (CHAT_SEARCH_TARGET_USER, "x"),
+        )
+    _clear_override(NON_ADMIN_USER, CHAT_SEARCH_TARGET_USER)
+    _set_chat_search_role(CHAT_SEARCH_TARGET_USER, True)
+    try:
+        resp = _send_via_api(
+            CHAT_SEARCH_TARGET_USER,
+            "regular user reaching a chat-search contact",
+            token=non_admin_headers()["Bearer"],
+        )
+        assert resp.status_code == 200, resp.text
+    finally:
+        _set_chat_search_role(CHAT_SEARCH_TARGET_USER, False)
+
+
+def test_block_override_wins_over_chat_search_role():
+    _ensure_third_user_non_chattable()
+    _set_chat_search_role(NON_ADMIN_USER, True)
+    _set_override(NON_ADMIN_USER, THIRD_USER, "block")
+    try:
+        resp = _send_via_api(
+            THIRD_USER,
+            "should be blocked despite chat-search role",
+            token=non_admin_headers()["Bearer"],
+        )
+        assert resp.status_code == 403, resp.text
+        chats = requests.get(f"{URL}/chats/", headers=non_admin_headers(), verify=False).json()["result"]
+        assert THIRD_USER not in [u["username"] for u in chats]
+    finally:
+        _clear_override(NON_ADMIN_USER, THIRD_USER)
+        _set_chat_search_role(NON_ADMIN_USER, False)
 
 
 def test_get_chats_admin_list_sorted_by_recency():


### PR DESCRIPTION
Closes #85.

## Summary
- add role.chat_search as a non-admin chat discovery role
- let chat_search users search/message the full contact list while keeping block overrides authoritative
- make chat_search users discoverable/messageable even when user.chattable=false
- add the chat_search schema migration and regression coverage for admin, regular non-admin, chat_search requester/target, and block overrides

## Validation
- cmake --build . (from src/)
- python3 -c "import ast, pathlib; ast.parse(pathlib.Path('test/test_chat.py').read_text())"
- git diff --check

Note: local API e2e was not run because no backend was listening on 0.0.0.0:8080.