### PR TITLE
Fix production release startup checks

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -230,6 +230,11 @@ jobs:
           push: true
           build-args: |
             LETOVO_BUILD_SHA=${{ github.sha }}
+            NEXT_PUBLIC_BASE_URL=${{ vars.PRODUCTION_BASE_URL || 'https://letovocorp.ru' }}/letovo-api
+            NEXT_PUBLIC_BASE_URL_UPLOAD=${{ vars.PRODUCTION_BASE_URL || 'https://letovocorp.ru' }}/letovo-api/upload/
+            NEXT_PUBLIC_BASE_URL_MEDIA=${{ vars.PRODUCTION_BASE_URL || 'https://letovocorp.ru' }}/letovo-api/media/get
+            NEXT_PUBLIC_UPLOAD_URL=${{ vars.PRODUCTION_BASE_URL || 'https://letovocorp.ru' }}/letovo-api/upload/
+            NEXT_PUBLIC_BASE_URL_CLEAR=${{ vars.PRODUCTION_BASE_URL || 'https://letovocorp.ru' }}
             NEXT_PUBLIC_OTEL_ENABLED=true
             NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=/otel/v1/traces
             NEXT_PUBLIC_OTEL_SERVICE_NAME=letovo-frontend

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -272,6 +272,7 @@ jobs:
           compose_dir="$(dirname "$COMPOSE_FILE")"
           otel_config="$compose_dir/otel-collector-config.yaml"
           front_env="/mnt/letovo-front.env"
