### PR TITLE
Fix public user profile access

### DIFF
--- a/docs/methods_ai_expl.json
+++ b/docs/methods_ai_expl.json
@@ -1245,7 +1245,7 @@
     "response": {}
   },
   "/user/:username([a-zA-Z0-9\\-]+)": {
-    "explanation": "This method retrieves user information by username. It requires a valid Bearer header or AuthSession cookie. The authenticated caller must be the same user as the requested username or an admin. Anonymous requests return 401, and authenticated callers who are neither the owner nor an admin return 403. On success it returns profile fields such as ID, rights, join time, avatar picture, activity status, visits count, department ID, role name, and registration date.",
+    "explanation": "This method retrieves public user information by username. It requires a valid Bearer header or AuthSession cookie, but any authenticated user may request any other user's public profile. Anonymous requests return 401. On success it returns public profile fields such as ID, rights, join time, avatar picture, activity status, visits count, department ID, role name, brigade data, and registration date. Private account fields such as balance, paycheck, and payment metadata are intentionally omitted; use /user/full/:username for owner/admin-only private profile data.",
     "request": {
       "function": "user_info",
       "header_fields": [

--- a/src/basic/user_data.cc
+++ b/src/basic/user_data.cc
@@ -495,9 +495,6 @@ void user_info(std::unique_ptr<restinio::router::express_router_t<>> &router,
         if (actor.empty()) {
           return req->create_response(restinio::status_unauthorized()).done();
         }
-        if (!security::is_same_user_or_admin(actor, username, pool_ptr)) {
-          return req->create_response(restinio::status_forbidden()).done();
-        }
 
         pqxx::result result = user::user_info(username, pool_ptr);
 

--- a/test/test_security_vulnerabilities.py
+++ b/test/test_security_vulnerabilities.py
@@ -84,8 +84,8 @@ def test_user_profile_requires_authentication():
     assert response.status_code == 401
 
 
-def test_user_cannot_read_another_users_private_profile(security_user):
-    # Precondition: the deployment has an existing admin user profile to protect.
+def test_user_can_read_another_users_public_profile_without_private_fields(security_user):
+    # Precondition: the deployment has an existing admin user profile to read publicly.
     response = requests.get(
         f"{BASE_URL}/user/admin",
         headers={"Bearer": security_user["token"]},
@@ -94,7 +94,17 @@ def test_user_cannot_read_another_users_private_profile(security_user):
     )
 
     _skip_if_fixture_is_absent(response, "admin user")
-    assert response.status_code == 403
+    assert response.status_code == 200
+    data = response.json()
+    public_user = data["result"][0]
+    assert "username" in public_user
+    assert "avatar_pic" in public_user
+    assert "departmentid" in public_user
+    assert "rolename" in public_user
+    assert "balance" not in public_user
+    assert "paycheck" not in public_user
+    assert "last_incoming_payment" not in data
+    assert "last_outgoing_payment" not in data
 
 
 def test_full_user_response_does_not_expose_balance_to_other_user(security_user):

--- a/test/test_user_full_payments_metadata.py
+++ b/test/test_user_full_payments_metadata.py
@@ -20,3 +20,38 @@ def test_user_full_endpoint_includes_last_payment_metadata():
     transactions_source = TRANSACTIONS_CC.read_text()
     assert "'last_incoming_payment'" in transactions_source
     assert "'last_outgoing_payment'" in transactions_source
+
+
+def test_public_user_endpoint_is_authenticated_but_not_owner_admin_only():
+    source = USER_DATA_CC.read_text()
+    handler_start = source.index("void user_info(")
+    handler_end = source.index("void full_user_info(", handler_start)
+    handler = source[handler_start:handler_end]
+
+    assert "auth::get_username(token, pool_ptr)" in handler
+    assert "status_unauthorized" in handler
+    assert "security::is_same_user_or_admin" not in handler
+    assert "status_forbidden" not in handler
+
+
+def test_public_user_query_does_not_select_private_money_fields():
+    source = USER_DATA_CC.read_text()
+    query_start = source.index("pqxx::result user_info(")
+    query_end = source.index("pqxx::result full_user_info(", query_start)
+    query = source[query_start:query_end]
+
+    assert '"user".balance' not in query
+    assert '"roles".payment' not in query
+    assert "paycheck" not in query
+    assert "last_incoming_payment" not in query
+    assert "last_outgoing_payment" not in query
+
+
+def test_private_user_endpoint_stays_owner_admin_only():
+    source = USER_DATA_CC.read_text()
+    handler_start = source.index("void full_user_info(")
+    handler_end = source.index("void user_roles(", handler_start)
+    handler = source[handler_start:handler_end]
+
+    assert "security::is_same_user_or_admin(actor, username, pool_ptr)" in handler
+    assert "status_forbidden" in handler


### PR DESCRIPTION
Fixes #88.

Summary:
- Allow any authenticated user to read another user's public /user/:username profile.
- Keep /user/full/:username restricted to the owner or admin for balance, paycheck, and payment metadata.
- Add regression coverage for the public/private profile contract and update endpoint docs.

Tests:
- python3 -m pytest test/test_user_full_payments_metadata.py -q
- git diff --check