### PR TITLE
Require whireable role for transfer recipients

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -680,7 +680,8 @@ CREATE TABLE public.role (
     write_posts boolean,
     admin boolean,
     moder boolean,
-    main_page boolean
+    main_page boolean,
+    whireable boolean DEFAULT false
 );
 
 
@@ -1496,4 +1497,3 @@ CREATE INDEX idx_message_attachments_message_id ON public.message_attachments(me
 --
 
 \unrestrict DcZgZcQEi4f3bvxPbX2ujwdl1hqpF6E4scmb22IrRXAOOfLe0MsHhy1DhNbFZEJ
-

--- a/docs/whireable_role_migration.sql
+++ b/docs/whireable_role_migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.role
+ADD COLUMN IF NOT EXISTS whireable boolean DEFAULT false;

--- a/src/basic/auth.cc
+++ b/src/basic/auth.cc
@@ -167,7 +167,8 @@ bool is_user(std::string username,
 bool is_rights_by_username(const std::string& username,
                            std::shared_ptr<cp::ConnectionsManager> pool_ptr,
                            const std::string& rights) {
-  static const std::unordered_set<std::string> allowed = {"write_posts", "admin", "moder", "main_page"};
+  static const std::unordered_set<std::string> allowed = {
+      "write_posts", "admin", "moder", "main_page", "whireable"};
   if (!allowed.count(rights)) {
     return false;
   }

--- a/src/basic/auth.h
+++ b/src/basic/auth.h
@@ -37,6 +37,8 @@ bool is_admin(std::string token,
               std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 bool is_user(std::string token,
              std::shared_ptr<cp::ConnectionsManager> pool_ptr);
+bool is_active(std::string username,
+               std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 bool is_rights_by_username(const std::string& username,
                            std::shared_ptr<cp::ConnectionsManager> pool_ptr,
                            const std::string& rights = "admin");

--- a/src/market/transactions.cc
+++ b/src/market/transactions.cc
@@ -65,6 +65,10 @@ namespace transactions {
         return result[0]["balance"].as<int>();
     }
 
+    bool can_receive_transfer(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+        return auth::is_rights_by_username(username, pool_ptr, "whireable");
+    }
+
 
     TransferResult transfer_with_result(std::string tr_id, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
         TransferResult result;
@@ -77,6 +81,11 @@ namespace transactions {
         result.sender = transaction->sender;
         result.receiver = transaction->receiver;
         result.amount = amount;
+
+        if (!can_receive_transfer(transaction->receiver, pool_ptr)) {
+            result.status = TransactionStatus::NotReceiver;
+            return result;
+        }
 
         int balance = get_balance(transaction->sender, pool_ptr);
         bool sender_is_admin = auth::is_rights_by_username(transaction->sender, pool_ptr);
@@ -223,6 +232,9 @@ namespace transactions {
         if (r.empty()) {
             return {TransactionStatus::WrongId, ""};
         }
+        if (!can_receive_transfer(reciver, pool_ptr)) {
+            return {TransactionStatus::NotReceiver, ""};
+        }
         
         return {registered_transactions.add_transaction(tr_id, std::make_shared<TransactionDetails>(sender, reciver, std::to_string(ammount))), tr_id};
     }
@@ -347,6 +359,12 @@ namespace transactions::server {
                         .set_body("wrong username")
                     .done();
                     break;
+                case TransactionStatus::NotReceiver:
+                    return req->create_response(restinio::status_not_acceptable())
+                        .append_header("Content-Type", "text/plain; charset=utf-8")
+                        .set_body("receiver is not whireable")
+                    .done();
+                    break;
                 case TransactionStatus::Error:
                 default:
                     break;
@@ -410,6 +428,12 @@ namespace transactions::server {
                     return req->create_response(restinio::status_not_acceptable())
                         .append_header("Content-Type", "text/plain; charset=utf-8")
                         .set_body("wrong id")
+                    .done();
+                    break;
+                case TransactionStatus::NotReceiver:
+                    return req->create_response(restinio::status_not_acceptable())
+                        .append_header("Content-Type", "text/plain; charset=utf-8")
+                        .set_body("receiver is not whireable")
                     .done();
                     break;
                 case TransactionStatus::Error:

--- a/src/market/transactions.cc
+++ b/src/market/transactions.cc
@@ -65,6 +65,10 @@ namespace transactions {
         return result[0]["balance"].as<int>();
     }
 
+    bool can_use_transactions(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+        return auth::is_active(username, pool_ptr);
+    }
+
     bool can_receive_transfer(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
         return auth::is_rights_by_username(username, pool_ptr, "whireable");
     }
@@ -81,6 +85,12 @@ namespace transactions {
         result.sender = transaction->sender;
         result.receiver = transaction->receiver;
         result.amount = amount;
+
+        if (!can_use_transactions(transaction->sender, pool_ptr) ||
+            !can_use_transactions(transaction->receiver, pool_ptr)) {
+            result.status = TransactionStatus::InactiveUser;
+            return result;
+        }
 
         if (!can_receive_transfer(transaction->receiver, pool_ptr)) {
             result.status = TransactionStatus::NotReceiver;
@@ -207,6 +217,9 @@ namespace transactions {
     }
 
     std::pair<TransactionStatus, std::string> prepare_transaction(std::string sender, std::string reciver, int ammount, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+        if (!can_use_transactions(sender, pool_ptr)) {
+            return {TransactionStatus::InactiveUser, ""};
+        }
         int balance = get_balance(sender, pool_ptr);
         bool sender_is_admin = auth::is_rights_by_username(sender, pool_ptr);
         if (!sender_is_admin && ammount < 0) {
@@ -231,6 +244,9 @@ namespace transactions {
         pool_ptr->returnConnection(std::move(con));
         if (r.empty()) {
             return {TransactionStatus::WrongId, ""};
+        }
+        if (!can_use_transactions(reciver, pool_ptr)) {
+            return {TransactionStatus::InactiveUser, ""};
         }
         if (!can_receive_transfer(reciver, pool_ptr)) {
             return {TransactionStatus::NotReceiver, ""};
@@ -321,6 +337,12 @@ namespace transactions::server {
 
             if (new_body.HasMember("receiver") && new_body.HasMember("amount")) {
                 std::string sender = auth::get_username(token, pool_ptr);
+                if (!transactions::can_use_transactions(sender, pool_ptr)) {
+                    return req->create_response(restinio::status_forbidden())
+                        .append_header("Content-Type", "text/plain; charset=utf-8")
+                        .set_body("user is not active")
+                    .done();
+                }
                 std::string receiver = new_body["receiver"].GetString();
                 if(auth::is_user(receiver, pool_ptr) == false) {
                     return req->create_response(restinio::status_not_acceptable())
@@ -365,6 +387,12 @@ namespace transactions::server {
                         .set_body("receiver is not whireable")
                     .done();
                     break;
+                case TransactionStatus::InactiveUser:
+                    return req->create_response(restinio::status_forbidden())
+                        .append_header("Content-Type", "text/plain; charset=utf-8")
+                        .set_body("user is not active")
+                    .done();
+                    break;
                 case TransactionStatus::Error:
                 default:
                     break;
@@ -401,6 +429,12 @@ namespace transactions::server {
                 .done();
             }
             std::string username = auth::get_username(token, pool_ptr);
+            if (!transactions::can_use_transactions(username, pool_ptr)) {
+                return req->create_response(restinio::status_forbidden())
+                    .append_header("Content-Type", "text/plain; charset=utf-8")
+                    .set_body("user is not active")
+                .done();
+            }
 
             if (new_body.HasMember("tr_id")) {
                 std::string tr_id = new_body["tr_id"].GetString();
@@ -436,6 +470,12 @@ namespace transactions::server {
                         .set_body("receiver is not whireable")
                     .done();
                     break;
+                case TransactionStatus::InactiveUser:
+                    return req->create_response(restinio::status_forbidden())
+                        .append_header("Content-Type", "text/plain; charset=utf-8")
+                        .set_body("user is not active")
+                    .done();
+                    break;
                 case TransactionStatus::Error:
                 default:
                     return req->create_response(restinio::status_internal_server_error())
@@ -469,6 +509,12 @@ namespace transactions::server {
             }
 
             std::string username = auth::get_username(token, pool_ptr);
+            if (!transactions::can_use_transactions(username, pool_ptr)) {
+                return req->create_response(restinio::status_forbidden())
+                    .append_header("Content-Type", "text/plain; charset=utf-8")
+                    .set_body("user is not active")
+                .done();
+            }
             analytics::record_event(username, token, req->remote_endpoint().address().to_string(),
                 req->header().has_field("User-Agent") ? req->header().get_field("User-Agent") : "",
                 "GET", "/transactions/balance", 200, 0, "", "{}", pool_ptr, logger_ptr);
@@ -499,6 +545,12 @@ namespace transactions::server {
             }
 
             std::string username = auth::get_username(token, pool_ptr);
+            if (!transactions::can_use_transactions(username, pool_ptr)) {
+                return req->create_response(restinio::status_forbidden())
+                    .append_header("Content-Type", "text/plain; charset=utf-8")
+                    .set_body("user is not active")
+                .done();
+            }
             analytics::record_event(username, token, req->remote_endpoint().address().to_string(),
                 req->header().has_field("User-Agent") ? req->header().get_field("User-Agent") : "",
                 "GET", "/transactions/my", 200, 0, "", "{}", pool_ptr, logger_ptr);

--- a/src/market/transactions.h
+++ b/src/market/transactions.h
@@ -33,7 +33,7 @@ namespace transactions {
         Error,
         Success,
         NegativeNumber,
-        NotReciver,
+        NotReceiver,
     };
 
     struct TransferResult {
@@ -64,6 +64,8 @@ namespace transactions {
     TransferResult transfer_with_result(std::string tr_id, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
     int get_balance(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
+
+    bool can_receive_transfer(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
     pqxx::result get_transactions(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 

--- a/src/market/transactions.h
+++ b/src/market/transactions.h
@@ -34,6 +34,7 @@ namespace transactions {
         Success,
         NegativeNumber,
         NotReceiver,
+        InactiveUser,
     };
 
     struct TransferResult {
@@ -64,6 +65,8 @@ namespace transactions {
     TransferResult transfer_with_result(std::string tr_id, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
     int get_balance(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
+
+    bool can_use_transactions(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
     bool can_receive_transfer(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 

--- a/test/test_transaction_rules.py
+++ b/test/test_transaction_rules.py
@@ -32,3 +32,20 @@ def test_admin_negative_transaction_ignores_receiver_balance(tmp_path):
         check=True,
     )
     subprocess.run([str(binary)], check=True)
+
+
+def test_whireable_role_is_required_for_transfer_recipient():
+    repo_root = Path(__file__).resolve().parents[1]
+    auth_source = (repo_root / "src/basic/auth.cc").read_text()
+    transaction_source = (repo_root / "src/market/transactions.cc").read_text()
+    transaction_header = (repo_root / "src/market/transactions.h").read_text()
+    schema = (repo_root / "docs/schema.sql").read_text()
+    migration = (repo_root / "docs/whireable_role_migration.sql").read_text()
+
+    assert '"whireable"' in auth_source
+    assert "bool can_receive_transfer" in transaction_header
+    assert 'auth::is_rights_by_username(username, pool_ptr, "whireable")' in transaction_source
+    assert "TransactionStatus::NotReceiver" in transaction_source
+    assert "receiver is not whireable" in transaction_source
+    assert "whireable boolean DEFAULT false" in schema
+    assert "ADD COLUMN IF NOT EXISTS whireable boolean DEFAULT false" in migration

--- a/test/test_transaction_rules.py
+++ b/test/test_transaction_rules.py
@@ -36,6 +36,7 @@ def test_admin_negative_transaction_ignores_receiver_balance(tmp_path):
 
 def test_whireable_role_is_required_for_transfer_recipient():
     repo_root = Path(__file__).resolve().parents[1]
+    auth_header = (repo_root / "src/basic/auth.h").read_text()
     auth_source = (repo_root / "src/basic/auth.cc").read_text()
     transaction_source = (repo_root / "src/market/transactions.cc").read_text()
     transaction_header = (repo_root / "src/market/transactions.h").read_text()
@@ -43,9 +44,24 @@ def test_whireable_role_is_required_for_transfer_recipient():
     migration = (repo_root / "docs/whireable_role_migration.sql").read_text()
 
     assert '"whireable"' in auth_source
+    assert "bool is_active" in auth_header
     assert "bool can_receive_transfer" in transaction_header
     assert 'auth::is_rights_by_username(username, pool_ptr, "whireable")' in transaction_source
     assert "TransactionStatus::NotReceiver" in transaction_source
     assert "receiver is not whireable" in transaction_source
     assert "whireable boolean DEFAULT false" in schema
     assert "ADD COLUMN IF NOT EXISTS whireable boolean DEFAULT false" in migration
+
+
+def test_transactions_require_active_users():
+    repo_root = Path(__file__).resolve().parents[1]
+    transaction_source = (repo_root / "src/market/transactions.cc").read_text()
+    transaction_header = (repo_root / "src/market/transactions.h").read_text()
+
+    assert "bool can_use_transactions" in transaction_header
+    assert "TransactionStatus::InactiveUser" in transaction_source
+    assert "auth::is_active(username, pool_ptr)" in transaction_source
+    assert 'set_body("user is not active")' in transaction_source
+    assert transaction_source.count("transactions::can_use_transactions(username, pool_ptr)") >= 3
+    assert "can_use_transactions(transaction->sender, pool_ptr)" in transaction_source
+    assert "can_use_transactions(transaction->receiver, pool_ptr)" in transaction_source


### PR DESCRIPTION
## Summary
- add the whireable permission flag to the role table schema and migration
- require whireable=true on transfer recipients during prepare and send
- restrict transaction endpoints and transfer participants to active users
- cover the transfer recipient and active-user contracts in tests

## Tests
- python3 -m pytest test/test_transaction_rules.py -q