### PR TITLE
fix: allow senior achievement awards

### DIFF
--- a/src/basic/security.cc
+++ b/src/basic/security.cc
@@ -266,6 +266,16 @@ bool can_read_secret_posts(const std::string &username,
                       "COALESCE(u.userrights, '') = 'admin'");
 }
 
+bool can_award_achievements(const std::string &username,
+                            std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+  return has_any_role(username, pool_ptr,
+                      "COALESCE(r.admin, false) = true OR "
+                      "COALESCE(r.moder, false) = true OR "
+                      "COALESCE(u.userrights, '') IN ('admin', 'moder') OR "
+                      "COALESCE((SELECT roles.rang FROM public.roles WHERE "
+                      "roles.roleid = u.role), 0) > 0");
+}
+
 std::string create_post_reveal_token(
     int post_id, const std::string &created_by,
     std::shared_ptr<cp::ConnectionsManager> pool_ptr) {

--- a/src/basic/security.h
+++ b/src/basic/security.h
@@ -52,6 +52,8 @@ bool is_same_user_or_admin(const std::string &requester_username,
                            std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 bool can_read_secret_posts(const std::string &username,
                            std::shared_ptr<cp::ConnectionsManager> pool_ptr);
+bool can_award_achievements(const std::string &username,
+                            std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 std::string create_post_reveal_token(
     int post_id, const std::string &created_by,
     std::shared_ptr<cp::ConnectionsManager> pool_ptr);

--- a/src/basic/user_data.cc
+++ b/src/basic/user_data.cc
@@ -128,6 +128,11 @@ pqxx::result full_user_info(std::string username,
       "\"user\".balance, \"user\".registered, \"user\".jointime, "
       "\"user\".avatar_pic, \"user\".active, \"user\".times_visited, "
       "\"user\".brigade, "
+      "(CASE WHEN COALESCE(permission_role.admin, false) = true "
+      "OR COALESCE(permission_role.moder, false) = true "
+      "OR COALESCE(\"user\".userrights, '') IN ('admin', 'moder') "
+      "OR COALESCE(\"roles\".rang, 0) > 0 THEN true ELSE false END) "
+      "AS can_award_achievements, "
       "\"roles\".rolename as role, \"roles\".payment as paycheck, "
       "\"department\".*, \"brigade\".name as brigadename, "
       "(SELECT COALESCE(json_agg(json_build_object("
@@ -139,7 +144,8 @@ pqxx::result full_user_info(std::string username,
       "join \"roles\" on \"user\".role = "
       "\"roles\".roleid  left join \"department\" on \"roles\".departmentid = "
       "\"department\".departmentid left join \"brigade\" on \"user\".brigade = "
-      "\"brigade\".brigade_id where \"user\".username = ($1);",
+      "\"brigade\".brigade_id left join \"role\" permission_role on "
+      "\"user\".username = permission_role.username where \"user\".username = ($1);",
       params);
 
 

--- a/src/letovo-soc-net/achivements.cc
+++ b/src/letovo-soc-net/achivements.cc
@@ -1,4 +1,5 @@
 #include "achivements.h"
+#include "../basic/security.h"
 
 namespace achivements {
     pqxx::result full_user_achivements(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
@@ -421,8 +422,9 @@ namespace achivements::server {
                 return req->create_response(restinio::status_unauthorized()).done();
             }
 
-            if (!auth::is_admin(token, pool_ptr) && !auth::is_rights_by_username(auth::get_username(token, pool_ptr), pool_ptr, "moder")) {
-                logger_ptr->info([]{return "not admin";});
+            const std::string actor = auth::get_username(token, pool_ptr);
+            if (!security::can_award_achievements(actor, pool_ptr)) {
+                logger_ptr->info([]{return "not allowed to award achievements";});
                 return req->create_response(restinio::status_unauthorized()).done();
             }
 

--- a/test/test_achievement_award_permissions.py
+++ b/test/test_achievement_award_permissions.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path):
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def function_body(source, signature):
+    start = source.index(signature)
+    brace = source.index("{", start)
+    depth = 0
+    for pos in range(brace, len(source)):
+        if source[pos] == "{":
+            depth += 1
+        elif source[pos] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace : pos + 1]
+    raise AssertionError(f"Function body not found for {signature}")
+
+
+def test_add_achievement_uses_shared_award_permission():
+    achievement_source = read("src/letovo-soc-net/achivements.cc")
+    add_route = function_body(
+        achievement_source,
+        "void add_achivement(std::unique_ptr<restinio::router::express_router_t<>>& router",
+    )
+
+    assert '#include "../basic/security.h"' in achievement_source
+    assert "security::can_award_achievements(actor, pool_ptr)" in add_route
+    assert 'is_rights_by_username(auth::get_username(token, pool_ptr), pool_ptr, "moder")' not in add_route
+
+
+def test_award_permission_allows_positive_department_roles():
+    security_source = read("src/basic/security.cc")
+    helper = function_body(security_source, "bool can_award_achievements")
+
+    assert "COALESCE(r.admin, false) = true" in helper
+    assert "COALESCE(r.moder, false) = true" in helper
+    assert "COALESCE(u.userrights, '') IN ('admin', 'moder')" in helper
+    assert "roles.roleid = u.role" in helper
+    assert "), 0) > 0" in helper
+
+
+def test_full_user_payload_exposes_award_permission():
+    user_data_source = read("src/basic/user_data.cc")
+    full_user_info = function_body(user_data_source, "pqxx::result full_user_info")
+
+    assert "AS can_award_achievements" in full_user_info
+    assert 'left join \\"role\\" permission_role' in full_user_info
+    assert 'COALESCE(\\"roles\\".rang, 0) > 0' in full_user_info


### PR DESCRIPTION
## Summary
- allow senior department-role users to award achievements from scanned QR links
- expose can_award_achievements in /user/full for the frontend guard
- update the open achievement page to use the backend permission flag
- add focused backend/frontend contract tests

Fixes #97

## Validation
- PYTHONDONTWRITEBYTECODE=1 pytest -q test/test_achievement_award_permissions.py frontend/test/test_frontend_api_contracts.py -p no:cacheprovider
- cmake --build . --target server_starter -j2
- npx tsc --noEmit --pretty false --incremental false