+          smoke_name="letovo-server-release-smoke-${RUN_ID}"
 
           as_root() {
             if [ "$(id -u)" -eq 0 ]; then
@@ -287,6 +288,11 @@ jobs:
           test -f "$repo_compose"
           test -f "$repo_otel"
           test -f "$repo_front_env"
+          docker rm -f "$smoke_name" >/dev/null 2>&1 || true
+          cleanup_smoke() {
+            docker rm -f "$smoke_name" >/dev/null 2>&1 || true
+          }
+          trap cleanup_smoke EXIT
 
           cp "$COMPOSE_FILE" "$compose_backup"
           if [ -f "$otel_config" ]; then
@@ -306,6 +312,41 @@ jobs:
             -e "s#image: .*letovo.*front.*:.*#image: ${FRONTEND_IMAGE}#" \
             -e "s#LETOVO_BUILD_SHA: \".*\"#LETOVO_BUILD_SHA: \"${RELEASE_SHA}\"#" \
             "$repo_compose" > "$candidate"
+
+          docker run -d \
+            --name "$smoke_name" \
+            --network host \
+            -e SERVER_ADRESS=127.0.0.1 \
+            -e SERVER_PORT=18080 \
+            -e LETOVO_BUILD_SHA="$RELEASE_SHA" \
+            -e OTEL_SERVICE_NAME=letovo-server-release-smoke \
+            -e OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
+            -e OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:4318/v1/traces \
+            -e OTEL_TRACES_EXPORTER=otlp \
+            -e OTEL_LOG_LEVEL=info \
+            -v /mnt/server-media:/app/pages \
+            -v /mnt/server-configs:/app/configs \
+            "$BACKEND_IMAGE"
+
+          smoke_status=""
+          for _ in $(seq 1 20); do
+            if [ "$(docker inspect -f '{{.State.Running}}' "$smoke_name" 2>/dev/null || true)" != "true" ]; then
+              break
+            fi
+            smoke_status="$(curl --connect-timeout 2 --max-time 5 -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:18080/auth/login || true)"
+            if [ "$smoke_status" = "501" ]; then
+              break
+            fi
+            sleep 2
+          done
+          if [ "$smoke_status" != "501" ]; then
+            echo "Candidate letovo-server image failed pre-deploy smoke on 127.0.0.1:18080; got ${smoke_status:-no response}"
+            docker ps -a --filter "name=$smoke_name" || true
+            docker logs --tail 200 "$smoke_name" || true
+            exit 1
+          fi
+          cleanup_smoke
+          trap - EXIT
 
           cp "$repo_otel" "$otel_config"
           as_root install -m 0644 "$repo_front_env" "$front_env"

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
         image: jaegertracing/all-in-one:1.57
         container_name: jaeger
         restart: unless-stopped
+        user: "0:0"
         environment:
           COLLECTOR_OTLP_ENABLED: "true"
           SPAN_STORAGE_TYPE: badger
@@ -47,10 +48,7 @@ services:
         depends_on:
           - otel-collector
         environment:
-          SERVER_ADRESS: "127.0.0.1"
-          SERVER_PORT: "8080"
           OTEL_SERVICE_NAME: letovo-server
-          OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=letovocorp
           OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://127.0.0.1:4318/v1/traces
           OTEL_TRACES_EXPORTER: otlp
@@ -77,7 +75,6 @@ services:
           SERVER_ADRESS: "127.0.0.1"
           SERVER_PORT: "8082"
           OTEL_SERVICE_NAME: letovo-registration-server
-          OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=letovocorp
           OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://127.0.0.1:4318/v1/traces
           OTEL_TRACES_EXPORTER: otlp

--- a/test/test_issue116_opentelemetry_contract.py
+++ b/test/test_issue116_opentelemetry_contract.py
@@ -31,6 +31,7 @@ def test_collector_config_and_compose_are_wired():
 
     assert "jaeger:" in compose
     assert "jaegertracing/all-in-one:1.57" in compose
+    assert 'user: "0:0"' in compose
     assert "SPAN_STORAGE_TYPE: badger" in compose
     assert "BADGER_EPHEMERAL: \"false\"" in compose
     assert "127.0.0.1:16686:16686" in compose
@@ -43,7 +44,7 @@ def test_collector_config_and_compose_are_wired():
     assert "127.0.0.1:4318:4318" in compose
     assert "OTEL_SERVICE_NAME: letovo-server" in compose
     assert "OTEL_SERVICE_NAME: letovo-registration-server" in compose
-    assert "OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=letovocorp" in compose
+    assert "OTEL_RESOURCE_ATTRIBUTES" not in compose
     assert "OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318" in compose
     assert "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://127.0.0.1:4318/v1/traces" in compose
     assert 'NEXT_PUBLIC_OTEL_ENABLED: "true"' in compose

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -126,6 +126,12 @@ def test_production_release_is_manual_deploy_with_required_live_e2e_gate():
     assert 'repo_front_env="$state_dir/letovo-front.env.from-repo"' in workflow
     assert 'front_env="/mnt/letovo-front.env"' in workflow
     assert 'test -f "$repo_front_env"' in workflow
+    assert 'smoke_name="letovo-server-release-smoke-${RUN_ID}"' in workflow
+    assert "docker rm -f \"$smoke_name\" >/dev/null 2>&1 || true" in workflow
+    assert "--name \"$smoke_name\"" in workflow
+    assert "-e SERVER_PORT=18080" in workflow
+    assert "http://127.0.0.1:18080/auth/login" in workflow
+    assert "Candidate letovo-server image failed pre-deploy smoke" in workflow
     assert 'as_root install -m 0644 "$repo_front_env" "$front_env"' in workflow
     assert 'python3 "$state_dir/patch_nginx_otel.py" "$NGINX_SITE" "$nginx_candidate" --server-name letovocorp.ru' in workflow
     assert "as_root nginx -t" in workflow
@@ -194,8 +200,8 @@ def test_checked_in_compose_matches_watchtower_frontend_image_contract():
     compose = _read(COMPOSE)
 
     assert "image: ghcr.io/letovo-dev/letovo-all-frontend:latest" in compose
-    assert 'SERVER_ADRESS: "127.0.0.1"' in compose
-    assert 'SERVER_PORT: "8080"' in compose
+    assert 'user: "0:0"' in compose
+    assert "OTEL_RESOURCE_ATTRIBUTES" not in compose
     assert "com.centurylinklabs.watchtower.enable=true" in compose
     assert 'ports:\n          - "127.0.0.1:3000:3000"' in compose
 

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -82,6 +82,18 @@ def test_pr_build_publishes_candidate_images_before_live_e2e_gate():
     assert "Restore live deployment images" in workflow
 
 
+def test_main_latest_frontend_image_bakes_production_api_prefix():
+    workflow = _read(BUILD_WORKFLOW)
+
+    assert "publish-main:" in workflow
+    assert "${{ env.FRONTEND_IMAGE }}:latest" in workflow
+    assert "NEXT_PUBLIC_BASE_URL=${{ vars.PRODUCTION_BASE_URL || 'https://letovocorp.ru' }}/letovo-api" in workflow
+    assert "NEXT_PUBLIC_BASE_URL_UPLOAD=${{ vars.PRODUCTION_BASE_URL || 'https://letovocorp.ru' }}/letovo-api/upload/" in workflow
+    assert "NEXT_PUBLIC_BASE_URL_MEDIA=${{ vars.PRODUCTION_BASE_URL || 'https://letovocorp.ru' }}/letovo-api/media/get" in workflow
+    assert "NEXT_PUBLIC_UPLOAD_URL=${{ vars.PRODUCTION_BASE_URL || 'https://letovocorp.ru' }}/letovo-api/upload/" in workflow
+    assert "NEXT_PUBLIC_BASE_URL_CLEAR=${{ vars.PRODUCTION_BASE_URL || 'https://letovocorp.ru' }}" in workflow
+
+
 def test_production_release_is_manual_deploy_with_required_live_e2e_gate():
     workflow = _read(PRODUCTION_RELEASE_WORKFLOW)
 


### PR DESCRIPTION
## Summary
- run a candidate backend container smoke on 127.0.0.1:18080 before replacing the live production compose file
- run Jaeger as root so Badger can create/write its named volume directories
- remove the production backend OTEL_RESOURCE_ATTRIBUTES override and let the backend keep its existing config-derived bind address

## Failure addressed
The production release run 28805282276 failed because the candidate letovo-server image restarted with exit 139 before opening 127.0.0.1:8080. The same run also showed Jaeger repeatedly failing with permission denied while creating /badger/key.

## Validation
- pytest -q test/test_issue116_opentelemetry_contract.py test/test_user_activity_analytics_contract.py test/test_live_e2e_workflow_contract.py
- YAML parse check for docs/docker-compose.yaml, docs/otel-collector-config.yaml, and .github/workflows/production-release.yml

Note: a local full CMake backend build is still blocked by the existing local protobuf generator/header mismatch.

## Issue 128 follow-up
- build the main `latest` frontend image with the same production `NEXT_PUBLIC_BASE_URL*` values used by production release and PR candidate images
- add a workflow contract test so `ghcr.io/letovo-dev/letovo-all-frontend:latest` keeps baking `https://letovocorp.ru/letovo-api` instead of a bare `/auth/login` route

Fixes #128
