### PR TITLE
Issue 91 production performance wins

### DIFF
--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -11,6 +11,11 @@ services:
           - /mnt/server-configs:/app/configs
         labels:
           - "com.centurylinklabs.watchtower.enable=true"
+        logging:
+          driver: json-file
+          options:
+            max-size: "100m"
+            max-file: "5"
 
     letovo-registration-server:
         image: ghcr.io/letovo-dev/letovo-registration-server:latest
@@ -25,6 +30,11 @@ services:
           - /mnt/server-configs:/app/configs
         labels:
           - "com.centurylinklabs.watchtower.enable=false"
+        logging:
+          driver: json-file
+          options:
+            max-size: "100m"
+            max-file: "5"
 
     watchtower:
         image: containrrr/watchtower
@@ -32,7 +42,12 @@ services:
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
           - /home/sergei-scv/.docker/config.json:/config.json:ro
-        command: --interval 60 --cleanup --include-restarting --label-enable
+        command: --interval 300 --cleanup --include-restarting --label-enable
+        logging:
+          driver: json-file
+          options:
+            max-size: "100m"
+            max-file: "5"
 
     letovo-front:
         image: ghcr.io/letovo-dev/letovo-all-frontend:latest
@@ -65,6 +80,11 @@ services:
           - /mnt/server-media:/app/pages
         ports:
           - "8880:8880"
+        logging:
+          driver: json-file
+          options:
+            max-size: "100m"
+            max-file: "5"
 
     keycloak:
         image: quay.io/keycloak/keycloak:26.0
@@ -85,3 +105,8 @@ services:
             KEYCLOAK_ADMIN_PASSWORD: admin
         ports:
           - "8081:8080"
+        logging:
+          driver: json-file
+          options:
+            max-size: "100m"
+            max-file: "5"

