### PR TITLE
fix: deploy production telemetry pipeline

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -155,6 +155,9 @@ jobs:
             NEXT_PUBLIC_OTEL_ENABLED=true
             NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=/otel/v1/traces
             NEXT_PUBLIC_OTEL_SERVICE_NAME=letovo-frontend
+            NEXT_PUBLIC_OTEL_DEPLOYMENT_ENVIRONMENT=production
+            NEXT_PUBLIC_OTEL_SERVICE_NAMESPACE=letovocorp
+            NEXT_PUBLIC_OTEL_TRACES_SAMPLER_RATIO=0.1
             NEXT_PUBLIC_LETOVO_BUILD_SHA=${{ github.sha }}
           tags: ${{ env.FRONTEND_IMAGE }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
           cache-from: type=gha
@@ -230,6 +233,9 @@ jobs:
             NEXT_PUBLIC_OTEL_ENABLED=true
             NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=/otel/v1/traces
             NEXT_PUBLIC_OTEL_SERVICE_NAME=letovo-frontend
+            NEXT_PUBLIC_OTEL_DEPLOYMENT_ENVIRONMENT=production
+            NEXT_PUBLIC_OTEL_SERVICE_NAMESPACE=letovocorp
+            NEXT_PUBLIC_OTEL_TRACES_SAMPLER_RATIO=0.1
             NEXT_PUBLIC_LETOVO_BUILD_SHA=${{ github.sha }}
           tags: |
             ${{ env.FRONTEND_IMAGE }}:latest
@@ -269,6 +275,9 @@ jobs:
           NEXT_PUBLIC_OTEL_ENABLED: "true"
           NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: /otel/v1/traces
           NEXT_PUBLIC_OTEL_SERVICE_NAME: letovo-frontend
+          NEXT_PUBLIC_OTEL_DEPLOYMENT_ENVIRONMENT: production
+          NEXT_PUBLIC_OTEL_SERVICE_NAMESPACE: letovocorp
+          NEXT_PUBLIC_OTEL_TRACES_SAMPLER_RATIO: "0.1"
           NEXT_PUBLIC_LETOVO_BUILD_SHA: ${{ github.sha }}
         run: npm run build
 
@@ -292,6 +301,7 @@ jobs:
       LIVE_E2E_WAIT_TIMEOUT_SECONDS: ${{ vars.LIVE_E2E_WAIT_TIMEOUT_SECONDS || '600' }}
       LIVE_E2E_REQUIRE_AUTH: "true"
       LIVE_E2E_REQUIRE_EXTENDED: ${{ vars.LIVE_E2E_REQUIRE_EXTENDED || 'false' }}
+      LIVE_E2E_REQUIRE_OTEL: "false"
       LIVE_E2E_EXPECTED_BACKEND_SHA: ${{ github.sha }}
       LIVE_E2E_EXPECTED_FRONTEND_SHA: ${{ github.sha }}
       LETOVO_E2E_DEPLOY_HOST: ${{ vars.LETOVO_E2E_DEPLOY_HOST || 'ya.sergeiscv.ru' }}

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -19,6 +19,10 @@ on:
         description: Require mutating transfer/upload/post checks with secondary e2e secrets
         required: false
         default: "false"
+      require_otel:
+        description: Require public OTLP trace ingest during live smoke checks
+        required: false
+        default: "false"
       expected_sha:
         description: Optional backend/frontend deployment SHA to require before smoke checks pass
         required: false
@@ -36,6 +40,7 @@ env:
   LIVE_E2E_WAIT_TIMEOUT_SECONDS: ${{ inputs.wait_timeout_seconds || '600' }}
   LIVE_E2E_REQUIRE_AUTH: ${{ inputs.require_auth || 'false' }}
   LIVE_E2E_REQUIRE_EXTENDED: ${{ inputs.require_extended || 'false' }}
+  LIVE_E2E_REQUIRE_OTEL: ${{ inputs.require_otel || 'false' }}
   LIVE_E2E_EXPECTED_BACKEND_SHA: ${{ inputs.expected_sha || github.event.workflow_run.head_sha || '' }}
   LIVE_E2E_EXPECTED_FRONTEND_SHA: ${{ inputs.expected_sha || github.event.workflow_run.head_sha || '' }}
 

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -41,6 +41,7 @@ env:
   LIVE_E2E_WAIT_TIMEOUT_SECONDS: ${{ inputs.wait_timeout_seconds }}
   LIVE_E2E_REQUIRE_AUTH: "true"
   LIVE_E2E_REQUIRE_EXTENDED: ${{ inputs.require_extended }}
+  LIVE_E2E_REQUIRE_OTEL: "true"
 
 jobs:
   release:
@@ -98,6 +99,7 @@ jobs:
           LETOVO_PROD_DEPLOY_SSH_KEY: ${{ secrets.LETOVO_PROD_DEPLOY_SSH_KEY }}
           LETOVO_PROD_DEPLOY_COMPOSE: ${{ vars.LETOVO_PROD_DEPLOY_COMPOSE || '/srv/letovo/compose/docker-compose.yaml' }}
           LETOVO_PROD_DEPLOY_PROJECT: ${{ vars.LETOVO_PROD_DEPLOY_PROJECT || 'compose' }}
+          LETOVO_PROD_NGINX_SITE: ${{ vars.LETOVO_PROD_NGINX_SITE || '/etc/nginx/sites-available/default' }}
         run: |
           set -euo pipefail
           test -n "$LETOVO_PROD_DEPLOY_USER" || { echo "LETOVO_PROD_DEPLOY_USER secret is required"; exit 1; }
@@ -105,6 +107,7 @@ jobs:
           test -n "$LETOVO_PROD_DEPLOY_HOST" || { echo "LETOVO_PROD_DEPLOY_HOST is required"; exit 1; }
           test -n "$LETOVO_PROD_DEPLOY_COMPOSE" || { echo "LETOVO_PROD_DEPLOY_COMPOSE is required"; exit 1; }
           test -n "$LETOVO_PROD_DEPLOY_PROJECT" || { echo "LETOVO_PROD_DEPLOY_PROJECT is required"; exit 1; }
+          test -n "$LETOVO_PROD_NGINX_SITE" || { echo "LETOVO_PROD_NGINX_SITE is required"; exit 1; }
           test "$LIVE_E2E_REQUIRE_AUTH" = "true"
 
       - name: Set up QEMU
@@ -140,6 +143,9 @@ jobs:
           NEXT_PUBLIC_OTEL_ENABLED: "true"
           NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: /otel/v1/traces
           NEXT_PUBLIC_OTEL_SERVICE_NAME: letovo-frontend
+          NEXT_PUBLIC_OTEL_DEPLOYMENT_ENVIRONMENT: production
+          NEXT_PUBLIC_OTEL_SERVICE_NAMESPACE: letovocorp
+          NEXT_PUBLIC_OTEL_TRACES_SAMPLER_RATIO: "0.1"
           NEXT_PUBLIC_LETOVO_BUILD_SHA: ${{ steps.release.outputs.release_sha }}
         run: |
           set -euo pipefail
@@ -194,6 +200,9 @@ jobs:
             NEXT_PUBLIC_OTEL_ENABLED=true
             NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=/otel/v1/traces
             NEXT_PUBLIC_OTEL_SERVICE_NAME=letovo-frontend
+            NEXT_PUBLIC_OTEL_DEPLOYMENT_ENVIRONMENT=production
+            NEXT_PUBLIC_OTEL_SERVICE_NAMESPACE=letovocorp
+            NEXT_PUBLIC_OTEL_TRACES_SAMPLER_RATIO=0.1
             NEXT_PUBLIC_LETOVO_BUILD_SHA=${{ steps.release.outputs.release_sha }}
           tags: ${{ steps.release.outputs.frontend_image }}
           cache-from: type=gha
@@ -233,24 +242,52 @@ jobs:
           LETOVO_PROD_DEPLOY_USER: ${{ secrets.LETOVO_PROD_DEPLOY_USER }}
           LETOVO_PROD_DEPLOY_COMPOSE: ${{ vars.LETOVO_PROD_DEPLOY_COMPOSE || '/srv/letovo/compose/docker-compose.yaml' }}
           LETOVO_PROD_DEPLOY_PROJECT: ${{ vars.LETOVO_PROD_DEPLOY_PROJECT || 'compose' }}
+          LETOVO_PROD_NGINX_SITE: ${{ vars.LETOVO_PROD_NGINX_SITE || '/etc/nginx/sites-available/default' }}
         run: |
           set -euo pipefail
           remote="${LETOVO_PROD_DEPLOY_USER}@${LETOVO_PROD_DEPLOY_HOST}"
+          state_dir="/tmp/letovo-production-release-${{ github.run_id }}"
+          ssh -i ~/.ssh/letovo-production-release "$remote" "mkdir -p '$state_dir'"
+          scp -i ~/.ssh/letovo-production-release docs/docker-compose.yaml "$remote:$state_dir/docker-compose.yaml.from-repo"
+          scp -i ~/.ssh/letovo-production-release docs/otel-collector-config.yaml "$remote:$state_dir/otel-collector-config.yaml.from-repo"
+          scp -i ~/.ssh/letovo-production-release scripts/patch_nginx_otel.py "$remote:$state_dir/patch_nginx_otel.py"
           ssh -i ~/.ssh/letovo-production-release "$remote" \
-            "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
+            "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' NGINX_SITE='$LETOVO_PROD_NGINX_SITE' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
           set -euo pipefail
           test -f "$COMPOSE_FILE"
+          test -f "$NGINX_SITE"
           state_dir="/tmp/letovo-production-release-${RUN_ID}"
           mkdir -p "$state_dir"
           restore="$state_dir/restore.env"
           compose_backup="$state_dir/docker-compose.yaml.before-release"
+          otel_backup="$state_dir/otel-collector-config.yaml.before-release"
+          nginx_backup="$state_dir/nginx-site.before-release"
           candidate="$state_dir/docker-compose.yaml"
+          repo_compose="$state_dir/docker-compose.yaml.from-repo"
+          repo_otel="$state_dir/otel-collector-config.yaml.from-repo"
+          nginx_candidate="$state_dir/nginx-site.candidate"
+          compose_dir="$(dirname "$COMPOSE_FILE")"
+          otel_config="$compose_dir/otel-collector-config.yaml"
+
+          as_root() {
+            if [ "$(id -u)" -eq 0 ]; then
+              "$@"
+            else
+              sudo -n "$@"
+            fi
+          }
 
           docker image inspect "$BACKEND_IMAGE" >/dev/null
           docker image inspect "$REGISTRATION_IMAGE" >/dev/null
           docker image inspect "$FRONTEND_IMAGE" >/dev/null
+          test -f "$repo_compose"
+          test -f "$repo_otel"
 
           cp "$COMPOSE_FILE" "$compose_backup"
+          if [ -f "$otel_config" ]; then
+            cp "$otel_config" "$otel_backup"
+          fi
+          as_root cp "$NGINX_SITE" "$nginx_backup"
           docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
           docker inspect -f 'letovo-registration-server={{.Config.Image}}' letovo-registration-server >> "$restore"
           docker inspect -f 'letovo-front={{.Config.Image}}' letovo-front >> "$restore"
@@ -260,10 +297,23 @@ jobs:
             -e "s#image: ghcr.io/letovo-dev/letovo-registration-server:.*#image: ${REGISTRATION_IMAGE}#" \
             -e "s#image: .*letovo.*front.*:.*#image: ${FRONTEND_IMAGE}#" \
             -e "s#LETOVO_BUILD_SHA: \".*\"#LETOVO_BUILD_SHA: \"${RELEASE_SHA}\"#" \
-            "$COMPOSE_FILE" > "$candidate"
+            "$repo_compose" > "$candidate"
 
+          cp "$repo_otel" "$otel_config"
           cp "$candidate" "$COMPOSE_FILE"
-          docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d letovo-server letovo-registration-server letovo-front
+
+          python3 "$state_dir/patch_nginx_otel.py" "$NGINX_SITE" "$nginx_candidate" --server-name letovocorp.ru
+          as_root cp "$nginx_candidate" "$NGINX_SITE"
+          if ! as_root nginx -t; then
+            as_root cp "$nginx_backup" "$NGINX_SITE"
+            as_root nginx -t
+            exit 1
+          fi
+          as_root nginx -s reload || as_root systemctl reload nginx
+
+          docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d jaeger otel-collector letovo-server letovo-registration-server letovo-front
+          test "$(docker inspect -f '{{.State.Running}}' jaeger)" = "true"
+          test "$(docker inspect -f '{{.State.Running}}' otel-collector)" = "true"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-server)" = "$BACKEND_IMAGE"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-registration-server)" = "$REGISTRATION_IMAGE"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-front)" = "$FRONTEND_IMAGE"
@@ -293,6 +343,29 @@ jobs:
           LETOVO_E2E_SECONDARY_PASSWORD: ${{ secrets.LETOVO_E2E_SECONDARY_PASSWORD }}
         run: node $GITHUB_WORKSPACE/test/e2e/live-platform-smoke.mjs
 
