### PR TITLE
fix(auth): allow inactive users to log in

### DIFF
--- a/src/basic/auth.cc
+++ b/src/basic/auth.cc
@@ -695,16 +695,8 @@ void enable_auth(
               .done();
         }
 
-        if (!auth::is_active(loginHeader, pool_ptr)) {
-          telemetry::record_domain_event(
-              logger_ptr, "auth.login_failed", telemetry::DomainEventLevel::kWarn,
-              "user_inactive", {{"user.hash", user_hash}});
-          return req->create_response(restinio::status_forbidden())
-              .append_header_date_field()
-              .connection_close()
-              .done();
-        }
-
+        // Inactive users are intentionally allowed to authenticate: the active
+        // flag controls current-year account lists, not portal login access.
         if (!user_sessions_columns_exist(pool_ptr)) {
           logger_ptr->error([] {
             return "auth session table is missing or incomplete; cannot create "

--- a/test/test_security_vulnerabilities.py
+++ b/test/test_security_vulnerabilities.py
@@ -222,6 +222,18 @@ def test_session_authentication_allows_inactive_portal_users():
     assert "u.active = true" not in username_from_session
 
 
+def test_login_allows_inactive_portal_users_by_design():
+    auth_cc = (ROOT / "src/basic/auth.cc").read_text()
+    login_route = auth_cc.split('http_post("/auth/login"', 1)[1]
+    login_route = login_route.split('http_post("/auth/reg"', 1)[0]
+
+    assert "auth::auth(loginHeader, passwordHeader, pool_ptr)" in login_route
+    assert "Inactive users are intentionally allowed to authenticate" in login_route
+    assert "user_inactive" not in login_route
+    assert "status_forbidden" not in login_route
+    assert "auth::is_active(loginHeader, pool_ptr)" not in login_route
+
+
 def test_social_news_saved_and_titles_accept_http_only_auth_session_cookie():
     social_cc = (ROOT / "src/letovo-soc-net/social.cc").read_text()
 


### PR DESCRIPTION
## Summary
- allow inactive portal users to authenticate with valid credentials
- document the intended inactive-login behavior inline in the login handler
- add a regression/contract test that keeps `/auth/login` from reintroducing an `active` gate

## Test Plan
- `python3 -m pytest test/test_security_vulnerabilities.py::test_login_allows_inactive_portal_users_by_design -q`
- `python3 -m pytest test/test_security_vulnerabilities.py::test_session_authentication_allows_inactive_portal_users test/test_security_vulnerabilities.py::test_login_allows_inactive_portal_users_by_design -q`
- `git diff --check`
