### PR TITLE
Fix production release backend readiness

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -329,7 +329,7 @@ jobs:
 
           backend_status=""
           for _ in $(seq 1 30); do
-            backend_status="$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/auth/login || true)"
+            backend_status="$(curl --connect-timeout 2 --max-time 5 -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/auth/login || true)"
             if [ "$backend_status" = "501" ]; then
               break
             fi

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -326,6 +326,23 @@ jobs:
           test "$(docker inspect -f '{{.Config.Image}}' letovo-server)" = "$BACKEND_IMAGE"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-registration-server)" = "$REGISTRATION_IMAGE"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-front)" = "$FRONTEND_IMAGE"
+
+          backend_status=""
+          for _ in $(seq 1 30); do
+            backend_status="$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/auth/login || true)"
+            if [ "$backend_status" = "501" ]; then
+              break
+            fi
+            sleep 2
+          done
+          if [ "$backend_status" != "501" ]; then
+            echo "Expected letovo-server on 127.0.0.1:8080 to return 501 for GET /auth/login, got ${backend_status:-no response}"
+            docker ps -a --filter "name=letovo-server" --filter "name=otel-collector" --filter "name=jaeger" || true
+            docker logs --tail 200 letovo-server || true
+            docker logs --tail 200 otel-collector || true
+            docker logs --tail 200 jaeger || true
+            exit 1
+          fi
           REMOTE
 
       - name: Set up Node.js for live e2e

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -47,6 +47,8 @@ services:
         depends_on:
           - otel-collector
         environment:
+          SERVER_ADRESS: "127.0.0.1"
+          SERVER_PORT: "8080"
           OTEL_SERVICE_NAME: letovo-server
           OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=letovocorp
           OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -137,7 +137,7 @@ def test_production_release_is_manual_deploy_with_required_live_e2e_gate():
     assert "cp \"$candidate\" \"$COMPOSE_FILE\"" in workflow
     assert "up -d jaeger otel-collector letovo-server letovo-registration-server letovo-front" in workflow
     assert "docker inspect -f '{{.State.Running}}' jaeger" in workflow
-    assert 'curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/auth/login' in workflow
+    assert 'curl --connect-timeout 2 --max-time 5 -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/auth/login' in workflow
     assert "Expected letovo-server on 127.0.0.1:8080 to return 501" in workflow
     assert 'docker logs --tail 200 letovo-server' in workflow
     assert "Run production live e2e" in workflow

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -137,6 +137,9 @@ def test_production_release_is_manual_deploy_with_required_live_e2e_gate():
     assert "cp \"$candidate\" \"$COMPOSE_FILE\"" in workflow
     assert "up -d jaeger otel-collector letovo-server letovo-registration-server letovo-front" in workflow
     assert "docker inspect -f '{{.State.Running}}' jaeger" in workflow
+    assert 'curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/auth/login' in workflow
+    assert "Expected letovo-server on 127.0.0.1:8080 to return 501" in workflow
+    assert 'docker logs --tail 200 letovo-server' in workflow
     assert "Run production live e2e" in workflow
     assert "Verify production OTEL storage" in workflow
     assert "http://127.0.0.1:16686/api/traces/${trace_id}" in workflow
@@ -191,6 +194,8 @@ def test_checked_in_compose_matches_watchtower_frontend_image_contract():
     compose = _read(COMPOSE)
 
     assert "image: ghcr.io/letovo-dev/letovo-all-frontend:latest" in compose
+    assert 'SERVER_ADRESS: "127.0.0.1"' in compose
+    assert 'SERVER_PORT: "8080"' in compose
     assert "com.centurylinklabs.watchtower.enable=true" in compose
     assert 'ports:\n          - "127.0.0.1:3000:3000"' in compose
 


### PR DESCRIPTION
## Summary
- pin production letovo-server to the nginx upstream address/port with SERVER_ADRESS=127.0.0.1 and SERVER_PORT=8080
- add an immediate remote backend readiness check after docker compose starts the production containers
- dump backend/otel/jaeger logs if the backend does not answer GET /auth/login with 501 before public live e2e

## Failure mode
Production release run 28795185757 got past image deploy, but live e2e timed out for 10 minutes because https://letovocorp.ru/letovo-api/auth/login returned 502 instead of the expected backend 501.

## Tests
- python3 -m pytest test/test_live_e2e_workflow_contract.py test/test_issue116_opentelemetry_contract.py -q
- git diff --check