+      - name: Verify production OTEL storage
+        env:
+          LETOVO_PROD_DEPLOY_HOST: ${{ vars.LETOVO_PROD_DEPLOY_HOST || '84.201.185.37' }}
+          LETOVO_PROD_DEPLOY_USER: ${{ secrets.LETOVO_PROD_DEPLOY_USER }}
+        run: |
+          set -euo pipefail
+          remote="${LETOVO_PROD_DEPLOY_USER}@${LETOVO_PROD_DEPLOY_HOST}"
+          ssh -i ~/.ssh/letovo-production-release "$remote" 'bash -s' <<'REMOTE'
+          set -euo pipefail
+          trace_id="11111111111111111111111111111111"
+          for _ in $(seq 1 30); do
+            body="$(curl -fsS "http://127.0.0.1:16686/api/traces/${trace_id}" || true)"
+            if printf '%s' "$body" | grep -q 'live-e2e-otel-smoke'; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Jaeger did not return the live e2e OTEL smoke span"
+          docker logs --tail 200 otel-collector || true
+          docker logs --tail 200 jaeger || true
+          exit 1
+          REMOTE
+
       - name: Roll back production images on failure
         if: failure()
         env:
@@ -300,20 +373,39 @@ jobs:
           LETOVO_PROD_DEPLOY_USER: ${{ secrets.LETOVO_PROD_DEPLOY_USER }}
           LETOVO_PROD_DEPLOY_COMPOSE: ${{ vars.LETOVO_PROD_DEPLOY_COMPOSE || '/srv/letovo/compose/docker-compose.yaml' }}
           LETOVO_PROD_DEPLOY_PROJECT: ${{ vars.LETOVO_PROD_DEPLOY_PROJECT || 'compose' }}
