### PR TITLE
fix: omit missing news media paths

### DIFF
--- a/src/letovo-soc-net/social.cc
+++ b/src/letovo-soc-net/social.cc
@@ -179,6 +179,7 @@ media_rows AS (
     FROM "post_media" pm
     JOIN visible_posts vp ON vp.post_id::text = pm.post_id
     WHERE COALESCE(pm.is_secret, false) = false
+      AND pm.media IS NOT NULL
     GROUP BY pm.post_id
 ),
 comment_counts AS (

--- a/test/test_issue91_feed_related_contract.py
+++ b/test/test_issue91_feed_related_contract.py
@@ -31,3 +31,10 @@ def test_news_related_endpoint_uses_bounded_comment_preview():
     assert "comments_size = std::min(comments_size, 5);" in source
     assert "comments_size = std::max(comments_size, 0);" in source
     assert "rn <= " in source
+
+
+def test_news_related_endpoint_omits_null_media_paths():
+    source = read("src/letovo-soc-net/social.cc")
+
+    assert "pm.media IS NOT NULL" in source
+    assert "COALESCE(m.media, '[]'::jsonb)" in source


### PR DESCRIPTION
Fixes #102. Backend related-media query now excludes post_media rows where media is NULL, so social/news/related returns an empty media array instead of media:null entries. Also bumps the frontend submodule to letovo-dev/letovo-all-frontend#22, which skips null or empty media paths defensively before carousel URL construction. Checks: python3 -m pytest test/test_issue91_feed_related_contract.py; frontend npm run test:news-media-null-paths; frontend npm run test:news-feed-fanout; frontend npm run test:media-prefetch; frontend npx tsc --noEmit --incremental false.