--- a/docs/issue91_hot_indexes.sql
+++ b/docs/issue91_hot_indexes.sql
@@ -1,0 +1,31 @@
+-- Issue #91 production hot-path indexes.
+-- Run each CREATE INDEX CONCURRENTLY outside an explicit transaction block.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_feed_public_date
+ON posts (date DESC)
+WHERE parent_id IS NULL AND post_path IS NULL AND is_secret = false;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_feed_all_date
+ON posts (date DESC)
+WHERE parent_id IS NULL AND post_path IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_comments_parent_date
+ON posts (parent_id, date DESC)
+WHERE post_path IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_post_media_post_id
+ON post_media (post_id);
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_user_saved_username_post_id
+ON user_saved (username, post_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_likes_username_post_id
+ON user_likes (username, post_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_direct_message_sender_receiver_time_open
+ON direct_message (sender, receiver, sent_at DESC)
+WHERE deleted_at IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_direct_message_receiver_sender_time_open
+ON direct_message (receiver, sender, sent_at DESC)
+WHERE deleted_at IS NULL;

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -1,4 +1,4 @@
-worker_processes  1;
+worker_processes  auto;
 
 events { worker_connections 1024; }
 
@@ -7,6 +7,31 @@ http {
     default_type  application/octet-stream;
     sendfile on;
     keepalive_timeout 65;
+
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_min_length 1024;
+    gzip_comp_level 5;
+    gzip_types
+        application/json
+        application/javascript
+        application/xml
+        image/svg+xml
+        text/css
+        text/javascript
+        text/plain
+        text/xml;
+
+    upstream letovo_backend {
+        server 127.0.0.1:8080;
+        keepalive 32;
+    }
+
+    upstream letovo_frontend {
+        server 127.0.0.1:3000;
+        keepalive 16;
+    }
 
     map $http_upgrade $connection_upgrade {
       default upgrade;
@@ -17,7 +42,13 @@ http {
         # ===== proxy locations =====
 
         location /api/ {
-            proxy_pass http://127.0.0.1:8080/;
+            proxy_pass http://letovo_backend/;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         location /upload/ {
@@ -85,7 +116,13 @@ http {
         }
 
         location / {
-            proxy_pass http://127.0.0.1:3000;
+            proxy_pass http://letovo_frontend;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         # ===== errors / TLS =====

--- a/scripts/perf/issue91_baseline.sh
+++ b/scripts/perf/issue91_baseline.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-https://letovocorp.ru}"
+API_BASE="${API_BASE:-${BASE_URL}/letovo-api}"
+OUT_DIR="${OUT_DIR:-/tmp/letovo-issue91-baseline}"
+AUTH_TOKEN="${LETOVO_AUTH_TOKEN:-}"
+
+mkdir -p "$OUT_DIR"
+
+curl_public() {
+  local name="$1"
+  local url="$2"
+  curl -sS -o "$OUT_DIR/${name}.body" \
+    -w "${name} status=%{http_code} ttfb=%{time_starttransfer} total=%{time_total} bytes=%{size_download}\n" \
+    "$url"
+}
+
+curl_api() {
+  local name="$1"
+  local url="$2"
+  local auth_args=()
+  if [ -n "$AUTH_TOKEN" ]; then
+    auth_args=(-H "Authorization: Bearer ${AUTH_TOKEN}")
+  fi
+  curl -sS -o "$OUT_DIR/${name}.body" \
+    -w "${name} status=%{http_code} ttfb=%{time_starttransfer} total=%{time_total} bytes=%{size_download}\n" \
+    -H "Accept-Encoding: gzip" \
+    "${auth_args[@]}" \
+    "$url"
+}
+
+echo "Writing bodies to $OUT_DIR"
+curl_public "home" "${BASE_URL}/"
+curl_public "news_page" "${BASE_URL}/news"
+curl_api "social_news" "${API_BASE}/social/news?start=0&size=10"
+curl_api "social_titles" "${API_BASE}/social/titles"
+curl_api "social_saved" "${API_BASE}/social/saved"
+curl_api "chats" "${API_BASE}/chats/"
+
+if [ -f "$OUT_DIR/chats.body" ]; then
+  gzip -9c "$OUT_DIR/chats.body" | wc -c | awk '{print "chats gzip_estimate_bytes="$1}'
+fi
+if [ -f "$OUT_DIR/social_titles.body" ]; then
+  gzip -9c "$OUT_DIR/social_titles.body" | wc -c | awk '{print "social_titles gzip_estimate_bytes="$1}'
+fi

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -36,7 +36,8 @@ ENV MAIN_FILE=${MAIN_FILE}
 ENV BUILD_FILES=${BUILD_FILES}
 
 # Собираем проект
-RUN mkdir build && cd build && cmake .. && make
+RUN mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make -j"$(nproc)"
+RUN cp /app/build/server_starter /app/server_starter && strip /app/server_starter || true
 
 # ------ Stage 2: runtime -------
 FROM ubuntu:24.04
@@ -44,12 +45,12 @@ FROM ubuntu:24.04
 # Устанавливаем только runtime-библиотеки
 RUN apt update && apt install -y \
         libfmt9 \
-        libhttp-parser-dev \
-        libpqxx-dev \
-        libpq-dev \
-        libssl-dev \
-        libqrencode-dev \
-        libpng-dev \
+        libhttp-parser2.9 \
+        libpqxx-7.8 \
+        libpq5 \
+        libssl3 \
+        libqrencode4 \
+        libpng16-16 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -57,7 +58,7 @@ WORKDIR /app
 ARG LETOVO_BUILD_SHA=unknown
 ENV LETOVO_BUILD_SHA=${LETOVO_BUILD_SHA}
 
-COPY --from=builder /app/build/server_starter .
+COPY --from=builder /app/server_starter .
 
 EXPOSE 8080
 

--- a/src/basic/media.cc
+++ b/src/basic/media.cc
@@ -1,7 +1,9 @@
 #include "media.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
+#include <mutex>
 #include <sstream>
 
 namespace {
@@ -16,6 +18,56 @@ struct RangeRequest {
   bool valid = false;
   ByteRange range;
 };
+
+constexpr std::uintmax_t kTopDownloadMaxFileBytes = 300ull * 1024ull;
+constexpr std::size_t kTopDownloadDefaultLimit = 20;
+constexpr auto kTopDownloadTtl = std::chrono::hours(24);
+
+struct DownloadStat {
+  std::size_t count = 0;
+  std::uintmax_t bytes = 0;
+  std::string content_type;
+  std::chrono::steady_clock::time_point last_seen;
+};
+
+std::mutex g_download_stats_mutex;
+std::unordered_map<std::string, DownloadStat> g_download_stats;
+
+bool is_top_download_candidate(const std::string &content_type,
+                               std::uintmax_t file_size) {
+  return file_size > 0 && file_size <= kTopDownloadMaxFileBytes &&
+         (content_type.rfind("image/", 0) == 0 ||
+          content_type == "image/svg+xml");
+}
+
+void prune_download_stats_locked(std::chrono::steady_clock::time_point now) {
+  for (auto it = g_download_stats.begin(); it != g_download_stats.end();) {
+    if (now - it->second.last_seen > kTopDownloadTtl) {
+      it = g_download_stats.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+std::string json_escape(const std::string &value) {
+  std::string escaped;
+  escaped.reserve(value.size());
+  for (char c : value) {
+    switch (c) {
+    case '\\':
+      escaped += "\\\\";
+      break;
+    case '"':
+      escaped += "\\\"";
+      break;
+    default:
+      escaped += c;
+      break;
+    }
+  }
+  return escaped;
+}
 
 bool parse_uintmax(const std::string &value, std::uintmax_t &result) {
   if (value.empty()) {
@@ -207,6 +259,71 @@ bool is_secret(std::string file_name, std::string token,
     return false;
   return res[0]["is_secret"].as<bool>();
 }
+
+void record_public_download(const std::string &relative_filename,
+                            const std::string &content_type,
+                            std::uintmax_t file_size) {
+  if (!is_top_download_candidate(content_type, file_size)) {
+    return;
+  }
+
+  const auto now = std::chrono::steady_clock::now();
+  std::lock_guard<std::mutex> lock(g_download_stats_mutex);
+  prune_download_stats_locked(now);
+  auto &stat = g_download_stats[relative_filename];
+  stat.count += 1;
+  stat.bytes = file_size;
+  stat.content_type = content_type;
+  stat.last_seen = now;
+}
+
+std::string top_downloads_json(std::size_t limit) {
+  if (limit == 0) {
+    limit = kTopDownloadDefaultLimit;
+  }
+  limit = std::min<std::size_t>(limit, 50);
+
+  const auto now = std::chrono::steady_clock::now();
+  std::vector<std::pair<std::string, DownloadStat>> items;
+  {
+    std::lock_guard<std::mutex> lock(g_download_stats_mutex);
+    prune_download_stats_locked(now);
+    items.reserve(g_download_stats.size());
+    for (const auto &entry : g_download_stats) {
+      items.push_back(entry);
+    }
+  }
+
+  std::sort(items.begin(), items.end(), [](const auto &a, const auto &b) {
+    if (a.second.count == b.second.count) {
+      return a.first < b.first;
+    }
+    return a.second.count > b.second.count;
+  });
+
+  std::string body = R"({"result":[)";
+  std::size_t emitted = 0;
+  for (const auto &entry : items) {
+    if (emitted >= limit) {
+      break;
+    }
+    if (emitted > 0) {
+      body += ",";
+    }
+    body += R"({"url":"/media/get/)";
+    body += json_escape(entry.first);
+    body += R"(","bytes":)";
+    body += std::to_string(entry.second.bytes);
+    body += R"(,"content_type":")";
+    body += json_escape(entry.second.content_type);
+    body += R"(","count":)";
+    body += std::to_string(entry.second.count);
+    body += "}";
+    emitted += 1;
+  }
+  body += "]}";
+  return body;
+}
 } // namespace media
 
 namespace media::server {
@@ -305,6 +422,10 @@ void get_file(std::unique_ptr<restinio::router::express_router_t<>> &router,
     std::error_code size_error;
     std::uintmax_t file_size = std::filesystem::file_size(file_path, size_error);
     if (!size_error) {
+      if (status == FileStatus::SHARED) {
+        media::record_public_download(relative_filename, content_type, file_size);
+      }
+
       RangeRequest range_request = parse_range_header(range_header, file_size);
       if (range_request.present && !range_request.valid) {
         return req
@@ -324,6 +445,7 @@ void get_file(std::unique_ptr<restinio::router::express_router_t<>> &router,
         return req->create_response(restinio::status_partial_content())
             .append_header(restinio::http_field::content_type, content_type)
             .append_header(restinio::http_field::accept_ranges, "bytes")
+            .append_header(restinio::http_field::cache_control, "public, max-age=86400")
             .append_header(restinio::http_field::content_range,
                            content_range.str())
             .set_body(restinio::sendfile(file_path).offset_and_size(
@@ -338,6 +460,7 @@ void get_file(std::unique_ptr<restinio::router::express_router_t<>> &router,
       return req->create_response()
           .append_header(restinio::http_field::content_type, content_type)
           .append_header(restinio::http_field::accept_ranges, "bytes")
+          .append_header(restinio::http_field::cache_control, "public, max-age=86400")
           .set_body(restinio::sendfile(file_path))
           .done();
     } else {
@@ -347,9 +470,33 @@ void get_file(std::unique_ptr<restinio::router::express_router_t<>> &router,
       return req->create_response()
           .append_header(restinio::http_field::content_type, content_type)
           .append_header(restinio::http_field::accept_ranges, "bytes")
+          .append_header(restinio::http_field::cache_control, "public, max-age=86400")
           .set_body(std::string(file_content->begin(), file_content->end()))
           .done();
     }
+  });
+}
+
+void get_top_downloads(
+    std::unique_ptr<restinio::router::express_router_t<>> &router,
+    std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
+  router.get()->http_get(R"(/media/top-downloads:search(.*))", [logger_ptr](auto req, auto) {
+    logger_ptr->trace([] { return "called /media/top-downloads"; });
+    const auto qp = restinio::parse_query(req->header().query());
+    std::size_t limit = kTopDownloadDefaultLimit;
+    if (qp.has("limit")) {
+      try {
+        limit = static_cast<std::size_t>(std::stoul((std::string)qp["limit"]));
+      } catch (...) {
+        return req->create_response(restinio::status_bad_request()).done();
+      }
+    }
+
+    return req->create_response()
+        .append_header("Content-Type", "application/json; charset=utf-8")
+        .append_header(restinio::http_field::cache_control, "public, max-age=900")
+        .set_body(media::top_downloads_json(limit))
+        .done();
   });
 }
 } // namespace media::server

--- a/src/basic/media.cc
+++ b/src/basic/media.cc
@@ -310,7 +310,7 @@ std::string top_downloads_json(std::size_t limit) {
     if (emitted > 0) {
       body += ",";
     }
-    body += R"({"url":"/media/get/)";
+    body += R"({"url":"/api/media/get/)";
     body += json_escape(entry.first);
     body += R"(","bytes":)";
     body += std::to_string(entry.second.bytes);

--- a/src/basic/media.h
+++ b/src/basic/media.h
@@ -36,6 +36,12 @@ std::vector<std::string> get_all_files(std::string path);
 bool is_secret(std::string file_name, std::string token,
                std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
+void record_public_download(const std::string &relative_filename,
+                            const std::string &content_type,
+                            std::uintmax_t file_size);
+
+std::string top_downloads_json(std::size_t limit);
+
 enum class FileStatus {
   SHARED,
   AVALUABLE,
@@ -51,6 +57,10 @@ namespace media::server {
 void get_file(std::unique_ptr<restinio::router::express_router_t<>> &router,
               std::shared_ptr<cp::ConnectionsManager> pool_ptr,
               std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
+
+void get_top_downloads(
+    std::unique_ptr<restinio::router::express_router_t<>> &router,
+    std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
 
 void get_all_files(
     std::unique_ptr<restinio::router::express_router_t<>> &router,

--- a/src/basic/media_cash.cc
+++ b/src/basic/media_cash.cc
@@ -1,7 +1,12 @@
 #include "media_cash.h"
 #include <iostream>
+
 namespace media_cash {
-FileCache::FileCache(std::size_t max_files) : m_max_files(max_files) {}
+
+FileCache::FileCache(std::size_t max_files, std::size_t max_bytes,
+                     std::size_t max_single_file_bytes)
+    : m_max_files(max_files), m_max_bytes(max_bytes),
+      m_max_single_file_bytes(max_single_file_bytes) {}
 
 std::shared_ptr<FileContent> FileCache::get_file(const std::string &path) {
   std::lock_guard<std::mutex> lock(m_mutex);
@@ -9,49 +14,70 @@ std::shared_ptr<FileContent> FileCache::get_file(const std::string &path) {
   ++m_usage_count[path];
 
   auto it = m_cache.find(path);
-  if (it != m_cache.end())
+  if (it != m_cache.end()) {
     return it->second;
+  }
 
-  auto content = load_file(path);
+  std::error_code ec;
+  auto size = std::filesystem::file_size(path, ec);
+  if (ec || size > m_max_single_file_bytes || size > m_max_bytes) {
+    return nullptr;
+  }
 
-  if (m_cache.size() < m_max_files) {
+  auto content = load_file(path, size);
+  if (content == nullptr) {
+    return nullptr;
+  }
+
+  evict_until_fits(path, content->size());
+  if (m_cache.size() < m_max_files && m_current_bytes + content->size() <= m_max_bytes) {
+    m_current_bytes += content->size();
     m_cache[path] = content;
-  } else {
-    evict_least_popular_if_needed(path);
-    if (m_cache.size() < m_max_files)
-      m_cache[path] = content;
   }
 
   return content;
 }
 
-std::shared_ptr<FileContent> FileCache::load_file(const std::string &path) {
-  const std::uintmax_t MAX_CACHEABLE_SIZE = 1ull << 30; // 1GB
+std::size_t FileCache::cached_bytes() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_current_bytes;
+}
 
-  std::error_code ec;
-  auto size = std::filesystem::file_size(path, ec);
-  if (ec || size > MAX_CACHEABLE_SIZE)
+std::shared_ptr<FileContent> FileCache::load_file(const std::string &path,
+                                                  std::uintmax_t size) {
+  if (size > m_max_single_file_bytes) {
     return nullptr;
+  }
 
   std::ifstream file(path, std::ios::binary);
-  if (!file)
+  if (!file) {
     return nullptr;
+  }
 
   FileContent vec(std::istreambuf_iterator<char>(file), {});
   return std::make_shared<FileContent>(std::move(vec));
 }
 
-void FileCache::evict_least_popular_if_needed(
-    const std::string &incoming_path) {
-  auto min_it = std::min_element(
-      m_cache.begin(), m_cache.end(), [this](const auto &a, const auto &b) {
-        return m_usage_count[a.first] < m_usage_count[b.first];
-      });
+void FileCache::evict_until_fits(const std::string &incoming_path,
+                                 std::size_t incoming_size) {
+  while (!m_cache.empty() &&
+         (m_cache.size() >= m_max_files || m_current_bytes + incoming_size > m_max_bytes)) {
+    auto min_it = std::min_element(
+        m_cache.begin(), m_cache.end(), [this](const auto &a, const auto &b) {
+          return m_usage_count[a.first] < m_usage_count[b.first];
+        });
 
-  if (min_it != m_cache.end()) {
-    if (m_usage_count[incoming_path] >= m_usage_count[min_it->first]) {
-      m_cache.erase(min_it);
+    if (min_it == m_cache.end()) {
+      return;
     }
+    if (m_usage_count[incoming_path] < m_usage_count[min_it->first] &&
+        m_current_bytes + incoming_size <= m_max_bytes) {
+      return;
+    }
+
+    m_current_bytes -= min_it->second->size();
+    m_cache.erase(min_it);
   }
 }
+
 } // namespace media_cash

--- a/src/basic/media_cash.h
+++ b/src/basic/media_cash.h
@@ -12,16 +12,22 @@ namespace media_cash {
 using FileContent = std::vector<uint8_t>;
 class FileCache {
 public:
-  FileCache(std::size_t max_files);
+  explicit FileCache(std::size_t max_files,
+                     std::size_t max_bytes = 128ull * 1024ull * 1024ull,
+                     std::size_t max_single_file_bytes = 2ull * 1024ull * 1024ull);
   std::shared_ptr<FileContent> get_file(const std::string &path);
+  std::size_t cached_bytes() const;
 
 private:
   std::size_t m_max_files;
-  std::mutex m_mutex;
+  std::size_t m_max_bytes;
+  std::size_t m_max_single_file_bytes;
+  std::size_t m_current_bytes = 0;
+  mutable std::mutex m_mutex;
   std::unordered_map<std::string, std::shared_ptr<FileContent>> m_cache;
   std::unordered_map<std::string, std::size_t> m_usage_count;
 
-  std::shared_ptr<FileContent> load_file(const std::string &path);
-  void evict_least_popular_if_needed(const std::string &incoming_path);
+  std::shared_ptr<FileContent> load_file(const std::string &path, std::uintmax_t size);
+  void evict_until_fits(const std::string &incoming_path, std::size_t incoming_size);
 };
 } // namespace media_cash

--- a/src/basic/pqxx_cp.cc
+++ b/src/basic/pqxx_cp.cc
@@ -1,7 +1,9 @@
 #include "pqxx_cp.h"
 
+#include <chrono>
 #include <cstdio>
 #include <ctime>
+#include <mutex>
 #include <string_view>
 
 namespace {
@@ -59,6 +61,18 @@ struct CampShift {
     time_t start;
     time_t end;
 };
+
+constexpr auto kMetadataCacheTtl = std::chrono::seconds(60);
+
+struct MetadataCache {
+    std::vector<CalendarSegment> calendar;
+    std::vector<CampShift> shifts;
+    std::chrono::steady_clock::time_point calendar_loaded_at{};
+    std::chrono::steady_clock::time_point shifts_loaded_at{};
+};
+
+MetadataCache g_metadata_cache;
+std::mutex g_metadata_cache_mutex;
 
 // Parse PostgreSQL timestamp "YYYY-MM-DD HH:MM:SS"
 time_t parse_pg_timestamp(const std::string &s) {
@@ -123,6 +137,64 @@ ShiftInfo compute_shift_info(time_t dt, const std::vector<CampShift> &shifts) {
         }
     }
     return {};
+}
+
+std::vector<CampShift> get_cached_shifts(std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+    const auto now = std::chrono::steady_clock::now();
+    {
+        std::lock_guard<std::mutex> lock(g_metadata_cache_mutex);
+        if (!g_metadata_cache.shifts.empty() &&
+            now - g_metadata_cache.shifts_loaded_at < kMetadataCacheTtl) {
+            return g_metadata_cache.shifts;
+        }
+    }
+
+    std::vector<CampShift> shifts;
+    cp::SafeCon con{pool_ptr};
+    pqxx::result shift_rows = con->execute(
+        R"(SELECT name, start_date, end_date FROM "camp_dates" ORDER BY start_date)");
+
+    for (const auto &row : shift_rows) {
+        CampShift shift;
+        shift.name = row["name"].as<std::string>();
+        shift.start = parse_pg_timestamp(row["start_date"].as<std::string>());
+        shift.end = parse_pg_timestamp(row["end_date"].as<std::string>());
+        shifts.push_back(std::move(shift));
+    }
+
+    std::lock_guard<std::mutex> lock(g_metadata_cache_mutex);
+    g_metadata_cache.shifts = shifts;
+    g_metadata_cache.shifts_loaded_at = now;
+    return g_metadata_cache.shifts;
+}
+
+std::vector<CalendarSegment> get_cached_calendar(std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+    const auto now = std::chrono::steady_clock::now();
+    {
+        std::lock_guard<std::mutex> lock(g_metadata_cache_mutex);
+        if (!g_metadata_cache.calendar.empty() &&
+            now - g_metadata_cache.calendar_loaded_at < kMetadataCacheTtl) {
+            return g_metadata_cache.calendar;
+        }
+    }
+
+    std::vector<CalendarSegment> calendar;
+    cp::SafeCon con{pool_ptr};
+    pqxx::result cal = con->execute(
+        R"(SELECT chapter, start, "end" FROM "calendar" ORDER BY start)");
+
+    for (const auto &row : cal) {
+        CalendarSegment seg;
+        seg.chapter = row["chapter"].as<std::string>();
+        seg.start = parse_pg_timestamp(row["start"].as<std::string>());
+        seg.end = parse_pg_timestamp(row["end"].as<std::string>());
+        calendar.push_back(std::move(seg));
+    }
+
+    std::lock_guard<std::mutex> lock(g_metadata_cache_mutex);
+    g_metadata_cache.calendar = calendar;
+    g_metadata_cache.calendar_loaded_at = now;
+    return g_metadata_cache.calendar;
 }
 
 } // namespace
@@ -193,23 +265,9 @@ std::string serialize_with_shift_day(const pqxx::result &res, std::shared_ptr<Co
   }
 
   std::vector<CampShift> shifts;
-  auto con = std::move(pool_ptr->getConnection());
   try {
-    pqxx::result shift_rows = con->execute(
-        R"(SELECT name, start_date, end_date FROM "camp_dates" ORDER BY start_date)");
-    pool_ptr->returnConnection(std::move(con));
-
-    for (const auto &row : shift_rows) {
-      CampShift shift;
-      shift.name = row["name"].as<std::string>();
-      shift.start = parse_pg_timestamp(row["start_date"].as<std::string>());
-      shift.end = parse_pg_timestamp(row["end_date"].as<std::string>());
-      shifts.push_back(std::move(shift));
-    }
+    shifts = get_cached_shifts(pool_ptr);
   } catch (...) {
-    if (con) {
-      pool_ptr->returnConnection(std::move(con));
-    }
     return serialize(res);
   }
 
@@ -265,35 +323,12 @@ std::string serialize_with_segment_day(const pqxx::result &res, std::shared_ptr<
     return serialize(res);
   }
 
-  // Fetch all calendar segments once
   std::vector<CalendarSegment> calendar;
   std::vector<CampShift> shifts;
-  auto con = std::move(pool_ptr->getConnection());
   try {
-    pqxx::result cal = con->execute(
-        R"(SELECT chapter, start, "end" FROM "calendar" ORDER BY start)");
-    pqxx::result shift_rows = con->execute(
-        R"(SELECT name, start_date, end_date FROM "camp_dates" ORDER BY start_date)");
-    pool_ptr->returnConnection(std::move(con));
-
-    for (const auto &row : cal) {
-      CalendarSegment seg;
-      seg.chapter = row["chapter"].as<std::string>();
-      seg.start = parse_pg_timestamp(row["start"].as<std::string>());
-      seg.end = parse_pg_timestamp(row["end"].as<std::string>());
-      calendar.push_back(std::move(seg));
-    }
-    for (const auto &row : shift_rows) {
-      CampShift shift;
-      shift.name = row["name"].as<std::string>();
-      shift.start = parse_pg_timestamp(row["start_date"].as<std::string>());
-      shift.end = parse_pg_timestamp(row["end_date"].as<std::string>());
-      shifts.push_back(std::move(shift));
-    }
+    calendar = get_cached_calendar(pool_ptr);
+    shifts = get_cached_shifts(pool_ptr);
   } catch (...) {
-    if (con) {
-      pool_ptr->returnConnection(std::move(con));
-    }
     return serialize_with_shift_day(res, pool_ptr);
   }
 

--- a/src/letovo-soc-net/social.cc
+++ b/src/letovo-soc-net/social.cc
@@ -1,6 +1,61 @@
 #include "social.h"
 #include "../basic/analytics.h"
 
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+
+namespace {
+
+bool parse_non_negative_int(const std::string& value, int& parsed) {
+    if(value.empty()) {
+        return false;
+    }
+    for(char c : value) {
+        if(!std::isdigit(static_cast<unsigned char>(c))) {
+            return false;
+        }
+    }
+    try {
+        parsed = std::stoi(value);
+        return parsed >= 0;
+    } catch(...) {
+        return false;
+    }
+}
+
+std::vector<int> parse_post_ids_csv(const std::string& raw) {
+    std::vector<int> ids;
+    std::stringstream ss(raw);
+    std::string item;
+    while(std::getline(ss, item, ',')) {
+        int id = 0;
+        if(!parse_non_negative_int(item, id)) {
+            return {};
+        }
+        ids.push_back(id);
+        if(ids.size() > 50) {
+            break;
+        }
+    }
+    std::sort(ids.begin(), ids.end());
+    ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
+    return ids;
+}
+
+std::string int_csv(const std::vector<int>& ids) {
+    std::string result;
+    for(int id : ids) {
+        if(!result.empty()) {
+            result += ",";
+        }
+        result += std::to_string(id);
+    }
+    return result;
+}
+
+} // namespace
+
 namespace social {
 
     bool is_leap_year(int year) {
@@ -83,6 +138,109 @@ namespace social {
         
         pool_ptr->returnConnection(std::move(con));
         return result;
+    }
+
+    std::string get_news_related(std::vector<int> post_ids, int comments_size, std::string username, bool include_secret, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+        if(post_ids.empty()) {
+            return R"({"result":[]})";
+        }
+        comments_size = std::max(comments_size, 0);
+        comments_size = std::min(comments_size, 5);
+
+        const std::string ids = int_csv(post_ids);
+        const std::string visible_post_predicate = include_secret ? "true" : "p.is_secret = false";
+        const std::string visible_comment_predicate = include_secret ? "true" : "p.is_secret = false AND COALESCE(parent.is_secret, false) = false";
+
+        auto con = std::move(pool_ptr->getConnection());
+        std::vector<std::string> params = {username};
+        const std::string query = fmt::format(R"SQL(
+WITH input_ids AS (
+    SELECT unnest(ARRAY[{0}]::int[]) AS post_id
+),
+visible_posts AS (
+    SELECT p.post_id
+    FROM "posts" p
+    JOIN input_ids i ON i.post_id = p.post_id
+    WHERE p.parent_id IS NULL
+      AND p.post_path IS NULL
+      AND ({1})
+),
+media_rows AS (
+    SELECT pm.post_id::int AS post_id,
+           jsonb_agg(
+               jsonb_build_object(
+                   'media', pm.media,
+                   'is_pic', pm.is_pic,
+                   'is_secret', pm.is_secret,
+                   'post_id', pm.post_id
+               )
+               ORDER BY pm.media
+           ) AS media
+    FROM "post_media" pm
+    JOIN visible_posts vp ON vp.post_id::text = pm.post_id
+    WHERE COALESCE(pm.is_secret, false) = false
+    GROUP BY pm.post_id
+),
+comment_counts AS (
+    SELECT p.parent_id::int AS post_id, count(*)::int AS comments_count
+    FROM "posts" p
+    LEFT JOIN "posts" parent ON p.parent_id = parent.post_id
+    JOIN visible_posts vp ON vp.post_id = p.parent_id
+    WHERE p.post_path IS NULL
+      AND ({2})
+    GROUP BY p.parent_id
+),
+ranked_comments AS (
+    SELECT p.*,
+           u.avatar_pic,
+           u.display_name,
+           CASE WHEN l.username = $1 AND l.value = 1 THEN true ELSE false END AS is_liked,
+           CASE WHEN l.username = $1 AND l.value = -1 THEN true ELSE false END AS is_disliked,
+           CASE WHEN s.username IS NOT NULL THEN true ELSE false END AS saved,
+           ROW_NUMBER() OVER (PARTITION BY p.parent_id ORDER BY p.date DESC) AS rn
+    FROM "posts" p
+    LEFT JOIN "posts" parent ON p.parent_id = parent.post_id
+    LEFT JOIN "user_likes" l ON l.post_id = p.post_id AND l.username = $1
+    LEFT JOIN "user_saved" s ON p.post_id = s.post_id AND s.username = $1
+    LEFT JOIN "user" u ON p.author = u.username
+    JOIN visible_posts vp ON vp.post_id = p.parent_id
+    WHERE p.post_path IS NULL
+      AND ({2})
+),
+comment_preview AS (
+    SELECT parent_id::int AS post_id,
+           jsonb_agg(to_jsonb(ranked_comments) - 'rn' ORDER BY date DESC) AS comments
+    FROM ranked_comments
+    WHERE rn <= {3}
+    GROUP BY parent_id
+)
+SELECT jsonb_build_object(
+    'result',
+    COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'post_id', vp.post_id::text,
+                'media', COALESCE(m.media, '[]'::jsonb),
+                'comments_count', COALESCE(cc.comments_count, 0),
+                'comments', COALESCE(cp.comments, '[]'::jsonb)
+            )
+            ORDER BY array_position(ARRAY[{0}]::int[], vp.post_id)
+        ),
+        '[]'::jsonb
+    )
+)::text AS payload
+FROM visible_posts vp
+LEFT JOIN media_rows m ON m.post_id = vp.post_id
+LEFT JOIN comment_counts cc ON cc.post_id = vp.post_id
+LEFT JOIN comment_preview cp ON cp.post_id = vp.post_id;
+)SQL", ids, visible_post_predicate, visible_comment_predicate, comments_size);
+
+        pqxx::result result = con->execute_params(query, params);
+        pool_ptr->returnConnection(std::move(con));
+        if(result.empty() || result[0]["payload"].is_null()) {
+            return R"({"result":[]})";
+        }
+        return result[0]["payload"].as<std::string>();
     }
 
     // FIXME: bug select always returns empty result
@@ -293,6 +451,44 @@ namespace social::server {
                 "GET", "/social/news", 200, 0, "", "{}", pool_ptr, logger_ptr);
             return req->create_response()
                 .set_body(cp::serialize_with_segment_day(result, pool_ptr))
+                .append_header("Content-Type", "application/json; charset=utf-8")
+                .done();
+        });
+    }
+
+    void get_news_related(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
+        router.get()->http_get(R"(/social/news/related:search(.*))", [pool_ptr, logger_ptr](auto req, auto) {
+            logger_ptr->trace([]{return "called /social/news/related";});
+            std::string token = security::bearer_or_cookie_token(req->header());
+            if(token.empty()) {
+                return req->create_response(restinio::status_unauthorized()).done();
+            }
+            std::string username = auth::get_username(token, pool_ptr);
+            if(username == "") {
+                return req->create_response(restinio::status_unauthorized()).done();
+            }
+            const auto qp = restinio::parse_query(req->header().query());
+            if(!qp.has("post_ids")) {
+                return req->create_response(restinio::status_bad_request()).done();
+            }
+
+            std::vector<int> post_ids = parse_post_ids_csv((std::string)qp["post_ids"]);
+            if(post_ids.empty()) {
+                return req->create_response(restinio::status_bad_request()).done();
+            }
+
+            int comments_size = 3;
+            if(qp.has("comments_size")) {
+                int parsed = 0;
+                if(!parse_non_negative_int((std::string)qp["comments_size"], parsed)) {
+                    return req->create_response(restinio::status_bad_request()).done();
+                }
+                comments_size = parsed;
+            }
+
+            const bool can_read_secret = security::can_read_secret_posts(username, pool_ptr);
+            return req->create_response()
+                .set_body(social::get_news_related(post_ids, comments_size, username, can_read_secret, pool_ptr))
                 .append_header("Content-Type", "application/json; charset=utf-8")
                 .done();
         });

--- a/src/letovo-soc-net/social.h
+++ b/src/letovo-soc-net/social.h
@@ -29,6 +29,8 @@ namespace social {
         
     pqxx::result get_post_media(std::string post_id, bool pics, bool include_secret, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
+    std::string get_news_related(std::vector<int> post_ids, int comments_size, std::string username, bool include_secret, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
+
     pqxx::result get_all_titles(bool include_secret, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
     pqxx::result get_post(std::string post_id, std::string usenrame, bool include_secret, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
@@ -56,6 +58,8 @@ namespace social::server {
     void get_authors_list(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
 
     void get_news(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
+
+    void get_news_related(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
 
     void get_comments(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -172,6 +172,7 @@ create(std::shared_ptr<cp::ConnectionsManager> pool_ptr,
 
   social::server::get_authors_list(router, pool_ptr, logger_ptr);
   social::server::get_news(router, pool_ptr, logger_ptr);
+  social::server::get_news_related(router, pool_ptr, logger_ptr);
   social::server::get_all_posts(router, pool_ptr, logger_ptr);
   social::server::get_posts_by_author(router, pool_ptr, logger_ptr);
   social::server::get_comments(router, pool_ptr, logger_ptr);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -204,6 +204,7 @@ create(std::shared_ptr<cp::ConnectionsManager> pool_ptr,
   authors::server::get_avaluable_authors(router, pool_ptr, logger_ptr);
 
   media::server::get_file(router, pool_ptr, logger_ptr);
+  media::server::get_top_downloads(router, logger_ptr);
 
   qr::server::achivement_qr(router, pool_ptr, logger_ptr);
   qr::server::page_qr(router, pool_ptr, logger_ptr);

--- a/test/test_issue91_feed_related_contract.py
+++ b/test/test_issue91_feed_related_contract.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_backend_has_news_related_batch_endpoint():
+    header = read("src/letovo-soc-net/social.h")
+    source = read("src/letovo-soc-net/social.cc")
+    server = read("src/server.cpp")
+
+    assert "std::string get_news_related(" in header
+    assert "void get_news_related(" in header
+    assert "std::string get_news_related(" in source
+    assert 'R"(/social/news/related:search(.*))"' in source
+    assert 'qp.has("post_ids")' in source
+    assert "'comments_count'" in source
+    assert "'comments'" in source
+    assert "'media'" in source
+    assert "ROW_NUMBER() OVER (PARTITION BY p.parent_id ORDER BY p.date DESC)" in source
+    assert "social::server::get_news_related(router, pool_ptr, logger_ptr);" in server
+
+
+def test_news_related_endpoint_uses_bounded_comment_preview():
+    source = read("src/letovo-soc-net/social.cc")
+
+    assert "comments_size = std::min(comments_size, 5);" in source
+    assert "comments_size = std::max(comments_size, 0);" in source
+    assert "rn <= " in source

--- a/test/test_issue91_performance_contract.py
+++ b/test/test_issue91_performance_contract.py
@@ -34,3 +34,17 @@ def test_issue91_hot_indexes_cover_feed_comments_media_chat():
     assert "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_user_saved_username_post_id" in sql
     assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_direct_message_sender_receiver_time_open" in sql
     assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_direct_message_receiver_sender_time_open" in sql
+
+
+def test_media_cache_is_bounded_by_bytes_not_only_file_count():
+    header = read("src/basic/media_cash.h")
+    source = read("src/basic/media_cash.cc")
+
+    assert "m_max_bytes" in header
+    assert "m_max_single_file_bytes" in header
+    assert "m_current_bytes" in header
+    assert "cached_bytes" in header
+    assert "1ull << 30" not in source
+    assert "size > m_max_single_file_bytes" in source
+    assert "m_current_bytes + incoming_size > m_max_bytes" in source
+    assert "m_current_bytes -= min_it->second->size();" in source

--- a/test/test_issue91_performance_contract.py
+++ b/test/test_issue91_performance_contract.py
@@ -60,6 +60,7 @@ def test_media_top_downloads_endpoint_tracks_only_public_bounded_media():
     assert "void get_top_downloads(" in header
     assert 'R"(/media/top-downloads:search(.*))"' in source
     assert "kTopDownloadMaxFileBytes" in source
+    assert 'R"({"url":"/api/media/get/)"' in source
     assert "status == FileStatus::SHARED" in source
     assert "record_public_download(relative_filename" in source
     assert "media::server::get_top_downloads(router, logger_ptr);" in server

--- a/test/test_issue91_performance_contract.py
+++ b/test/test_issue91_performance_contract.py
@@ -48,3 +48,18 @@ def test_media_cache_is_bounded_by_bytes_not_only_file_count():
     assert "size > m_max_single_file_bytes" in source
     assert "m_current_bytes + incoming_size > m_max_bytes" in source
     assert "m_current_bytes -= min_it->second->size();" in source
+
+
+def test_media_top_downloads_endpoint_tracks_only_public_bounded_media():
+    header = read("src/basic/media.h")
+    source = read("src/basic/media.cc")
+    server = read("src/server.cpp")
+
+    assert "record_public_download" in header
+    assert "top_downloads_json" in header
+    assert "void get_top_downloads(" in header
+    assert 'R"(/media/top-downloads:search(.*))"' in source
+    assert "kTopDownloadMaxFileBytes" in source
+    assert "status == FileStatus::SHARED" in source
+    assert "record_public_download(relative_filename" in source
+    assert "media::server::get_top_downloads(router, logger_ptr);" in server

--- a/test/test_issue91_performance_contract.py
+++ b/test/test_issue91_performance_contract.py
@@ -22,3 +22,15 @@ def test_nginx_compresses_api_json_and_static_text():
     assert "upstream letovo_backend" in nginx
     assert "keepalive 32;" in nginx
     assert "proxy_http_version 1.1;" in nginx
+
+
+def test_issue91_hot_indexes_cover_feed_comments_media_chat():
+    sql = read("docs/issue91_hot_indexes.sql")
+
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_feed_public_date" in sql
+    assert "WHERE parent_id IS NULL AND post_path IS NULL AND is_secret = false" in sql
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_comments_parent_date" in sql
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_post_media_post_id" in sql
+    assert "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_user_saved_username_post_id" in sql
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_direct_message_sender_receiver_time_open" in sql
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_direct_message_receiver_sender_time_open" in sql

--- a/test/test_issue91_performance_contract.py
+++ b/test/test_issue91_performance_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_nginx_compresses_api_json_and_static_text():
+    nginx = read("docs/nginx.conf")
+
+    assert "worker_processes  auto;" in nginx
+    assert "gzip on;" in nginx
+    assert "gzip_vary on;" in nginx
+    assert "gzip_min_length 1024;" in nginx
+    assert "gzip_comp_level 5;" in nginx
+    assert "application/json" in nginx
+    assert "application/javascript" in nginx
+    assert "image/svg+xml" in nginx
+    assert "upstream letovo_backend" in nginx
+    assert "keepalive 32;" in nginx
+    assert "proxy_http_version 1.1;" in nginx

--- a/test/test_issue91_performance_contract.py
+++ b/test/test_issue91_performance_contract.py
@@ -75,3 +75,15 @@ def test_serializer_metadata_uses_short_ttl_cache():
     assert 'SELECT name, start_date, end_date FROM "camp_dates"' in source
     assert 'SELECT chapter, start, "end" FROM "calendar"' in source
     assert "std::lock_guard<std::mutex> lock(g_metadata_cache_mutex);" in source
+
+
+def test_runtime_image_and_compose_limit_disk_pressure():
+    dockerfile = read("src/Dockerfile")
+    compose = read("docs/docker-compose.yaml")
+
+    assert "cmake -DCMAKE_BUILD_TYPE=Release .." in dockerfile
+    assert "strip /app/server_starter" in dockerfile
+    assert "libpqxx-7.8" in dockerfile or "libpqxx-" in dockerfile
+    assert "libpqxx-dev" not in dockerfile.split("# ------ Stage 2: runtime -------", 1)[1]
+    assert compose.count('max-size: "100m"') >= 5
+    assert "--interval 300" in compose

--- a/test/test_issue91_performance_contract.py
+++ b/test/test_issue91_performance_contract.py
@@ -63,3 +63,15 @@ def test_media_top_downloads_endpoint_tracks_only_public_bounded_media():
     assert "status == FileStatus::SHARED" in source
     assert "record_public_download(relative_filename" in source
     assert "media::server::get_top_downloads(router, logger_ptr);" in server
+
+
+def test_serializer_metadata_uses_short_ttl_cache():
+    source = read("src/basic/pqxx_cp.cc")
+
+    assert "kMetadataCacheTtl" in source
+    assert "MetadataCache" in source
+    assert "get_cached_shifts" in source
+    assert "get_cached_calendar" in source
+    assert 'SELECT name, start_date, end_date FROM "camp_dates"' in source
+    assert 'SELECT chapter, start, "end" FROM "calendar"' in source
+    assert "std::lock_guard<std::mutex> lock(g_metadata_cache_mutex);" in source


### PR DESCRIPTION
## Summary
- Add issue #91 baseline tooling, nginx gzip/keepalive tuning, and hot-query Postgres indexes.
- Replace feed media/comment N+1 calls with a backend batch endpoint and frontend store batching.
- Bound backend media cache by bytes, expose rolling top media downloads, prefetch during idle time, cache serializer metadata, and reduce runtime/log pressure.

## Validation
- `python3 -m pytest test/test_issue91_performance_contract.py test/test_issue91_feed_related_contract.py test/test_video_streaming_contract.py test/test_camp_dates_shift_day.py test/test_social_news_date_filter.py -q` -> 14 passed.
- `cd frontend && npm run test:news-feed-fanout && npm run test:media-prefetch && npx tsc --noEmit` -> passed.
- Docker backend image build for `src/Dockerfile` -> passed.
- `scripts/perf/issue91_baseline.sh` without auth -> public pages 200; authenticated endpoints 401 as expected without `LETOVO_AUTH_TOKEN`.

## Known limitation
- `./test/run_tests.sh` starts `server_starter` but local PostgreSQL was unavailable at `127.0.0.1:5432`, so the broad runner aborted before pytest with `pqxx::broken_connection`.

Closes #91