+          LETOVO_PROD_NGINX_SITE: ${{ vars.LETOVO_PROD_NGINX_SITE || '/etc/nginx/sites-available/default' }}
         run: |
           set -euo pipefail
           test -f ~/.ssh/letovo-production-release || exit 0
           remote="${LETOVO_PROD_DEPLOY_USER}@${LETOVO_PROD_DEPLOY_HOST}"
           ssh -i ~/.ssh/letovo-production-release "$remote" \
-            "COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
+            "COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' NGINX_SITE='$LETOVO_PROD_NGINX_SITE' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
           set -euo pipefail
           state_dir="/tmp/letovo-production-release-${RUN_ID}"
           restore="$state_dir/restore.env"
           compose_backup="$state_dir/docker-compose.yaml.before-release"
+          otel_backup="$state_dir/otel-collector-config.yaml.before-release"
+          nginx_backup="$state_dir/nginx-site.before-release"
           test -f "$restore" || exit 0
           test -f "$compose_backup" || exit 0
 
+          as_root() {
+            if [ "$(id -u)" -eq 0 ]; then
+              "$@"
+            else
+              sudo -n "$@"
+            fi
+          }
+
           cp "$compose_backup" "$COMPOSE_FILE"
+          if [ -f "$otel_backup" ]; then
+            cp "$otel_backup" "$(dirname "$COMPOSE_FILE")/otel-collector-config.yaml"
+          fi
+          if [ -f "$nginx_backup" ]; then
+            as_root cp "$nginx_backup" "$NGINX_SITE"
+            as_root nginx -t
+            as_root nginx -s reload || as_root systemctl reload nginx
+          fi
           backend_image="$(awk -F= '$1 == "letovo-server" { print $2 }' "$restore" | tail -n 1)"
           registration_image="$(awk -F= '$1 == "letovo-registration-server" { print $2 }' "$restore" | tail -n 1)"
           frontend_image="$(awk -F= '$1 == "letovo-front" { print $2 }' "$restore" | tail -n 1)"

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -1,10 +1,32 @@
 version: '3.8'
 
 services:
+    jaeger:
+        image: jaegertracing/all-in-one:1.57
+        container_name: jaeger
+        restart: unless-stopped
+        environment:
+          COLLECTOR_OTLP_ENABLED: "true"
+          SPAN_STORAGE_TYPE: badger
+          BADGER_EPHEMERAL: "false"
+          BADGER_DIRECTORY_VALUE: /badger/data
+          BADGER_DIRECTORY_KEY: /badger/key
+        volumes:
+          - jaeger-data:/badger
+        ports:
+          - "127.0.0.1:16686:16686"
+        logging:
+          driver: json-file
+          options:
+            max-size: "100m"
+            max-file: "5"
+
     otel-collector:
         image: otel/opentelemetry-collector:0.155.0
         container_name: otel-collector
         restart: unless-stopped
