### PR TITLE
feat: add transfer history

### DIFF
--- a/src/market/transactions.cc
+++ b/src/market/transactions.cc
@@ -209,7 +209,13 @@ namespace transactions {
     pqxx::result get_transactions(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
         auto con = std::move(pool_ptr->getConnection());
         std::vector<std::string> params = {username};
-        pqxx::result result = con->execute_params("SELECT * FROM \"transactions\" WHERE sender=($1) OR receiver=($1);", params);
+        pqxx::result result = con->execute_params(
+            "SELECT * FROM \"transactions\" "
+            "WHERE (sender=($1) OR receiver=($1)) "
+            "AND transactiontime >= LOCALTIMESTAMP - INTERVAL '7 days' "
+            "ORDER BY transactiontime DESC, transactionid DESC "
+            "LIMIT 100;",
+            params);
         pool_ptr->returnConnection(std::move(con));
         if (result.empty()) {
             return {};

--- a/test/test_user_full_payments_metadata.py
+++ b/test/test_user_full_payments_metadata.py
@@ -55,3 +55,14 @@ def test_private_user_endpoint_stays_owner_admin_only():
 
     assert "security::is_same_user_or_admin(actor, username, pool_ptr)" in handler
     assert "status_forbidden" in handler
+
+
+def test_transaction_history_is_recent_ordered_and_bounded():
+    source = TRANSACTIONS_CC.read_text()
+    query_start = source.index("pqxx::result get_transactions(")
+    query_end = source.index("std::string last_incoming_outgoing_payments_json", query_start)
+    query = source[query_start:query_end]
+
+    assert "LOCALTIMESTAMP - INTERVAL '7 days'" in query
+    assert "ORDER BY transactiontime DESC, transactionid DESC" in query
+    assert "LIMIT 100" in query


### PR DESCRIPTION
Closes #136.

- bounds /transactions/my to the newest 100 rows from the past seven days
- orders results deterministically by timestamp and transaction id
- updates the frontend submodule to the transfer-history UI

Validation: backend payment metadata contract passes; frontend targeted contract, TypeScript, formatting, and transfer-state checks pass.

Frontend PR: letovo-dev/letovo-all-frontend#31