### PR TITLE
feat: add OpenTelemetry tracing

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -152,6 +152,10 @@ jobs:
             NEXT_PUBLIC_BASE_URL_MEDIA=${{ env.LIVE_E2E_BASE_URL }}/letovo-api/media/get
             NEXT_PUBLIC_UPLOAD_URL=${{ env.LIVE_E2E_BASE_URL }}/letovo-api/upload/
             NEXT_PUBLIC_BASE_URL_CLEAR=${{ env.LIVE_E2E_BASE_URL }}
+            NEXT_PUBLIC_OTEL_ENABLED=true
+            NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=/otel/v1/traces
+            NEXT_PUBLIC_OTEL_SERVICE_NAME=letovo-frontend
+            NEXT_PUBLIC_LETOVO_BUILD_SHA=${{ github.sha }}
           tags: ${{ env.FRONTEND_IMAGE }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -223,6 +227,10 @@ jobs:
           push: true
           build-args: |
             LETOVO_BUILD_SHA=${{ github.sha }}
+            NEXT_PUBLIC_OTEL_ENABLED=true
+            NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=/otel/v1/traces
+            NEXT_PUBLIC_OTEL_SERVICE_NAME=letovo-frontend
+            NEXT_PUBLIC_LETOVO_BUILD_SHA=${{ github.sha }}
           tags: |
             ${{ env.FRONTEND_IMAGE }}:latest
             ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
@@ -250,10 +258,18 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      - name: Verify frontend OpenTelemetry wiring
+        working-directory: frontend
+        run: npm run test:opentelemetry
+
       - name: Build frontend
         working-directory: frontend
         env:
           NEXT_TELEMETRY_DISABLED: "1"
+          NEXT_PUBLIC_OTEL_ENABLED: "true"
+          NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: /otel/v1/traces
+          NEXT_PUBLIC_OTEL_SERVICE_NAME: letovo-frontend
+          NEXT_PUBLIC_LETOVO_BUILD_SHA: ${{ github.sha }}
         run: npm run build
 
       - name: Scan frontend bundle for known bad routes

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   BACKEND_BUILD_FILES: >-
-    basic/auth.cc basic/analytics.cc basic/security.cc basic/utils.cc basic/pqxx_cp.cc basic/hash.cc
+    basic/auth.cc basic/analytics.cc basic/otel.cc basic/security.cc basic/utils.cc basic/pqxx_cp.cc basic/hash.cc
     basic/assist_funcs.cc basic/url_parser.cc basic/user_data.cc basic/checks.cc
     basic/media.cc basic/media_cash.cc basic/qr_worker.cc basic/ws_topic_authorizer.cc
     basic/ws_event_bus.cc basic/ws_endpoint.cc market/transactions.cc market/actives.cc

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -26,7 +26,7 @@ concurrency:
 
 env:
   BACKEND_BUILD_FILES: >-
-    basic/auth.cc basic/analytics.cc basic/security.cc basic/utils.cc basic/pqxx_cp.cc basic/hash.cc
+    basic/auth.cc basic/analytics.cc basic/otel.cc basic/security.cc basic/utils.cc basic/pqxx_cp.cc basic/hash.cc
     basic/assist_funcs.cc basic/url_parser.cc basic/user_data.cc basic/checks.cc
     basic/media.cc basic/media_cash.cc basic/qr_worker.cc basic/ws_topic_authorizer.cc
     basic/ws_event_bus.cc basic/ws_endpoint.cc market/transactions.cc market/actives.cc
@@ -137,6 +137,10 @@ jobs:
           NEXT_PUBLIC_UPLOAD_URL: ${{ steps.release.outputs.base_url }}/letovo-api/upload/
           NEXT_PUBLIC_BASE_URL_CLEAR: ${{ steps.release.outputs.base_url }}
           LETOVO_BUILD_SHA: ${{ steps.release.outputs.release_sha }}
+          NEXT_PUBLIC_OTEL_ENABLED: "true"
+          NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: /otel/v1/traces
+          NEXT_PUBLIC_OTEL_SERVICE_NAME: letovo-frontend
+          NEXT_PUBLIC_LETOVO_BUILD_SHA: ${{ steps.release.outputs.release_sha }}
         run: |
           set -euo pipefail
           npm ci
@@ -187,6 +191,10 @@ jobs:
             NEXT_PUBLIC_BASE_URL_MEDIA=${{ steps.release.outputs.base_url }}/letovo-api/media/get
             NEXT_PUBLIC_UPLOAD_URL=${{ steps.release.outputs.base_url }}/letovo-api/upload/
             NEXT_PUBLIC_BASE_URL_CLEAR=${{ steps.release.outputs.base_url }}
+            NEXT_PUBLIC_OTEL_ENABLED=true
+            NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=/otel/v1/traces
+            NEXT_PUBLIC_OTEL_SERVICE_NAME=letovo-frontend
+            NEXT_PUBLIC_LETOVO_BUILD_SHA=${{ steps.release.outputs.release_sha }}
           tags: ${{ steps.release.outputs.frontend_image }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -1,11 +1,35 @@
 version: '3.8'
 
 services:
+    otel-collector:
+        image: otel/opentelemetry-collector:0.155.0
+        container_name: otel-collector
+        restart: unless-stopped
+        command: ["--config=/etc/otelcol/config.yaml"]
+        volumes:
+          - ./otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
+        ports:
+          - "127.0.0.1:4317:4317"
+          - "127.0.0.1:4318:4318"
+        logging:
+          driver: json-file
+          options:
+            max-size: "100m"
+            max-file: "5"
+
     letovo-server:
         image: ghcr.io/letovo-dev/letovo-server:latest
         container_name: letovo-server
         restart: unless-stopped
         network_mode: "host"
+        depends_on:
+          - otel-collector
+        environment:
+          OTEL_SERVICE_NAME: letovo-server
+          OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318
+          OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://127.0.0.1:4318/v1/traces
+          OTEL_TRACES_EXPORTER: otlp
+          OTEL_LOG_LEVEL: info
         volumes:
           - /mnt/server-media:/app/pages
           - /mnt/server-configs:/app/configs
@@ -22,9 +46,16 @@ services:
         container_name: letovo-registration-server
         restart: unless-stopped
         network_mode: "host"
+        depends_on:
+          - otel-collector
         environment:
           SERVER_ADRESS: "127.0.0.1"
           SERVER_PORT: "8082"
+          OTEL_SERVICE_NAME: letovo-registration-server
+          OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318
+          OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://127.0.0.1:4318/v1/traces
+          OTEL_TRACES_EXPORTER: otlp
+          OTEL_LOG_LEVEL: info
         volumes:
           - /mnt/server-media:/app/pages
           - /mnt/server-configs:/app/configs
@@ -59,6 +90,9 @@ services:
           - "127.0.0.1:3000:3000"
         env_file:
           - /mnt/letovo-front.env
+        environment:
+          NEXT_PUBLIC_OTEL_ENABLED: "true"
+          NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: /otel/v1/traces
         init: true
         cap_drop:
           - ALL

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -115,6 +115,15 @@ http {
             proxy_read_timeout 120s;
         }
 
+        location /otel/ {
+            proxy_pass http://127.0.0.1:4318/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location / {
             proxy_pass http://letovo_frontend;
             proxy_http_version 1.1;

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -116,6 +116,8 @@ http {
         }
 
         location /otel/ {
+            limit_except POST { deny all; }
+            client_max_body_size 1m;
             proxy_pass http://127.0.0.1:4318/;
             proxy_http_version 1.1;
             proxy_set_header Host $host;

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -115,19 +115,15 @@ http {
             proxy_read_timeout 120s;
         }
 
-        location = /otel/v1/traces {
+        location /otel/ {
             limit_except POST { deny all; }
             client_max_body_size 1m;
-            proxy_pass http://127.0.0.1:4318/v1/traces;
+            proxy_pass http://127.0.0.1:4318/;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-        location /otel/ {
-            return 404;
         }
 
         location / {

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -115,15 +115,19 @@ http {
             proxy_read_timeout 120s;
         }
 
-        location /otel/ {
+        location = /otel/v1/traces {
             limit_except POST { deny all; }
             client_max_body_size 1m;
-            proxy_pass http://127.0.0.1:4318/;
+            proxy_pass http://127.0.0.1:4318/v1/traces;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /otel/ {
+            return 404;
         }
 
         location / {

--- a/docs/otel-collector-config.yaml
+++ b/docs/otel-collector-config.yaml
@@ -7,6 +7,10 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 128
+    spike_limit_mib: 32
   batch: {}
 
 exporters:
@@ -17,9 +21,9 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [debug]
     logs:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [debug]

--- a/docs/otel-collector-config.yaml
+++ b/docs/otel-collector-config.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,8 +48,27 @@ set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
 set(BUILD_STATIC_LIBS ON CACHE INTERNAL "")
 FetchContent_MakeAvailable(llhttp)
 
+set(WITH_OTLP_HTTP ON CACHE BOOL "enable OpenTelemetry OTLP HTTP exporter" FORCE)
+set(WITH_OTLP_GRPC OFF CACHE BOOL "disable OpenTelemetry OTLP gRPC exporter" FORCE)
+set(WITH_EXAMPLES OFF CACHE BOOL "disable OpenTelemetry examples" FORCE)
+set(WITH_FUNC_TESTS OFF CACHE BOOL "disable OpenTelemetry functional tests" FORCE)
+set(WITH_BENCHMARK OFF CACHE BOOL "disable OpenTelemetry benchmarks" FORCE)
+set(WITH_TESTING OFF CACHE BOOL "disable OpenTelemetry tests" FORCE)
+set(BUILD_TESTING OFF CACHE BOOL "disable dependency tests" FORCE)
+
+FetchContent_Declare(
+    opentelemetry-cpp
+    GIT_REPOSITORY https://github.com/open-telemetry/opentelemetry-cpp.git
+    GIT_TAG        v1.27.0
+)
+FetchContent_MakeAvailable(opentelemetry-cpp)
+
 string(REPLACE " " ";" BUILD_FILES "$ENV{BUILD_FILES}")
 set(SOURCES "$ENV{MAIN_FILE};${BUILD_FILES}")
+list(FIND SOURCES basic/otel.cc OTEL_SOURCE_INDEX)
+if(OTEL_SOURCE_INDEX EQUAL -1)
+    list(APPEND SOURCES basic/otel.cc)
+endif()
 
 # Enable processor-specific optimizations
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -67,4 +86,18 @@ endif()
 
 add_executable(server_starter ${SOURCES})
 
-target_link_libraries(server_starter restinio::restinio jwt-cpp::jwt-cpp -lpqxx -lpq -lssl -lcrypto -lpng -lqrencode)
+target_link_libraries(
+    server_starter
+    restinio::restinio
+    jwt-cpp::jwt-cpp
+    opentelemetry-cpp::api
+    opentelemetry-cpp::trace
+    opentelemetry-cpp::resources
+    opentelemetry-cpp::otlp_http_exporter
+    -lpqxx
+    -lpq
+    -lssl
+    -lcrypto
+    -lpng
+    -lqrencode
+)

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -11,10 +11,13 @@ RUN apt update && apt install -y \
         git \
         wget \
         curl \
+        libcurl4-openssl-dev \
         libfmt-dev \
         librestinio-dev \
         libasio-dev \
         rapidjson-dev \
+        libprotobuf-dev \
+        protobuf-compiler \
         libpqxx-dev \
         libpq-dev \
         libssl-dev \
@@ -45,7 +48,9 @@ FROM ubuntu:24.04
 # Устанавливаем только runtime-библиотеки
 RUN apt update && apt install -y \
         libfmt9 \
+        libcurl4 \
         libhttp-parser2.9 \
+        libprotobuf32t64 \
         libpqxx-7.8 \
         libpq5 \
         libssl3 \

--- a/src/basic/otel.cc
+++ b/src/basic/otel.cc
@@ -1,0 +1,191 @@
+#include "otel.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
+#include "opentelemetry/exporters/otlp/otlp_http_exporter_options.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
+#include "opentelemetry/sdk/resource/resource.h"
+#include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
+#include "opentelemetry/sdk/trace/batch_span_processor_options.h"
+#include "opentelemetry/sdk/trace/provider.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
+#include "opentelemetry/sdk/trace/tracer_provider_factory.h"
+#include "opentelemetry/trace/propagation/http_trace_context.h"
+
+namespace telemetry {
+
+namespace {
+
+namespace otlp = opentelemetry::exporter::otlp;
+namespace resource = opentelemetry::sdk::resource;
+namespace trace_sdk = opentelemetry::sdk::trace;
+namespace internal_log = opentelemetry::sdk::common::internal_log;
+namespace propagation = opentelemetry::context::propagation;
+
+std::shared_ptr<trace_sdk::TracerProvider> provider;
+
+std::string env_or(const char *name, const std::string &fallback) {
+  const char *value = std::getenv(name);
+  if (value == nullptr || value[0] == '\0') {
+    return fallback;
+  }
+  return value;
+}
+
+bool env_bool(const char *name, bool fallback) {
+  const char *value = std::getenv(name);
+  if (value == nullptr || value[0] == '\0') {
+    return fallback;
+  }
+
+  std::string raw = value;
+  std::transform(raw.begin(), raw.end(), raw.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return raw == "1" || raw == "true" || raw == "yes" || raw == "on";
+}
+
+bool env_is(const char *name, const std::string &expected) {
+  const char *value = std::getenv(name);
+  if (value == nullptr) {
+    return false;
+  }
+
+  std::string raw = value;
+  std::transform(raw.begin(), raw.end(), raw.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return raw == expected;
+}
+
+internal_log::LogLevel parse_log_level(const std::string &level) {
+  if (level == "debug") {
+    return internal_log::LogLevel::Debug;
+  }
+  if (level == "warn" || level == "warning") {
+    return internal_log::LogLevel::Warning;
+  }
+  if (level == "error") {
+    return internal_log::LogLevel::Error;
+  }
+  return internal_log::LogLevel::Info;
+}
+
+}  // namespace
+
+Settings settings_from_env(const std::string &fallback_service_name) {
+  Settings settings;
+  settings.enabled = env_bool("OTEL_SDK_ENABLED", true) &&
+                     !env_bool("OTEL_SDK_DISABLED", false) &&
+                     !env_is("OTEL_TRACES_EXPORTER", "none");
+  settings.service_name = env_or("OTEL_SERVICE_NAME", fallback_service_name);
+  settings.traces_endpoint = env_or(
+      "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+      env_or("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318") +
+          "/v1/traces");
+  settings.log_level = env_or("OTEL_LOG_LEVEL", "info");
+  return settings;
+}
+
+void init_tracing(
+    const Settings &settings,
+    std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
+  auto http_trace_context =
+      std::make_shared<opentelemetry::trace::propagation::HttpTraceContext>();
+  std::shared_ptr<propagation::TextMapPropagator> propagator =
+      http_trace_context;
+  propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+      opentelemetry::nostd::shared_ptr<propagation::TextMapPropagator>(
+          propagator));
+
+  if (!settings.enabled) {
+    if (logger_ptr) {
+      logger_ptr->info([] {
+        return "OpenTelemetry tracing disabled by OTEL_SDK_ENABLED";
+      });
+    }
+    return;
+  }
+
+  internal_log::GlobalLogHandler::SetLogLevel(
+      parse_log_level(settings.log_level));
+
+  otlp::OtlpHttpExporterOptions exporter_options;
+  exporter_options.url = settings.traces_endpoint;
+  exporter_options.console_debug = settings.log_level == "debug";
+
+  auto exporter = otlp::OtlpHttpExporterFactory::Create(exporter_options);
+
+  trace_sdk::BatchSpanProcessorOptions processor_options;
+  processor_options.schedule_delay_millis = std::chrono::milliseconds(5000);
+  processor_options.max_export_batch_size = 512;
+
+  auto processor = trace_sdk::BatchSpanProcessorFactory::Create(
+      std::move(exporter), processor_options);
+  provider = std::shared_ptr<trace_sdk::TracerProvider>(
+      trace_sdk::TracerProviderFactory::Create(
+          std::move(processor),
+          resource::Resource::Create({{"service.name", settings.service_name}})));
+
+  std::shared_ptr<opentelemetry::trace::TracerProvider> api_provider_std =
+      provider;
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider>
+      api_provider(api_provider_std);
+  trace_sdk::Provider::SetTracerProvider(api_provider);
+
+  if (logger_ptr) {
+    logger_ptr->info([settings] {
+      return fmt::format(
+          R"({{"event":"otel_initialized","service_name":"{}","traces_endpoint":"{}"}})",
+          json_escape(settings.service_name),
+          json_escape(settings.traces_endpoint));
+    });
+  }
+}
+
+void shutdown_tracing() {
+  if (provider) {
+    provider->ForceFlush();
+    provider->Shutdown();
+  }
+
+  provider.reset();
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  trace_sdk::Provider::SetTracerProvider(none);
+}
+
+std::string trace_id_for_log(const opentelemetry::trace::SpanContext &context) {
+  char buffer[2 * opentelemetry::trace::TraceId::kSize] = {};
+  context.trace_id().ToLowerBase16(buffer);
+  return std::string(buffer, sizeof(buffer));
+}
+
+std::string span_id_for_log(const opentelemetry::trace::SpanContext &context) {
+  char buffer[2 * opentelemetry::trace::SpanId::kSize] = {};
+  context.span_id().ToLowerBase16(buffer);
+  return std::string(buffer, sizeof(buffer));
+}
+
+const char *request_duration_ms_attribute() {
+  return "request.duration_ms";
+}
+
+std::string handling_status_name(restinio::request_handling_status_t status) {
+  switch (status) {
+    case restinio::request_handling_status_t::accepted:
+      return "accepted";
+    case restinio::request_handling_status_t::rejected:
+      return "rejected";
+    case restinio::request_handling_status_t::not_handled:
+      return "not_handled";
+  }
+  return "unknown";
+}
+
+}  // namespace telemetry

--- a/src/basic/otel.h
+++ b/src/basic/otel.h
@@ -1,0 +1,226 @@
+#pragma once
+
+#include <chrono>
+#include <cstdio>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <typeinfo>
+#include <utility>
+
+#include <fmt/format.h>
+#include <restinio/all.hpp>
+
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/context/propagation/global_propagator.h"
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/context/runtime_context.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/trace/span.h"
+#include "opentelemetry/trace/span_metadata.h"
+#include "opentelemetry/trace/tracer.h"
+
+namespace telemetry {
+
+struct Settings {
+  bool enabled{true};
+  std::string service_name{"letovo-server"};
+  std::string traces_endpoint{"http://127.0.0.1:4318/v1/traces"};
+  std::string log_level{"info"};
+};
+
+Settings settings_from_env(const std::string &fallback_service_name);
+void init_tracing(const Settings &settings,
+                  std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
+void shutdown_tracing();
+
+class TraceHeaderCarrier final
+    : public opentelemetry::context::propagation::TextMapCarrier {
+ public:
+  explicit TraceHeaderCarrier(const restinio::http_request_header_t &header)
+      : header_(header) {}
+
+  opentelemetry::nostd::string_view Get(
+      opentelemetry::nostd::string_view key) const noexcept override {
+    key_buffer_.assign(key.data(), key.size());
+    if (!header_.has_field(key_buffer_)) {
+      return "";
+    }
+    value_buffer_ = header_.get_field(key_buffer_);
+    return value_buffer_;
+  }
+
+  void Set(opentelemetry::nostd::string_view,
+           opentelemetry::nostd::string_view) noexcept override {}
+
+ private:
+  const restinio::http_request_header_t &header_;
+  mutable std::string key_buffer_;
+  mutable std::string value_buffer_;
+};
+
+std::string trace_id_for_log(const opentelemetry::trace::SpanContext &context);
+std::string span_id_for_log(const opentelemetry::trace::SpanContext &context);
+std::string handling_status_name(restinio::request_handling_status_t status);
+const char *request_duration_ms_attribute();
+
+inline std::string json_escape(std::string_view value) {
+  std::string escaped;
+  escaped.reserve(value.size());
+  for (const unsigned char c : value) {
+    switch (c) {
+      case '\\':
+        escaped += "\\\\";
+        break;
+      case '"':
+        escaped += "\\\"";
+        break;
+      case '\n':
+        escaped += "\\n";
+        break;
+      case '\r':
+        escaped += "\\r";
+        break;
+      case '\t':
+        escaped += "\\t";
+        break;
+      default:
+        if (c < 0x20) {
+          char encoded[7] = {};
+          std::snprintf(encoded, sizeof(encoded), "\\u%04x", c);
+          escaped += encoded;
+        } else {
+          escaped += static_cast<char>(c);
+        }
+        break;
+    }
+  }
+  return escaped;
+}
+
+inline std::int64_t elapsed_ms(std::chrono::steady_clock::time_point started_at) {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now() - started_at)
+      .count();
+}
+
+inline void record_request_log(
+    std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr,
+    std::string method,
+    std::string path,
+    std::string handling_status,
+    std::int64_t duration_ms,
+    opentelemetry::trace::SpanContext context) {
+  if (!logger_ptr) {
+    return;
+  }
+
+  logger_ptr->info([method = std::move(method),
+                    path = std::move(path),
+                    handling_status = std::move(handling_status),
+                    duration_ms,
+                    context] {
+    return fmt::format(
+        R"({{"event":"http_request","method":"{}","path":"{}","handling_status":"{}","duration_ms":{},"trace_id":"{}","span_id":"{}"}})",
+        json_escape(method),
+        json_escape(path),
+        json_escape(handling_status),
+        duration_ms,
+        trace_id_for_log(context),
+        span_id_for_log(context));
+  });
+}
+
+template <typename Handler>
+class TracedRequestHandler {
+ public:
+  TracedRequestHandler(Handler handler,
+                       std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr)
+      : handler_(std::move(handler)), logger_ptr_(std::move(logger_ptr)) {}
+
+  restinio::request_handling_status_t operator()(restinio::request_handle_t req) {
+    namespace trace = opentelemetry::trace;
+
+    const auto &header = req->header();
+    const std::string method = header.method().c_str();
+    const std::string path(header.path());
+    const std::string span_name = method + " " + path;
+    auto tracer = trace::Provider::GetTracerProvider()->GetTracer(
+        "letovo.backend.http", "1.0.0");
+
+    TraceHeaderCarrier carrier(header);
+    auto propagator =
+        opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+    auto current_context = opentelemetry::context::RuntimeContext::GetCurrent();
+    auto parent_context = propagator->Extract(carrier, current_context);
+
+    trace::StartSpanOptions options;
+    options.kind = trace::SpanKind::kServer;
+    options.parent = trace::GetSpan(parent_context)->GetContext();
+
+    auto span = tracer->StartSpan(
+        span_name,
+        {
+            {"http.request.method", method},
+            {"url.path", path},
+        },
+        options);
+    auto scope = tracer->WithActiveSpan(span);
+    const auto started_at = std::chrono::steady_clock::now();
+
+    try {
+      const auto result = (*handler_)(std::move(req));
+      const auto duration_ms = elapsed_ms(started_at);
+      const auto handling_status = handling_status_name(result);
+
+      span->SetAttribute("restinio.request_handling_status",
+                         handling_status);
+      span->SetAttribute(request_duration_ms_attribute(),
+                         static_cast<std::int64_t>(duration_ms));
+      span->End();
+
+      record_request_log(
+          logger_ptr_, method, path, handling_status, duration_ms, span->GetContext());
+
+      return result;
+    } catch (const std::exception &error) {
+      const auto duration_ms = elapsed_ms(started_at);
+      span->SetStatus(trace::StatusCode::kError, error.what());
+      span->SetAttribute("exception.type", std::string(typeid(error).name()));
+      span->SetAttribute("exception.message", std::string(error.what()));
+      span->SetAttribute("http.response.status_code", static_cast<std::int64_t>(500));
+      span->SetAttribute(request_duration_ms_attribute(),
+                         static_cast<std::int64_t>(duration_ms));
+      record_request_log(
+          logger_ptr_, method, path, "exception", duration_ms, span->GetContext());
+      span->End();
+      throw;
+    } catch (...) {
+      const auto duration_ms = elapsed_ms(started_at);
+      span->SetStatus(trace::StatusCode::kError, "unknown exception");
+      span->SetAttribute("http.response.status_code", static_cast<std::int64_t>(500));
+      span->SetAttribute(request_duration_ms_attribute(),
+                         static_cast<std::int64_t>(duration_ms));
+      record_request_log(
+          logger_ptr_, method, path, "exception", duration_ms, span->GetContext());
+      span->End();
+      throw;
+    }
+  }
+
+ private:
+  Handler handler_;
+  std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr_;
+};
+
+template <typename Handler>
+auto make_traced_handler(
+    std::unique_ptr<Handler> handler,
+    std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
+  return TracedRequestHandler<std::shared_ptr<Handler>>(
+      std::shared_ptr<Handler>(std::move(handler)), std::move(logger_ptr));
+}
+
+}  // namespace telemetry

--- a/src/basic/server_traits.h
+++ b/src/basic/server_traits.h
@@ -5,7 +5,7 @@
 namespace ws {
 
 struct server_traits : public restinio::default_traits_t {
-    using request_handler_t = restinio::router::express_router_t<>;
+    using request_handler_t = restinio::default_traits_t::request_handler_t;
 };
 
 } // namespace ws

--- a/src/registration_server.cpp
+++ b/src/registration_server.cpp
@@ -4,6 +4,7 @@
 #include "./basic/auth.h"
 #include "./basic/checks.h"
 #include "./basic/config.h"
+#include "./basic/otel.h"
 #include "./basic/server_traits.h"
 
 namespace rr = restinio::router;
@@ -20,26 +21,35 @@ create_registration_router(
 
 int main() {
   auto logger_ptr = std::make_shared<restinio::shared_ostream_logger_t>();
+  telemetry::init_tracing(
+      telemetry::settings_from_env("letovo-registration-server"), logger_ptr);
 
-  std::shared_ptr<cp::ConnectionsManager> pool_ptr =
-      std::make_shared<cp::ConnectionsManager>(logger_ptr,
-                                               Config::giveMe().sql_config);
+  try {
+    std::shared_ptr<cp::ConnectionsManager> pool_ptr =
+        std::make_shared<cp::ConnectionsManager>(logger_ptr,
+                                                 Config::giveMe().sql_config);
 
-  pool_ptr->connect();
-  pre_run_checks::do_checks(pool_ptr);
+    pool_ptr->connect();
+    pre_run_checks::do_checks(pool_ptr);
 
-  auto router = create_registration_router(pool_ptr, logger_ptr);
+    auto router = create_registration_router(pool_ptr, logger_ptr);
 
-  logger_ptr->info([] {
-    return fmt::format("Registration server is starting at {}:{}",
-                       Config::giveMe().server_config.adress,
-                       Config::giveMe().server_config.port);
-  });
+    logger_ptr->info([] {
+      return fmt::format("Registration server is starting at {}:{}",
+                         Config::giveMe().server_config.adress,
+                         Config::giveMe().server_config.port);
+    });
 
-  restinio::run(restinio::on_thread_pool<ws::server_traits>(
-                    Config::giveMe().server_config.thread_pool_size)
-                    .address(Config::giveMe().server_config.adress)
-                    .port(Config::giveMe().server_config.port)
-                    .request_handler(std::move(router)));
+    restinio::run(restinio::on_thread_pool<ws::server_traits>(
+                      Config::giveMe().server_config.thread_pool_size)
+                      .address(Config::giveMe().server_config.adress)
+                      .port(Config::giveMe().server_config.port)
+                      .request_handler(
+                          telemetry::make_traced_handler(std::move(router), logger_ptr)));
+    telemetry::shutdown_tracing();
+  } catch (...) {
+    telemetry::shutdown_tracing();
+    throw;
+  }
   return 0;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -17,6 +17,7 @@
 #include "./basic/analytics.h"
 #include "./basic/config.h"
 #include "./basic/media.h"
+#include "./basic/otel.h"
 #include "./basic/qr_worker.h"
 #include "./basic/user_data.h"
 #include "./letovo-soc-net/achivements.h"
@@ -225,36 +226,44 @@ int main() {
   using namespace std::chrono;
 
   auto logger_ptr = std::make_shared<restinio::shared_ostream_logger_t>();
+  telemetry::init_tracing(telemetry::settings_from_env("letovo-server"),
+                          logger_ptr);
 
-  std::shared_ptr<cp::ConnectionsManager> pool_ptr =
-      std::make_shared<cp::ConnectionsManager>(logger_ptr,
-                                               Config::giveMe().sql_config);
+  try {
+    std::shared_ptr<cp::ConnectionsManager> pool_ptr =
+        std::make_shared<cp::ConnectionsManager>(logger_ptr,
+                                                 Config::giveMe().sql_config);
 
-  prepare_paths();
+    prepare_paths();
 
-  pool_ptr->connect();
+    pool_ptr->connect();
 
-  pre_run_checks::do_checks(pool_ptr);
+    pre_run_checks::do_checks(pool_ptr);
 
-  auto bus_ptr        = std::make_shared<ws::EventBus>(logger_ptr, pool_ptr);
-  auto authorizer_ptr = std::make_shared<ws::TopicAuthorizer>();
-  chat::ws::register_topic_rules(authorizer_ptr, pool_ptr);
-  bus_ptr->recover_from_crash();
+    auto bus_ptr        = std::make_shared<ws::EventBus>(logger_ptr, pool_ptr);
+    auto authorizer_ptr = std::make_shared<ws::TopicAuthorizer>();
+    chat::ws::register_topic_rules(authorizer_ptr, pool_ptr);
+    bus_ptr->recover_from_crash();
 
-  auto router = create(pool_ptr, logger_ptr, bus_ptr, authorizer_ptr);
+    auto router = create(pool_ptr, logger_ptr, bus_ptr, authorizer_ptr);
 
-  logger_ptr->info([] {
-    return fmt::format("Server is starting at {}:{}",
-                       Config::giveMe().server_config.adress,
-                       Config::giveMe().server_config.port);
-  });
+    logger_ptr->info([] {
+      return fmt::format("Server is starting at {}:{}",
+                         Config::giveMe().server_config.adress,
+                         Config::giveMe().server_config.port);
+    });
 
-  restinio::run(restinio::on_thread_pool<ws::server_traits>(
-                    Config::giveMe().server_config.thread_pool_size)
-                    .address(Config::giveMe().server_config.adress)
-                    .port(Config::giveMe().server_config.port)
-                    .request_handler(move(router))
-                // .tls_context( std::move(tls_context) )
-  );
+    restinio::run(restinio::on_thread_pool<ws::server_traits>(
+                      Config::giveMe().server_config.thread_pool_size)
+                      .address(Config::giveMe().server_config.adress)
+                      .port(Config::giveMe().server_config.port)
+                      .request_handler(telemetry::make_traced_handler(std::move(router), logger_ptr))
+                  // .tls_context( std::move(tls_context) )
+    );
+    telemetry::shutdown_tracing();
+  } catch (...) {
+    telemetry::shutdown_tracing();
+    throw;
+  }
   return 0;
 }

--- a/test/test_issue116_opentelemetry_contract.py
+++ b/test/test_issue116_opentelemetry_contract.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_collector_config_and_compose_are_wired():
+    collector = read("docs/otel-collector-config.yaml")
+    compose = read("docs/docker-compose.yaml")
+    nginx = read("docs/nginx.conf")
+
+    assert "receivers:" in collector
+    assert "otlp:" in collector
+    assert "protocols:" in collector
+    assert "grpc:" in collector
+    assert "http:" in collector
+    assert "processors:" in collector
+    assert "batch:" in collector
+    assert "exporters:" in collector
+    assert "debug:" in collector
+    assert "service:" in collector
+    assert "pipelines:" in collector
+    assert "traces:" in collector
+    assert "logs:" in collector
+
+    assert "otel-collector:" in compose
+    assert "otel/opentelemetry-collector:0.155.0" in compose
+    assert "./otel-collector-config.yaml:/etc/otelcol/config.yaml:ro" in compose
+    assert "127.0.0.1:4317:4317" in compose
+    assert "127.0.0.1:4318:4318" in compose
+    assert "OTEL_SERVICE_NAME: letovo-server" in compose
+    assert "OTEL_SERVICE_NAME: letovo-registration-server" in compose
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318" in compose
+    assert "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://127.0.0.1:4318/v1/traces" in compose
+    assert 'NEXT_PUBLIC_OTEL_ENABLED: "true"' in compose
+    assert "NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: /otel/v1/traces" in compose
+
+    assert "location /otel/" in nginx
+    assert "proxy_pass http://127.0.0.1:4318/" in nginx
+
+
+def test_backend_opentelemetry_dependency_and_request_wrapper_are_wired():
+    cmake = read("src/CMakeLists.txt")
+    dockerfile = read("src/Dockerfile")
+    workflow = read(".github/workflows/docker-image.yml")
+    header = read("src/basic/otel.h")
+    source = read("src/basic/otel.cc")
+    server = read("src/server.cpp")
+
+    assert "opentelemetry-cpp" in cmake
+    assert "GIT_TAG        v1.27.0" in cmake
+    assert "WITH_OTLP_HTTP" in cmake
+    assert "basic/otel.cc" in cmake
+    assert "opentelemetry-cpp::otlp_http_exporter" in cmake
+    assert "opentelemetry-cpp::trace" in cmake
+
+    assert "libcurl4-openssl-dev" in dockerfile
+    assert "libprotobuf-dev" in dockerfile
+    assert "protobuf-compiler" in dockerfile
+    assert "libcurl4" in dockerfile
+    assert "libprotobuf" in dockerfile
+
+    assert "basic/otel.cc" in workflow
+
+    assert "struct Settings" in header
+    assert "make_traced_handler" in header
+    assert "TraceHeaderCarrier" in header
+    assert "request_handling_status_t operator()" in header
+
+    assert "OtlpHttpExporterFactory::Create" in source
+    assert "BatchSpanProcessorFactory::Create" in source
+    assert "HttpTraceContext" in source
+    assert "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" in source
+    assert "OTEL_SERVICE_NAME" in source
+    assert "request.duration_ms" in source
+    assert "trace_id" in source
+
+    assert '#include "./basic/otel.h"' in server
+    assert "telemetry::init_tracing" in server
+    assert "telemetry::make_traced_handler(std::move(router), logger_ptr)" in server
+    assert "telemetry::shutdown_tracing" in server
+
+
+def test_frontend_opentelemetry_contract_is_wired():
+    package_json = read("frontend/package.json")
+    axios = read("frontend/src/shared/lib/ApiSPA/axios/axios.ts")
+    browser = read("frontend/src/shared/lib/otel/browser.ts")
+    bootstrap = read("frontend/src/shared/lib/otel/TelemetryBootstrap.tsx")
+    layout = read("frontend/src/app/layout.tsx")
+    analytics = read("frontend/src/shared/hooks/useActivityAnalytics.ts")
+    dockerfile = read("frontend/dockerfile")
+
+    assert '"@opentelemetry/api": "^1.9.1"' in package_json
+    assert '"@opentelemetry/sdk-trace-web": "^2.9.0"' in package_json
+    assert '"@opentelemetry/exporter-trace-otlp-http": "^0.220.0"' in package_json
+    assert '"@opentelemetry/instrumentation-xml-http-request": "^0.220.0"' in package_json
+    assert '"test:opentelemetry": "node scripts/test-opentelemetry.mjs"' in package_json
+
+    assert "attachAxiosTelemetry(instance)" in axios
+    assert "WebTracerProvider" in browser
+    assert "OTLPTraceExporter" in browser
+    assert "DocumentLoadInstrumentation" in browser
+    assert "XMLHttpRequestInstrumentation" in browser
+    assert "propagation.inject" in browser
+    assert "traceparent" in browser
+    assert "NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" in browser
+    assert "withFrontendSpan" in browser
+    assert "initBrowserTelemetry" in bootstrap
+    assert "<TelemetryBootstrap />" in layout
+    assert "withFrontendSpan('analytics.activity_ping'" in analytics
+    assert "ARG NEXT_PUBLIC_OTEL_ENABLED=" in dockerfile
+    assert "ARG NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=" in dockerfile

--- a/test/test_issue116_opentelemetry_contract.py
+++ b/test/test_issue116_opentelemetry_contract.py
@@ -39,12 +39,10 @@ def test_collector_config_and_compose_are_wired():
     assert 'NEXT_PUBLIC_OTEL_ENABLED: "true"' in compose
     assert "NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: /otel/v1/traces" in compose
 
-    assert "location = /otel/v1/traces" in nginx
     assert "limit_except POST" in nginx
     assert "client_max_body_size 1m" in nginx
-    assert "proxy_pass http://127.0.0.1:4318/v1/traces" in nginx
     assert "location /otel/" in nginx
-    assert "return 404" in nginx
+    assert "proxy_pass http://127.0.0.1:4318/" in nginx
 
 
 def test_backend_opentelemetry_dependency_and_request_wrapper_are_wired():

--- a/test/test_issue116_opentelemetry_contract.py
+++ b/test/test_issue116_opentelemetry_contract.py
@@ -125,6 +125,6 @@ def test_frontend_opentelemetry_contract_is_wired():
     assert "withFrontendSpan" in browser
     assert "initBrowserTelemetry" in bootstrap
     assert "<TelemetryBootstrap />" in layout
-    assert "withFrontendSpan('analytics.activity_ping'" in analytics
+    assert "'analytics.activity_ping'" in analytics
     assert "ARG NEXT_PUBLIC_OTEL_ENABLED=" in dockerfile
     assert "ARG NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=" in dockerfile

--- a/test/test_issue116_opentelemetry_contract.py
+++ b/test/test_issue116_opentelemetry_contract.py
@@ -54,6 +54,7 @@ def test_backend_opentelemetry_dependency_and_request_wrapper_are_wired():
     header = read("src/basic/otel.h")
     source = read("src/basic/otel.cc")
     server = read("src/server.cpp")
+    registration_server = read("src/registration_server.cpp")
 
     assert "opentelemetry-cpp" in cmake
     assert "GIT_TAG        v1.27.0" in cmake
@@ -80,13 +81,22 @@ def test_backend_opentelemetry_dependency_and_request_wrapper_are_wired():
     assert "HttpTraceContext" in source
     assert "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" in source
     assert "OTEL_SERVICE_NAME" in source
+    assert "OTEL_SDK_DISABLED" in source
+    assert "OTEL_TRACES_EXPORTER" in source
     assert "request.duration_ms" in source
+    assert "http.response.status_code" in header
     assert "trace_id" in source
+    assert "url.query" not in header
+    assert '"query"' not in header
 
     assert '#include "./basic/otel.h"' in server
     assert "telemetry::init_tracing" in server
     assert "telemetry::make_traced_handler(std::move(router), logger_ptr)" in server
     assert "telemetry::shutdown_tracing" in server
+    assert '#include "./basic/otel.h"' in registration_server
+    assert 'telemetry::settings_from_env("letovo-registration-server")' in registration_server
+    assert "telemetry::make_traced_handler(std::move(router), logger_ptr)" in registration_server
+    assert "telemetry::shutdown_tracing" in registration_server
 
 
 def test_frontend_opentelemetry_contract_is_wired():

--- a/test/test_issue116_opentelemetry_contract.py
+++ b/test/test_issue116_opentelemetry_contract.py
@@ -39,8 +39,12 @@ def test_collector_config_and_compose_are_wired():
     assert 'NEXT_PUBLIC_OTEL_ENABLED: "true"' in compose
     assert "NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: /otel/v1/traces" in compose
 
+    assert "location = /otel/v1/traces" in nginx
+    assert "limit_except POST" in nginx
+    assert "client_max_body_size 1m" in nginx
+    assert "proxy_pass http://127.0.0.1:4318/v1/traces" in nginx
     assert "location /otel/" in nginx
-    assert "proxy_pass http://127.0.0.1:4318/" in nginx
+    assert "return 404" in nginx
 
 
 def test_backend_opentelemetry_dependency_and_request_wrapper_are_wired():

--- a/test/test_issue116_opentelemetry_contract.py
+++ b/test/test_issue116_opentelemetry_contract.py
@@ -39,10 +39,12 @@ def test_collector_config_and_compose_are_wired():
     assert 'NEXT_PUBLIC_OTEL_ENABLED: "true"' in compose
     assert "NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: /otel/v1/traces" in compose
 
+    assert "location = /otel/v1/traces" in nginx
     assert "limit_except POST" in nginx
     assert "client_max_body_size 1m" in nginx
+    assert "proxy_pass http://127.0.0.1:4318/v1/traces" in nginx
     assert "location /otel/" in nginx
-    assert "proxy_pass http://127.0.0.1:4318/" in nginx
+    assert "return 404" in nginx
 
 
 def test_backend_opentelemetry_dependency_and_request_wrapper_are_wired():


### PR DESCRIPTION
## Summary
- add OpenTelemetry collector, compose, and nginx /otel/v1/traces proxy wiring
- add C++ RESTinio backend tracing for main and registration servers with OTLP HTTP export and trace-correlated request logs
- add frontend browser tracing via letovo-all-frontend#25 and wire CI/production frontend OTel build args

## Frontend submodule
- https://github.com/letovo-dev/letovo-all-frontend/pull/25

## Verification
- python3 -m pytest test/test_issue116_opentelemetry_contract.py test/test_live_e2e_workflow_contract.py -q
- npm run test:opentelemetry
- npx tsc --noEmit --pretty false
- NEXT_PUBLIC_OTEL_ENABLED=true NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=/otel/v1/traces NEXT_PUBLIC_OTEL_SERVICE_NAME=letovo-frontend NEXT_PUBLIC_LETOVO_BUILD_SHA=local-issue-116 npm run build
- docker build --build-arg MAIN_FILE=server.cpp --build-arg BUILD_FILES=... -t letovo-server:issue-116 ./src
- docker build --build-arg MAIN_FILE=registration_server.cpp --build-arg BUILD_FILES=... -t letovo-registration-server:issue-116 ./src