+        depends_on:
+          - jaeger
         command: ["--config=/etc/otelcol/config.yaml"]
         volumes:
           - ./otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
@@ -26,6 +48,7 @@ services:
           - otel-collector
         environment:
           OTEL_SERVICE_NAME: letovo-server
+          OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=letovocorp
           OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://127.0.0.1:4318/v1/traces
           OTEL_TRACES_EXPORTER: otlp
@@ -52,6 +75,7 @@ services:
           SERVER_ADRESS: "127.0.0.1"
           SERVER_PORT: "8082"
           OTEL_SERVICE_NAME: letovo-registration-server
+          OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=letovocorp
           OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://127.0.0.1:4318/v1/traces
           OTEL_TRACES_EXPORTER: otlp
@@ -93,6 +117,10 @@ services:
         environment:
           NEXT_PUBLIC_OTEL_ENABLED: "true"
           NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: /otel/v1/traces
+          NEXT_PUBLIC_OTEL_SERVICE_NAME: letovo-frontend
+          NEXT_PUBLIC_OTEL_DEPLOYMENT_ENVIRONMENT: production
+          NEXT_PUBLIC_OTEL_SERVICE_NAMESPACE: letovocorp
+          NEXT_PUBLIC_OTEL_TRACES_SAMPLER_RATIO: "0.1"
         init: true
         cap_drop:
           - ALL
@@ -144,3 +172,6 @@ services:
           options:
             max-size: "100m"
             max-file: "5"
+
+volumes:
+    jaeger-data:

--- a/docs/otel-collector-config.yaml
+++ b/docs/otel-collector-config.yaml
@@ -14,6 +14,8 @@ processors:
   batch: {}
 
 exporters:
+  otlphttp/jaeger:
+    endpoint: http://jaeger:4318
   debug:
     verbosity: basic
 
@@ -22,7 +24,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [debug]
+      exporters: [otlphttp/jaeger, debug]
     logs:
       receivers: [otlp]
       processors: [memory_limiter, batch]

