### PR TITLE
Enforce transfer cooldown

### DIFF
--- a/src/market/transaction_rules.h
+++ b/src/market/transaction_rules.h
@@ -3,6 +3,7 @@
 namespace transactions {
 
 constexpr int kAdminBalanceLimit = 999999999;
+constexpr int kTransferCooldownSeconds = 5;
 
 inline bool can_transfer_amount(int sender_balance, int amount, bool sender_is_admin) {
     if (!sender_is_admin && amount < 0) {

--- a/src/market/transactions.cc
+++ b/src/market/transactions.cc
@@ -77,6 +77,28 @@ namespace transactions {
         return can_receive_transfer(sender, pool_ptr) || can_receive_transfer(receiver, pool_ptr);
     }
 
+    int transfer_cooldown_seconds_remaining(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+        auto con = std::move(pool_ptr->getConnection());
+        std::vector<std::string> params = {username, std::to_string(kTransferCooldownSeconds)};
+        pqxx::result result = con->execute_params(
+            R"(SELECT CASE
+                   WHEN MAX(transactiontime) IS NULL THEN 0
+                   ELSE GREATEST(
+                       0,
+                       $2::integer - FLOOR(EXTRACT(EPOCH FROM (LOCALTIMESTAMP - MAX(transactiontime))))::integer
+                   )
+               END AS seconds_remaining
+               FROM "transactions"
+               WHERE sender = $1)",
+            params);
+        pool_ptr->returnConnection(std::move(con));
+
+        if (result.empty() || result[0]["seconds_remaining"].is_null()) {
+            return 0;
+        }
+        return result[0]["seconds_remaining"].as<int>();
+    }
+
 
     TransferResult transfer_with_result(std::string tr_id, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
         TransferResult result;
@@ -90,6 +112,11 @@ namespace transactions {
         result.receiver = transaction->receiver;
         result.amount = amount;
         bool sender_is_admin = auth::is_rights_by_username(transaction->sender, pool_ptr);
+
+        if (transfer_cooldown_seconds_remaining(transaction->sender, pool_ptr) > 0) {
+            result.status = TransactionStatus::Cooldown;
+            return result;
+        }
 
         if (!sender_is_admin &&
             (!can_use_transactions(transaction->sender, pool_ptr) ||
@@ -256,6 +283,9 @@ namespace transactions {
         if (!sender_is_admin && !has_whireable_participant(sender, reciver, pool_ptr)) {
             return {TransactionStatus::NotReceiver, ""};
         }
+        if (transfer_cooldown_seconds_remaining(sender, pool_ptr) > 0) {
+            return {TransactionStatus::Cooldown, ""};
+        }
         
         return {registered_transactions.add_transaction(tr_id, std::make_shared<TransactionDetails>(sender, reciver, std::to_string(ammount))), tr_id};
     }
@@ -399,6 +429,13 @@ namespace transactions::server {
                         .set_body("user is not active")
                     .done();
                     break;
+                case TransactionStatus::Cooldown:
+                    return req->create_response(restinio::status_too_many_requests())
+                        .append_header("Content-Type", "text/plain; charset=utf-8")
+                        .append_header("Retry-After", std::to_string(kTransferCooldownSeconds))
+                        .set_body("transfer cooldown active")
+                    .done();
+                    break;
                 case TransactionStatus::Error:
                 default:
                     break;
@@ -481,6 +518,13 @@ namespace transactions::server {
                     return req->create_response(restinio::status_forbidden())
                         .append_header("Content-Type", "text/plain; charset=utf-8")
                         .set_body("user is not active")
+                    .done();
+                    break;
+                case TransactionStatus::Cooldown:
+                    return req->create_response(restinio::status_too_many_requests())
+                        .append_header("Content-Type", "text/plain; charset=utf-8")
+                        .append_header("Retry-After", std::to_string(kTransferCooldownSeconds))
+                        .set_body("transfer cooldown active")
                     .done();
                     break;
                 case TransactionStatus::Error:

--- a/src/market/transactions.h
+++ b/src/market/transactions.h
@@ -35,6 +35,7 @@ namespace transactions {
         NegativeNumber,
         NotReceiver,
         InactiveUser,
+        Cooldown,
     };
 
     struct TransferResult {
@@ -71,6 +72,8 @@ namespace transactions {
     bool can_receive_transfer(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
     bool has_whireable_participant(std::string sender, std::string receiver, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
+
+    int transfer_cooldown_seconds_remaining(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
     pqxx::result get_transactions(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 

--- a/test/test_market.py
+++ b/test/test_market.py
@@ -183,7 +183,7 @@ def test_prepare_transaction_success(sender_user, receiver_user):
     # Success returns transaction ID
     # Conflict (409) means insufficient funds
     # Not found (404) means receiver doesn't exist
-    assert response.status_code in [200, 409, 404]
+    assert response.status_code in [200, 409, 404, 429]
     
     if response.status_code == 200:
         # Should return transaction ID
@@ -203,7 +203,7 @@ def test_prepare_transaction_zero_amount(sender_user, receiver_user):
         verify=False
     )
     # Should succeed as 0 is valid
-    assert response.status_code in [200, 409]
+    assert response.status_code in [200, 409, 429]
 
 
 def test_non_admin_cookie_auth_transfer_flow():
@@ -254,6 +254,60 @@ def test_non_admin_cookie_auth_transfer_flow():
     assert send_response.status_code == 200, send_response.text
 
 
+def test_prepared_transfer_ids_obey_send_cooldown():
+    """A second pre-created transfer ID cannot be sent during the cooldown."""
+    sender = f"cooldown_sender_{uuid.uuid4().hex[:12]}"
+    receiver = f"cooldown_receiver_{uuid.uuid4().hex[:12]}"
+    password = "test"
+
+    for login in (sender, receiver):
+        response = requests.post(
+            f"{BASE_URL}/auth/reg",
+            json={"login": login, "password": password},
+            verify=False,
+        )
+        assert response.status_code == 200, response.text
+
+    login_response = requests.post(
+        f"{BASE_URL}/auth/login",
+        json={"login": sender, "password": password},
+        verify=False,
+    )
+    assert login_response.status_code == 200
+    auth_session = login_response.headers.get("Authorization")
+    assert auth_session
+    cookie_header = {"Cookie": f"AuthSession={auth_session}"}
+
+    prepared_ids = []
+    for _ in range(2):
+        prepare_response = requests.post(
+            f"{BASE_URL}/transactions/prepare",
+            headers=cookie_header,
+            json={"receiver": receiver, "amount": 0},
+            verify=False,
+        )
+        assert prepare_response.status_code == 200, prepare_response.text
+        prepared_ids.append(prepare_response.text)
+
+    first_send_response = requests.post(
+        f"{BASE_URL}/transactions/send",
+        headers=cookie_header,
+        json={"tr_id": prepared_ids[0]},
+        verify=False,
+    )
+    assert first_send_response.status_code == 200, first_send_response.text
+
+    second_send_response = requests.post(
+        f"{BASE_URL}/transactions/send",
+        headers=cookie_header,
+        json={"tr_id": prepared_ids[1]},
+        verify=False,
+    )
+    assert second_send_response.status_code == 429
+    assert second_send_response.headers.get("Retry-After") == "5"
+    assert second_send_response.text == "transfer cooldown active"
+
+
 def test_prepare_negative_transaction_as_admin(admin_user, sender_user):
     """Admins can prepare negative transactions without receiver balance checks."""
     response = requests.post(
@@ -266,7 +320,10 @@ def test_prepare_negative_transaction_as_admin(admin_user, sender_user):
         verify=False
     )
 
-    assert response.status_code == 200
+    assert response.status_code in [200, 429]
+    if response.status_code == 429:
+        assert response.headers.get("Retry-After") == "5"
+        return
     assert response.text
 
 
@@ -433,7 +490,7 @@ def test_full_transaction_flow_insufficient_funds(sender_user, receiver_user):
     
     # Should fail with insufficient funds (409 Conflict)
     # or succeed if user has special rights
-    assert prepare_response.status_code in [200, 409]
+    assert prepare_response.status_code in [200, 409, 429]
 
 
 def test_transaction_to_self(sender_user):
@@ -448,7 +505,7 @@ def test_transaction_to_self(sender_user):
         verify=False
     )
     # System should allow this (it's a valid edge case)
-    assert response.status_code in [200, 409]
+    assert response.status_code in [200, 409, 429]
 
 
 # Note: No cleanup needed since we're using persistent "test" and "scv" users

--- a/test/test_transaction_rules.py
+++ b/test/test_transaction_rules.py
@@ -81,3 +81,24 @@ def test_admin_sender_bypasses_transaction_recipient_restrictions():
     assert "if (!sender_is_admin && !can_use_transactions(reciver, pool_ptr))" in transaction_source
     assert "if (!sender_is_admin && !has_whireable_participant(sender, reciver, pool_ptr))" in transaction_source
     assert transaction_source.count("if (!sender_is_admin && !transactions::can_use_transactions(") >= 2
+
+
+def test_transfer_prepare_has_five_second_cooldown_for_all_senders():
+    repo_root = Path(__file__).resolve().parents[1]
+    transaction_source = (repo_root / "src/market/transactions.cc").read_text()
+    transaction_header = (repo_root / "src/market/transactions.h").read_text()
+    transaction_rules = (repo_root / "src/market/transaction_rules.h").read_text()
+
+    assert "constexpr int kTransferCooldownSeconds = 5;" in transaction_rules
+    assert "Cooldown," in transaction_header
+    assert "int transfer_cooldown_seconds_remaining" in transaction_header
+    assert 'FROM "transactions"' in transaction_source
+    assert "WHERE sender = $1" in transaction_source
+    assert "MAX(transactiontime)" in transaction_source
+    assert "LOCALTIMESTAMP - MAX(transactiontime)" in transaction_source
+    assert "transfer_cooldown_seconds_remaining(sender, pool_ptr) > 0" in transaction_source
+    assert "transfer_cooldown_seconds_remaining(transaction->sender, pool_ptr) > 0" in transaction_source
+    assert transaction_source.count("TransactionStatus::Cooldown") >= 3
+    assert transaction_source.count("restinio::status_too_many_requests()") >= 2
+    assert transaction_source.count('append_header("Retry-After", std::to_string(kTransferCooldownSeconds))') >= 2
+    assert transaction_source.count('set_body("transfer cooldown active")') >= 2


### PR DESCRIPTION
## Summary
- enforce a 5-second cooldown after completed outgoing transfers in /transactions/prepare
- return HTTP 429 with Retry-After when the cooldown is active
- include frontend submodule update for user-facing cooldown feedback: letovo-dev/letovo-all-frontend#29

Fixes #133

## Tests
- python3 -m pytest test/test_transaction_rules.py
- node scripts/check-transfer-payment-state.cjs (frontend)
- ./node_modules/.bin/prettier --check scripts/check-transfer-payment-state.cjs src/features/moneyTranfer/ui/TransferModal26.tsx src/features/moneyTranfer/ui/TransferModal26.module.scss src/shared/stores/user-store/index.ts (frontend)
- git diff --check

## Notes
- Local frontend tsc is currently blocked by stale .next/types entries for missing app routes.
- Local CMake build is currently blocked by generated OpenTelemetry protobuf files being newer than installed protobuf headers.