### PR TITLE
fix: prevent negative social reaction counters

### DIFF
--- a/docs/negative_social_counters_migration.sql
+++ b/docs/negative_social_counters_migration.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+-- Repair historical rows produced by non-idempotent like/dislike deletes.
+-- user_likes is the source of truth; cached counters must reflect existing rows,
+-- not merely clamp bad cached values to zero.
+WITH reaction_counts AS (
+    SELECT
+        p."post_id",
+        COUNT(*) FILTER (WHERE ul."value" = 1)::int AS "likes_count",
+        COUNT(*) FILTER (WHERE ul."value" = -1)::int AS "dislikes_count"
+    FROM "posts" p
+    LEFT JOIN "user_likes" ul ON ul."post_id" = p."post_id"
+    WHERE p."post_path" IS NULL
+    GROUP BY p."post_id"
+)
+UPDATE "posts" p
+SET
+    "likes" = reaction_counts."likes_count",
+    "dislikes" = reaction_counts."dislikes_count"
+FROM reaction_counts
+WHERE p."post_id" = reaction_counts."post_id"
+  AND p."post_path" IS NULL
+  AND (
+    COALESCE(p."likes", 0) <> reaction_counts."likes_count"
+    OR COALESCE(p."dislikes", 0) <> reaction_counts."dislikes_count"
+  );
+
+COMMIT;

--- a/src/letovo-soc-net/social.cc
+++ b/src/letovo-soc-net/social.cc
@@ -244,17 +244,21 @@ LEFT JOIN comment_preview cp ON cp.post_id = vp.post_id;
         return result[0]["payload"].as<std::string>();
     }
 
-    // FIXME: bug select always returns empty result
     void add_like(int like, std::string post_id, std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
         auto con = std::move(pool_ptr->getConnection());
-        std::vector<std::string> params = {std::to_string(like), post_id, username};
-        auto check = con->execute_params("SELECT * FROM \"user_likes\" ul WHERE ul.post_id=($2) AND ul.username=($3) and ul.value!=($1);", params);
-        params = {post_id};
-        if(check.size() > 0) {
-            if(like == 1) {
-                con->execute_params("UPDATE \"posts\" SET dislikes = dislikes - 1 WHERE post_id=($2);", params, true);
-            } else if(like == -1) {
-                con->execute_params("UPDATE \"posts\" SET likes = likes - 1 WHERE post_id=($2);", params, true);
+        std::vector<std::string> params = {post_id, username};
+        auto existing = con->execute_params("SELECT value FROM \"user_likes\" WHERE post_id=($1) AND username=($2);", params);
+        if(existing.size() > 0 && existing[0]["value"].as<int>() == like) {
+            pool_ptr->returnConnection(std::move(con));
+            return;
+        }
+        if(existing.size() > 0) {
+            params = {post_id};
+            int existing_like = existing[0]["value"].as<int>();
+            if(existing_like == 1) {
+                con->execute_params("UPDATE \"posts\" SET likes = GREATEST(likes - 1, 0) WHERE post_id=($1);", params, true);
+            } else if(existing_like == -1) {
+                con->execute_params("UPDATE \"posts\" SET dislikes = GREATEST(dislikes - 1, 0) WHERE post_id=($1);", params, true);
             }
         }
         params = {post_id, username};
@@ -272,13 +276,17 @@ LEFT JOIN comment_preview cp ON cp.post_id = vp.post_id;
 
     void delete_like(int like, std::string post_id, std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
         auto con = std::move(pool_ptr->getConnection());
-        std::vector<std::string> params = {post_id, username};
-        con->execute_params("DELETE FROM \"user_likes\" WHERE post_id=($1) AND username=($2);", params, true);
+        std::vector<std::string> params = {std::to_string(like), post_id, username};
+        auto removed = con->execute_params("DELETE FROM \"user_likes\" WHERE value=($1) AND post_id=($2) AND username=($3) RETURNING 1;", params, true);
+        if(removed.empty()) {
+            pool_ptr->returnConnection(std::move(con));
+            return;
+        }
         params = {post_id};
         if(like == 1) {
-            con->execute_params("UPDATE \"posts\" SET likes = likes - 1 WHERE post_id=($1);", params, true);
+            con->execute_params("UPDATE \"posts\" SET likes = GREATEST(likes - 1, 0) WHERE post_id=($1);", params, true);
         } else if(like == -1) {
-            con->execute_params("UPDATE \"posts\" SET dislikes = dislikes - 1 WHERE post_id=($1);", params, true);
+            con->execute_params("UPDATE \"posts\" SET dislikes = GREATEST(dislikes - 1, 0) WHERE post_id=($1);", params, true);
         }
         pool_ptr->returnConnection(std::move(con));
     }

--- a/test/test_issue130_negative_likes_contract.py
+++ b/test/test_issue130_negative_likes_contract.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_reaction_writes_are_idempotent_and_zero_clamped():
+    source = read("src/letovo-soc-net/social.cc").replace('\\"', '"')
+
+    assert 'SELECT value FROM "user_likes" WHERE post_id=($1) AND username=($2);' in source
+    assert 'existing[0]["value"].as<int>() == like' in source
+    assert 'DELETE FROM "user_likes" WHERE value=($1) AND post_id=($2) AND username=($3) RETURNING 1;' in source
+    assert "if(removed.empty())" in source
+    assert 'SET likes = GREATEST(likes - 1, 0)' in source
+    assert 'SET dislikes = GREATEST(dislikes - 1, 0)' in source
+
+
+def test_negative_social_counter_migration_recomputes_existing_rows_from_user_likes():
+    migration = read("docs/negative_social_counters_migration.sql")
+
+    assert "WITH reaction_counts AS" in migration
+    assert 'COUNT(*) FILTER (WHERE ul."value" = 1)::int AS "likes_count"' in migration
+    assert 'COUNT(*) FILTER (WHERE ul."value" = -1)::int AS "dislikes_count"' in migration
+    assert 'LEFT JOIN "user_likes" ul ON ul."post_id" = p."post_id"' in migration
+    assert 'UPDATE "posts"' in migration
+    assert '"likes" = reaction_counts."likes_count"' in migration
+    assert '"dislikes" = reaction_counts."dislikes_count"' in migration
+    assert '"post_path" IS NULL' in migration


### PR DESCRIPTION
Closes #130.\n\nChanges:\n- Makes social reaction writes idempotent so repeated like/dislike deletes do not decrement counters unless a matching reaction row was removed.\n- Clamps backend counter decrements with GREATEST(..., 0).\n- Adds docs/negative_social_counters_migration.sql to repair historical negative likes/dislikes rows.\n- Updates frontend submodule to letovo-dev/letovo-all-frontend#28, which normalizes stale negative counters and optimistic updates in news/comment stores.\n\nTests:\n- python3 -m pytest test/test_issue130_negative_likes_contract.py test/test_issue91_feed_related_contract.py test/test_social_news_date_filter.py test/test_post_text_escaping.py -q\n- npm run test:social-counters\n\nBuild note:\n- cmake --build src -j2 is blocked in this checkout by a local OpenTelemetry protobuf toolchain mismatch: generated proto files report they were produced by a newer protoc than the installed protobuf headers.