--- a/scripts/patch_nginx_otel.py
+++ b/scripts/patch_nginx_otel.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+import argparse
+import re
+from pathlib import Path
+
+
+OTEL_TRACE_LOCATION = "location = /otel/v1/traces"
+OTEL_FALLBACK_LOCATION = "location /otel/"
+
+
+def _brace_delta(line: str) -> int:
+    return line.count("{") - line.count("}")
+
+
+def _remove_managed_otel_locations(lines: list[str]) -> list[str]:
+    result = []
+    skip_depth = 0
+    location_re = re.compile(r"^\s*location\s+(?:=\s+/otel/v1/traces|/otel/)\s*\{")
+
+    for line in lines:
+        if skip_depth > 0:
+            skip_depth += _brace_delta(line)
+            continue
+
+        if location_re.match(line):
+            skip_depth = _brace_delta(line)
+            if skip_depth <= 0:
+                skip_depth = 0
+            continue
+
+        result.append(line)
+
+    if skip_depth > 0:
+        raise ValueError("unterminated managed OTEL location block")
+
+    return result
+
+
+def _server_blocks(lines: list[str]) -> list[tuple[int, int]]:
+    blocks = []
+    server_re = re.compile(r"^\s*server\s*\{")
+    index = 0
+
+    while index < len(lines):
+        if not server_re.match(lines[index]):
+            index += 1
+            continue
+
+        depth = _brace_delta(lines[index])
+        end = index + 1
+        while end < len(lines) and depth > 0:
+            depth += _brace_delta(lines[end])
+            end += 1
+        if depth != 0:
+            raise ValueError(f"unterminated server block at line {index + 1}")
+        blocks.append((index, end))
+        index = end
+
+    return blocks
+
+
+def _has_target_server_name(block: list[str], server_name: str) -> bool:
+    server_name_re = re.compile(r"^\s*server_name\s+([^;]+);")
+    for line in block:
+        match = server_name_re.match(line)
+        if match and server_name in match.group(1).split():
+            return True
+    return False
+
+
+def _has_https_listen(block: list[str]) -> bool:
+    listen_re = re.compile(r"^\s*listen\s+([^;]+);")
+    for line in block:
+        match = listen_re.match(line)
+        if not match:
+            continue
+        value = match.group(1)
+        if "ssl" in value.split() and re.search(r"(^|[\s:\[])(443)($|[\s;\]])", value):
+            return True
+    return False
+
+
+def _otel_locations(indent: str) -> list[str]:
+    inner = f"{indent}    "
+    return [
+        f"{indent}{OTEL_TRACE_LOCATION} {{\n",
+        f"{inner}limit_except POST {{ deny all; }}\n",
+        f"{inner}client_max_body_size 1m;\n",
+        f"{inner}proxy_pass http://127.0.0.1:4318/v1/traces;\n",
+        f"{inner}proxy_http_version 1.1;\n",
+        f"{inner}proxy_set_header Host $host;\n",
+        f"{inner}proxy_set_header X-Real-IP $remote_addr;\n",
+        f"{inner}proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n",
+        f"{inner}proxy_set_header X-Forwarded-Proto $scheme;\n",
+        f"{indent}}}\n",
+        "\n",
+        f"{indent}{OTEL_FALLBACK_LOCATION} {{\n",
+        f"{inner}return 404;\n",
+        f"{indent}}}\n",
+        "\n",
+    ]
+
+
+def patch_nginx_site(text: str, server_name: str) -> str:
+    lines = _remove_managed_otel_locations(text.splitlines(keepends=True))
+    blocks = _server_blocks(lines)
+    location_root_re = re.compile(r"^(\s*)location\s+/\s*\{")
+
+    for start, end in blocks:
+        block = lines[start:end]
+        if not (_has_target_server_name(block, server_name) and _has_https_listen(block)):
+            continue
+
+        depth = 1
+        insert_at = end - 1
+        indent = "    "
+        for index in range(start + 1, end - 1):
+            match = location_root_re.match(lines[index])
+            if depth == 1 and match:
+                insert_at = index
+                indent = match.group(1)
+                break
+            depth += _brace_delta(lines[index])
+
+        lines[insert_at:insert_at] = _otel_locations(indent)
+        return "".join(lines)
+
+    raise ValueError(f"did not find HTTPS nginx server block for {server_name}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--server-name", default="letovocorp.ru")
+    args = parser.parse_args()
+
+    args.output.write_text(
+        patch_nginx_site(args.input.read_text(encoding="utf-8"), args.server_name),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/basic/analytics.cc
+++ b/src/basic/analytics.cc
@@ -172,18 +172,23 @@ void record_event(const std::string &username, const std::string &session_id,
         "NULLIF(($9), ''), COALESCE(NULLIF(($10), '')::jsonb, '{}'::jsonb));",
         params, true);
     con->execute_params(
+        "WITH updated AS ("
+        "  UPDATE public.user_activity_last_seen SET "
+        "  last_seen_at = now(), last_route = ($6), "
+        "  last_client_event = NULLIF(($9), ''), "
+        "  session_id_hash = NULLIF(($2), ''), "
+        "  ip_hash = NULLIF(($3), ''), "
+        "  user_agent_hash = NULLIF(($4), '') "
+        "  WHERE username = ($1) RETURNING username"
+        ") "
         "INSERT INTO public.user_activity_last_seen "
         "(username, last_seen_at, last_route, last_client_event, "
         "session_id_hash, ip_hash, user_agent_hash) "
-        "VALUES (($1), now(), ($6), NULLIF(($9), ''), NULLIF(($2), ''), "
-        "NULLIF(($3), ''), NULLIF(($4), '')) "
-        "ON CONFLICT (username) DO UPDATE SET "
-        "last_seen_at = EXCLUDED.last_seen_at, "
-        "last_route = EXCLUDED.last_route, "
-        "last_client_event = EXCLUDED.last_client_event, "
-        "session_id_hash = EXCLUDED.session_id_hash, "
-        "ip_hash = EXCLUDED.ip_hash, "
-        "user_agent_hash = EXCLUDED.user_agent_hash;",
+        "SELECT ($1), now(), ($6), NULLIF(($9), ''), NULLIF(($2), ''), "
+        "NULLIF(($3), ''), NULLIF(($4), '') "
+        "WHERE NOT EXISTS (SELECT 1 FROM updated) "
+        "AND NOT EXISTS (SELECT 1 FROM public.user_activity_last_seen "
+        "WHERE username = ($1));",
         params, true);
   } catch (const std::exception &e) {
     if (logger_ptr) {

--- a/src/basic/otel.cc
+++ b/src/basic/otel.cc
@@ -84,6 +84,28 @@ bool env_is(const char *name, const std::string &expected) {
   return raw == expected;
 }
 
+std::vector<std::pair<std::string, std::string>> parse_resource_attributes(
+    const std::string &raw) {
+  std::vector<std::pair<std::string, std::string>> attributes;
+  std::size_t start = 0;
+  while (start < raw.size()) {
+    const std::size_t comma = raw.find(',', start);
+    const std::string item =
+        raw.substr(start, comma == std::string::npos ? std::string::npos
+                                                     : comma - start);
+    const std::size_t equals = item.find('=');
+    if (equals != std::string::npos && equals > 0 &&
+        equals + 1 < item.size()) {
+      attributes.emplace_back(item.substr(0, equals), item.substr(equals + 1));
+    }
+    if (comma == std::string::npos) {
+      break;
+    }
+    start = comma + 1;
+  }
+  return attributes;
+}
+
 internal_log::LogLevel parse_log_level(const std::string &level) {
   if (level == "debug") {
     return internal_log::LogLevel::Debug;
@@ -137,14 +159,19 @@ void write_domain_event_log(
 
 Settings settings_from_env(const std::string &fallback_service_name) {
   Settings settings;
+  const std::string traces_endpoint =
+      env_or("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "");
+  const std::string otlp_endpoint = env_or("OTEL_EXPORTER_OTLP_ENDPOINT", "");
+  settings.traces_endpoint =
+      traces_endpoint.empty() && !otlp_endpoint.empty()
+          ? otlp_endpoint + "/v1/traces"
+          : traces_endpoint;
   settings.enabled = env_bool("OTEL_SDK_ENABLED", true) &&
                      !env_bool("OTEL_SDK_DISABLED", false) &&
-                     !env_is("OTEL_TRACES_EXPORTER", "none");
+                     !env_is("OTEL_TRACES_EXPORTER", "none") &&
+                     !settings.traces_endpoint.empty();
   settings.service_name = env_or("OTEL_SERVICE_NAME", fallback_service_name);
-  settings.traces_endpoint = env_or(
-      "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-      env_or("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318") +
-          "/v1/traces");
+  settings.resource_attributes = env_or("OTEL_RESOURCE_ATTRIBUTES", "");
   settings.log_level = env_or("OTEL_LOG_LEVEL", "info");
   return settings;
 }
@@ -163,7 +190,7 @@ void init_tracing(
   if (!settings.enabled) {
     if (logger_ptr) {
       logger_ptr->info([] {
-        return "OpenTelemetry tracing disabled by OTEL_SDK_ENABLED";
+        return "OpenTelemetry tracing disabled by configuration";
       });
     }
     return;
@@ -184,10 +211,16 @@ void init_tracing(
 
   auto processor = trace_sdk::BatchSpanProcessorFactory::Create(
       std::move(exporter), processor_options);
+  auto resource_attributes = parse_resource_attributes(settings.resource_attributes);
+  resource_attributes.emplace_back("service.name", settings.service_name);
+  resource::ResourceAttributes attributes;
+  for (const auto &[key, value] : resource_attributes) {
+    attributes[key] = value;
+  }
   provider = std::shared_ptr<trace_sdk::TracerProvider>(
       trace_sdk::TracerProviderFactory::Create(
           std::move(processor),
-          resource::Resource::Create({{"service.name", settings.service_name}})));
+          resource::Resource::Create(attributes)));
 
   std::shared_ptr<opentelemetry::trace::TracerProvider> api_provider_std =
       provider;

--- a/src/basic/otel.h
+++ b/src/basic/otel.h
@@ -28,7 +28,8 @@ namespace telemetry {
 struct Settings {
   bool enabled{true};
   std::string service_name{"letovo-server"};
-  std::string traces_endpoint{"http://127.0.0.1:4318/v1/traces"};
+  std::string traces_endpoint{};
+  std::string resource_attributes{};
   std::string log_level{"info"};
 };
 

--- a/test/e2e/live-platform-smoke.mjs
+++ b/test/e2e/live-platform-smoke.mjs
@@ -10,6 +10,7 @@ const waitTimeoutMs = Number(process.env.LIVE_E2E_WAIT_TIMEOUT_SECONDS || 600) *
 const pollIntervalMs = 10_000;
 const requireAuth = process.env.LIVE_E2E_REQUIRE_AUTH === 'true';
 const requireExtended = process.env.LIVE_E2E_REQUIRE_EXTENDED === 'true';
+const requireOtel = process.env.LIVE_E2E_REQUIRE_OTEL === 'true';
 const expectedBackendSha = process.env.LIVE_E2E_EXPECTED_BACKEND_SHA || '';
 const expectedFrontendSha = process.env.LIVE_E2E_EXPECTED_FRONTEND_SHA || '';
 const username = process.env.LETOVO_E2E_USERNAME || '';
@@ -38,6 +39,47 @@ async function fetchText(path) {
   } finally {
     clearTimeout(timer);
   }
+}
+
+async function postOtelSmokeSpan() {
+  const now = BigInt(Date.now()) * 1_000_000n;
+  const response = await fetch(`${baseUrl}/otel/v1/traces`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              { key: 'service.name', value: { stringValue: 'letovo-live-e2e' } },
+              { key: 'service.namespace', value: { stringValue: 'letovocorp' } },
+              { key: 'deployment.environment', value: { stringValue: 'production' } },
+            ],
+          },
+          scopeSpans: [
+            {
+              scope: { name: 'letovo.live-e2e' },
+              spans: [
+                {
+                  traceId: '11111111111111111111111111111111',
+                  spanId: '2222222222222222',
+                  name: 'live-e2e-otel-smoke',
+                  kind: 'SPAN_KIND_INTERNAL',
+                  startTimeUnixNano: now.toString(),
+                  endTimeUnixNano: (now + 1_000_000n).toString(),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+  });
+
+  assert(
+    response.status >= 200 && response.status < 300,
+    `Expected /otel/v1/traces to accept OTLP JSON, got HTTP ${response.status}: ${await response.text()}`,
+  );
 }
 
 async function assertDeploymentMetadata(path, expectedSha, description) {
@@ -339,6 +381,12 @@ async function probeDeployment() {
     api.status === 501,
     `Expected /letovo-api/auth/login GET to return 501, got ${api.status}`,
   );
+
+  if (requireOtel) {
+    await postOtelSmokeSpan();
+  } else {
+    console.log('Skipping OTEL trace smoke because LIVE_E2E_REQUIRE_OTEL is not true.');
+  }
 
   await assertDeploymentMetadata(
     '/letovo-api/deployment/metadata',

--- a/test/test_issue116_opentelemetry_contract.py
+++ b/test/test_issue116_opentelemetry_contract.py
@@ -21,23 +21,36 @@ def test_collector_config_and_compose_are_wired():
     assert "processors:" in collector
     assert "batch:" in collector
     assert "exporters:" in collector
+    assert "otlphttp/jaeger:" in collector
+    assert "endpoint: http://jaeger:4318" in collector
     assert "debug:" in collector
     assert "service:" in collector
     assert "pipelines:" in collector
     assert "traces:" in collector
     assert "logs:" in collector
 
+    assert "jaeger:" in compose
+    assert "jaegertracing/all-in-one:1.57" in compose
+    assert "SPAN_STORAGE_TYPE: badger" in compose
+    assert "BADGER_EPHEMERAL: \"false\"" in compose
+    assert "127.0.0.1:16686:16686" in compose
+    assert "jaeger-data:" in compose
     assert "otel-collector:" in compose
     assert "otel/opentelemetry-collector:0.155.0" in compose
+    assert "          - jaeger" in compose
     assert "./otel-collector-config.yaml:/etc/otelcol/config.yaml:ro" in compose
     assert "127.0.0.1:4317:4317" in compose
     assert "127.0.0.1:4318:4318" in compose
     assert "OTEL_SERVICE_NAME: letovo-server" in compose
     assert "OTEL_SERVICE_NAME: letovo-registration-server" in compose
+    assert "OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=letovocorp" in compose
     assert "OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318" in compose
     assert "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://127.0.0.1:4318/v1/traces" in compose
     assert 'NEXT_PUBLIC_OTEL_ENABLED: "true"' in compose
     assert "NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: /otel/v1/traces" in compose
+    assert "NEXT_PUBLIC_OTEL_DEPLOYMENT_ENVIRONMENT: production" in compose
+    assert "NEXT_PUBLIC_OTEL_SERVICE_NAMESPACE: letovocorp" in compose
+    assert 'NEXT_PUBLIC_OTEL_TRACES_SAMPLER_RATIO: "0.1"' in compose
 
     assert "location = /otel/v1/traces" in nginx
     assert "limit_except POST" in nginx
@@ -81,8 +94,11 @@ def test_backend_opentelemetry_dependency_and_request_wrapper_are_wired():
     assert "HttpTraceContext" in source
     assert "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" in source
     assert "OTEL_SERVICE_NAME" in source
+    assert "OTEL_RESOURCE_ATTRIBUTES" in source
     assert "OTEL_SDK_DISABLED" in source
     assert "OTEL_TRACES_EXPORTER" in source
+    assert '"http://127.0.0.1:4318"' not in source
+    assert "std::string traces_endpoint{}" in header
     assert "request.duration_ms" in source
     assert "http.response.status_code" in header
     assert "trace_id" in source
@@ -122,9 +138,17 @@ def test_frontend_opentelemetry_contract_is_wired():
     assert "propagation.inject" in browser
     assert "traceparent" in browser
     assert "NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" in browser
+    assert "NEXT_PUBLIC_OTEL_DEPLOYMENT_ENVIRONMENT" in browser
+    assert "NEXT_PUBLIC_OTEL_SERVICE_NAMESPACE" in browser
+    assert "NEXT_PUBLIC_OTEL_TRACES_SAMPLER_RATIO" in browser
+    assert "TraceIdRatioBasedSampler" in browser
+    assert "!initialized" in browser
     assert "withFrontendSpan" in browser
     assert "initBrowserTelemetry" in bootstrap
     assert "<TelemetryBootstrap />" in layout
     assert "'analytics.activity_ping'" in analytics
     assert "ARG NEXT_PUBLIC_OTEL_ENABLED=" in dockerfile
     assert "ARG NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=" in dockerfile
+    assert "ARG NEXT_PUBLIC_OTEL_DEPLOYMENT_ENVIRONMENT=" in dockerfile
+    assert "ARG NEXT_PUBLIC_OTEL_SERVICE_NAMESPACE=" in dockerfile
+    assert "ARG NEXT_PUBLIC_OTEL_TRACES_SAMPLER_RATIO=" in dockerfile

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -1,4 +1,6 @@
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 
@@ -7,6 +9,7 @@ WORKFLOW = ROOT / ".github" / "workflows" / "live-e2e.yml"
 BUILD_WORKFLOW = ROOT / ".github" / "workflows" / "docker-image.yml"
 PRODUCTION_RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "production-release.yml"
 LIVE_SCRIPT = ROOT / "test" / "e2e" / "live-platform-smoke.mjs"
+NGINX_OTEL_PATCHER = ROOT / "scripts" / "patch_nginx_otel.py"
 COMPOSE = ROOT / "docs" / "docker-compose.yaml"
 BACKEND_DOCKERFILE = ROOT / "src" / "Dockerfile"
 FRONTEND_DOCKERFILE = ROOT / "frontend" / "dockerfile"
@@ -43,6 +46,8 @@ def test_live_e2e_workflow_runs_after_deployable_images_are_published():
     assert "LETOVO_E2E_SECONDARY_PASSWORD" in workflow
     assert "LIVE_E2E_REQUIRE_EXTENDED" in workflow
     assert "inputs.require_extended || 'false'" in workflow
+    assert "LIVE_E2E_REQUIRE_OTEL" in workflow
+    assert "inputs.require_otel || 'false'" in workflow
     assert "node $GITHUB_WORKSPACE/test/e2e/live-platform-smoke.mjs" in workflow
     assert "expected_sha:" in workflow
     assert "github.event.workflow_run.head_sha" in workflow
@@ -64,6 +69,7 @@ def test_pr_build_publishes_candidate_images_before_live_e2e_gate():
     assert "live-deployment-e2e:" in workflow
     assert "needs: [publish-pr-candidate]" in workflow
     assert 'LIVE_E2E_REQUIRE_AUTH: "true"' in workflow
+    assert 'LIVE_E2E_REQUIRE_OTEL: "false"' in workflow
     assert "LIVE_E2E_EXPECTED_BACKEND_SHA: ${{ github.sha }}" in workflow
     assert "LIVE_E2E_EXPECTED_FRONTEND_SHA: ${{ github.sha }}" in workflow
     assert "concurrency:" in workflow
@@ -103,21 +109,38 @@ def test_production_release_is_manual_deploy_with_required_live_e2e_gate():
     assert "LETOVO_PROD_DEPLOY_HOST" in workflow
     assert "LETOVO_PROD_DEPLOY_USER" in workflow
     assert "LETOVO_PROD_DEPLOY_SSH_KEY" in workflow
+    assert "LETOVO_PROD_NGINX_SITE || '/etc/nginx/sites-available/default'" in workflow
     workflow_env = _workflow_env(workflow)
     assert "LETOVO_PROD_DEPLOY_USER" not in workflow_env
     assert "LETOVO_PROD_DEPLOY_SSH_KEY" not in workflow_env
     assert "Transfer production images to host" in workflow
     assert "docker save \"${images[@]}\" | gzip -1 | ssh" in workflow
     assert "gzip -dc | docker load" in workflow
+    assert "scp -i ~/.ssh/letovo-production-release docs/docker-compose.yaml" in workflow
+    assert "scp -i ~/.ssh/letovo-production-release docs/otel-collector-config.yaml" in workflow
+    assert "scp -i ~/.ssh/letovo-production-release scripts/patch_nginx_otel.py" in workflow
+    assert "otel-collector-config.yaml.before-release" in workflow
+    assert "nginx-site.before-release" in workflow
+    assert 'python3 "$state_dir/patch_nginx_otel.py" "$NGINX_SITE" "$nginx_candidate" --server-name letovocorp.ru' in workflow
+    assert "as_root nginx -t" in workflow
+    assert "as_root nginx -s reload || as_root systemctl reload nginx" in workflow
     assert "docker compose -p \"$PROJECT_NAME\" -f \"$COMPOSE_FILE\" pull" not in workflow
     assert "docker image inspect \"$BACKEND_IMAGE\" >/dev/null" in workflow
     assert "RELEASE_SHA='${{ steps.release.outputs.release_sha }}'" in workflow
     assert 's#LETOVO_BUILD_SHA: \\".*\\"#LETOVO_BUILD_SHA: \\"${RELEASE_SHA}\\"#' in workflow
     assert "cp \"$candidate\" \"$COMPOSE_FILE\"" in workflow
+    assert "up -d jaeger otel-collector letovo-server letovo-registration-server letovo-front" in workflow
+    assert "docker inspect -f '{{.State.Running}}' jaeger" in workflow
     assert "Run production live e2e" in workflow
+    assert "Verify production OTEL storage" in workflow
+    assert "http://127.0.0.1:16686/api/traces/${trace_id}" in workflow
+    assert "live-e2e-otel-smoke" in workflow
     assert 'LIVE_E2E_REQUIRE_AUTH: "true"' in workflow
+    assert 'LIVE_E2E_REQUIRE_OTEL: "true"' in workflow
     assert "LIVE_E2E_EXPECTED_BACKEND_SHA=$release_sha" in workflow
     assert "Roll back production images on failure" in workflow
+    assert "cp \"$otel_backup\" \"$(dirname \"$COMPOSE_FILE\")/otel-collector-config.yaml\"" in workflow
+    assert "as_root cp \"$nginx_backup\" \"$NGINX_SITE\"" in workflow
 
 
 def test_production_release_backend_build_files_match_main_ci():
@@ -128,6 +151,12 @@ def test_live_e2e_uses_condition_polling_and_browser_level_checks():
     script = _read(LIVE_SCRIPT)
 
     assert "async function waitForLiveDeployment" in script
+    assert "async function postOtelSmokeSpan" in script
+    assert "LIVE_E2E_REQUIRE_OTEL === 'true'" in script
+    assert "/otel/v1/traces" in script
+    assert "live-e2e-otel-smoke" in script
+    assert "Expected /otel/v1/traces to accept OTLP JSON" in script
+    assert "Skipping OTEL trace smoke because LIVE_E2E_REQUIRE_OTEL is not true." in script
     assert "LIVE_E2E_EXPECTED_BACKEND_SHA" in script
     assert "LIVE_E2E_EXPECTED_FRONTEND_SHA" in script
     assert "async function assertDeploymentMetadata" in script
@@ -175,3 +204,52 @@ def test_images_expose_deployment_metadata_sha():
     assert "ARG NEXT_PUBLIC_BASE_URL_UPLOAD=" in frontend_dockerfile
     assert "ARG NEXT_PUBLIC_BASE_URL_MEDIA=" in frontend_dockerfile
     assert "process.env.LETOVO_BUILD_SHA" in frontend_route
+
+
+def test_nginx_otel_patcher_targets_https_letovocorp_server(tmp_path):
+    source = tmp_path / "site.conf"
+    output = tmp_path / "site.patched.conf"
+    source.write_text(
+        """
+server {
+    listen 80;
+    server_name letovocorp.ru www.letovocorp.ru;
+
+    location = /otel/v1/traces {
+        proxy_pass http://127.0.0.1:4318/v1/traces;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name letovocorp.ru www.letovocorp.ru;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+    }
+}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [sys.executable, str(NGINX_OTEL_PATCHER), str(source), str(output)],
+        check=True,
+    )
+
+    patched = output.read_text(encoding="utf-8")
+    first_server = patched.index("server {")
+    second_server = patched.index("server {", first_server + 1)
+    http_server = patched[first_server:second_server]
+    https_server = patched[second_server:]
+
+    assert "location = /otel/v1/traces" not in http_server
+    assert "location /otel/" not in http_server
+    assert "location = /otel/v1/traces" in https_server
+    assert "location /otel/" in https_server
+    assert "return 404;" in https_server
+    assert https_server.index("location = /otel/v1/traces") < https_server.index("location / {")

--- a/test/test_user_activity_analytics_contract.py
+++ b/test/test_user_activity_analytics_contract.py
@@ -79,6 +79,14 @@ def test_activity_summary_counts_distinct_usernames_not_requests():
     assert "'top_routes_24h'" in source
 
 
+def test_last_seen_write_does_not_require_preexisting_unique_constraint():
+    source = _read(ANALYTICS_CC)
+
+    assert "WITH updated AS (" in source
+    assert "WHERE NOT EXISTS (SELECT 1 FROM updated)" in source
+    assert "ON CONFLICT (username)" not in source
+
+
 def test_activity_ping_validates_event_and_route_shape():
     source = _read(ANALYTICS_CC)
 


### PR DESCRIPTION
## Summary
- deploy checked-in compose and collector config during production release, with backups and rollback for compose, collector config, and nginx site config
- add host-local Jaeger with Badger storage and export collector traces to it, while retaining debug logs for operational visibility
- patch production nginx with /otel/v1/traces, validate with nginx -t, reload nginx, and start jaeger/otel-collector with the app services
- remove the backend implicit localhost OTLP default, add production resource attributes, and avoid last_seen writes depending on an existing unique constraint
- add live OTEL smoke POST coverage, post-deploy Jaeger trace lookup, and production-safe frontend sampling/resource attributes via letovo-all-frontend#26

Closes #121

## Tests
- python3 -m pytest test/test_issue116_opentelemetry_contract.py test/test_live_e2e_workflow_contract.py test/test_user_activity_analytics_contract.py -q
- npm run test:opentelemetry (frontend)
- npm run build (frontend)

## Notes
- Full python3 -m pytest test -q currently stops during collection because the local environment is missing the clang Python package required by test/test_sql_cons.py.
- Local backend CMake build fetches opentelemetry-cpp, then fails before project sources compile because local protoc 3.15.8 generates files incompatible with protobuf headers 3.12.4.