### PR TITLE
fix: add underscore support to username regex in route patterns

### DIFF
--- a/src/letovo-soc-net/achivements.cc
+++ b/src/letovo-soc-net/achivements.cc
@@ -327,7 +327,7 @@ namespace achivements {
 
 namespace achivements::server {
     void user_achivements_by_department(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
-        router.get()->http_get(R"(/achivements/user/departments/:username([a-zA-Z0-9\-]+))", [pool_ptr, logger_ptr](auto req, auto) {
+        router.get()->http_get(R"(/achivements/user/departments/:username([a-zA-Z0-9_\-]+))", [pool_ptr, logger_ptr](auto req, auto) {
             logger_ptr->trace([] { return "called /achivements/user/departments/:username"; });
             auto qrl = req->header().path();
 
@@ -351,7 +351,7 @@ namespace achivements::server {
     }
 
     void user_achivemets(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
-        router.get()->http_get(R"(/achivements/user/:username([a-zA-Z0-9\-]+))", [pool_ptr, logger_ptr](auto req, auto) {
+        router.get()->http_get(R"(/achivements/user/:username([a-zA-Z0-9_\-]+))", [pool_ptr, logger_ptr](auto req, auto) {
             logger_ptr->trace([]{return "called /achivements/user/:username";});
             auto qrl = req->header().path();
 
@@ -373,7 +373,7 @@ namespace achivements::server {
     }
 
     void full_user_achivemets(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
-        router.get()->http_get(R"(/achivements/user/full/:username([a-zA-Z0-9\-]+))", [pool_ptr, logger_ptr](auto req, auto) {
+        router.get()->http_get(R"(/achivements/user/full/:username([a-zA-Z0-9_\-]+))", [pool_ptr, logger_ptr](auto req, auto) {
             logger_ptr->trace([]{return "called /achivements/user/full/:username";});
             auto qrl = req->header().path();
 

--- a/src/letovo-soc-net/page_server.cc
+++ b/src/letovo-soc-net/page_server.cc
@@ -328,7 +328,7 @@ namespace page::server {
     }
 
     void get_page_author(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
-        router.get()->http_get(R"(/post/author/:username([a-zA-Z0-9\-]+))", [pool_ptr, logger_ptr](auto req, auto params) {
+        router.get()->http_get(R"(/post/author/:username([a-zA-Z0-9_\-]+))", [pool_ptr, logger_ptr](auto req, auto params) {
             logger_ptr->trace([]{return "called /post/author/:username";});
             std::string endpoint = req->remote_endpoint().address().to_string();
             auto qrl = req->header().path();

--- a/src/letovo-soc-net/social.cc
+++ b/src/letovo-soc-net/social.cc
@@ -401,7 +401,7 @@ namespace social::server {
     }
 
     void get_posts_by_author(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
-        router.get()->http_get(R"(/social/posts/author/:username([a-zA-Z0-9\-]+))", [pool_ptr, logger_ptr](auto req, auto) {
+        router.get()->http_get(R"(/social/posts/author/:username([a-zA-Z0-9_\-]+))", [pool_ptr, logger_ptr](auto req, auto) {
             logger_ptr->trace([]{return "called /social/posts/author/:username";});
             std::string token = security::bearer_or_cookie_token(req->header());
             if(token.empty()) {


### PR DESCRIPTION
Fixes #98

## Root cause
Three routes in `achivements.cc` used the regex character class `[a-zA-Z0-9\\-]+` which rejects usernames containing underscores (e.g. `Citizen_hearst`). RESTinio's express router returns **501 Not Implemented** when no handler matches.

## Changes

### `src/letovo-soc-net/achivements.cc`
| Route | Fix |
|-------|-----|
| `/achivements/user/departments/:username` | `[a-zA-Z0-9_\\-]+` |
| `/achivements/user/:username` | `[a-zA-Z0-9_\\-]+` |
| `/achivements/user/full/:username` | `[a-zA-Z0-9_\\-]+` |

### Bonus: same bug in two other files
- `src/letovo-soc-net/social.cc` — `/social/posts/author/:username`
- `src/letovo-soc-net/page_server.cc` — `/post/author/:username`

All other username routes in the codebase (`user_data.cc`, `chat.cc`, `analytics.cc`) already include underscore — they use `[a-zA-Z0-9_-]+`.

## Verification
- Fix is a single-character addition (`_`) per route
- Regression risk: none — underscores are valid username characters in the DB schema
- After merge: rebuild and redeploy `letovo-server`