### PR TITLE
feat(profile): add private avatar uploads

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -375,6 +375,8 @@ jobs:
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.role > "$role_backup"
           test -s "$role_backup"
+          # Forward-only additive migration: never restore the whole role table
+          # automatically, because that could erase concurrent permission edits.
           docker cp "$migration" letovo-postgres-1:/tmp/avatar_upload_role_migration.sql
           docker exec letovo-postgres-1 \
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
@@ -447,5 +449,7 @@ jobs:
 
           docker compose -p "$PROJECT_NAME" -f "$candidate" pull letovo-server letovo-registration-server letovo-front || true
           docker compose -p "$PROJECT_NAME" -f "$candidate" up -d letovo-server letovo-registration-server letovo-front
+          # The additive schema migration intentionally remains in place. The
+          # retained role dump is for explicit operator recovery only.
           rm -rf "$state_dir"
           REMOTE

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -349,6 +349,10 @@ jobs:
         run: |
           set -euo pipefail
           remote="${LETOVO_E2E_DEPLOY_USER}@${LETOVO_E2E_DEPLOY_HOST}"
+          state_dir="/tmp/letovo-live-e2e-${{ github.run_id }}"
+          ssh -i ~/.ssh/live-e2e "$remote" "mkdir -p '$state_dir'"
+          scp -i ~/.ssh/live-e2e docs/avatar_upload_role_migration.sql \
+            "$remote:$state_dir/avatar_upload_role_migration.sql"
           ssh -i ~/.ssh/live-e2e "$remote" \
             "BACKEND_IMAGE='$BACKEND_CANDIDATE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_CANDIDATE_IMAGE' FRONTEND_IMAGE='$FRONTEND_CANDIDATE_IMAGE' COMPOSE_FILE='$LETOVO_E2E_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_E2E_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
           set -euo pipefail
@@ -357,10 +361,25 @@ jobs:
           mkdir -p "$state_dir"
           restore="$state_dir/restore.env"
           candidate="$state_dir/docker-compose.yaml"
+          migration="$state_dir/avatar_upload_role_migration.sql"
+          backup_root="$HOME/backups/letovo-live-e2e-${RUN_ID}"
+          role_backup="$backup_root/role.before-avatar-migration.sql"
+
+          test -f "$migration"
+          mkdir -p "$backup_root"
 
           docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
           docker inspect -f 'letovo-registration-server={{.Config.Image}}' letovo-registration-server >> "$restore"
           docker inspect -f 'letovo-front={{.Config.Image}}' letovo-front >> "$restore"
+
+          docker exec letovo-postgres-1 \
+            pg_dump -U scv -d letovo_db -t public.role > "$role_backup"
+          test -s "$role_backup"
+          docker cp "$migration" letovo-postgres-1:/tmp/avatar_upload_role_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
+              -f /tmp/avatar_upload_role_migration.sql
+          docker exec letovo-postgres-1 rm -f /tmp/avatar_upload_role_migration.sql
 
           sed -E \
             -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${BACKEND_IMAGE}#" \

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -318,6 +318,8 @@ jobs:
           test -s "$role_backup_tmp"
           as_root mkdir -p "$backup_root"
           as_root install -m 0600 "$role_backup_tmp" "$role_backup"
+          # Forward-only additive migration: automatic table restoration could
+          # erase permission edits made while release verification is running.
           docker cp "$migration" letovo-postgres-1:/tmp/avatar_upload_role_migration.sql
           docker exec letovo-postgres-1 \
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
@@ -509,5 +511,7 @@ jobs:
           test "$(docker inspect -f '{{.Config.Image}}' letovo-server)" = "$backend_image"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-registration-server)" = "$registration_image"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-front)" = "$frontend_image"
+          # Keep the backward-compatible schema migration. The durable role
+          # dump is reserved for deliberate operator recovery, not blind rollback.
           rm -rf "$state_dir"
           REMOTE

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -252,6 +252,8 @@ jobs:
           scp -i ~/.ssh/letovo-production-release docs/otel-collector-config.yaml "$remote:$state_dir/otel-collector-config.yaml.from-repo"
           scp -i ~/.ssh/letovo-production-release frontend/front-env.env "$remote:$state_dir/letovo-front.env.from-repo"
           scp -i ~/.ssh/letovo-production-release scripts/patch_nginx_otel.py "$remote:$state_dir/patch_nginx_otel.py"
+          scp -i ~/.ssh/letovo-production-release docs/avatar_upload_role_migration.sql \
+            "$remote:$state_dir/avatar_upload_role_migration.sql"
           ssh -i ~/.ssh/letovo-production-release "$remote" \
             "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' NGINX_SITE='$LETOVO_PROD_NGINX_SITE' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
           set -euo pipefail
@@ -268,11 +270,15 @@ jobs:
           repo_compose="$state_dir/docker-compose.yaml.from-repo"
           repo_otel="$state_dir/otel-collector-config.yaml.from-repo"
           repo_front_env="$state_dir/letovo-front.env.from-repo"
+          migration="$state_dir/avatar_upload_role_migration.sql"
           nginx_candidate="$state_dir/nginx-site.candidate"
           compose_dir="$(dirname "$COMPOSE_FILE")"
           otel_config="$compose_dir/otel-collector-config.yaml"
           front_env="/mnt/letovo-front.env"
           smoke_name="letovo-server-release-smoke-${RUN_ID}"
+          backup_root="$(dirname "$(dirname "$COMPOSE_FILE")")/backups/production-release-${RUN_ID}"
+          role_backup="$backup_root/role.before-avatar-migration.sql"
+          role_backup_tmp="$state_dir/role.before-avatar-migration.sql"
 
           as_root() {
             if [ "$(id -u)" -eq 0 ]; then
@@ -288,6 +294,7 @@ jobs:
           test -f "$repo_compose"
           test -f "$repo_otel"
           test -f "$repo_front_env"
+          test -f "$migration"
           docker rm -f "$smoke_name" >/dev/null 2>&1 || true
           cleanup_smoke() {
             docker rm -f "$smoke_name" >/dev/null 2>&1 || true
@@ -305,6 +312,17 @@ jobs:
           docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
           docker inspect -f 'letovo-registration-server={{.Config.Image}}' letovo-registration-server >> "$restore"
           docker inspect -f 'letovo-front={{.Config.Image}}' letovo-front >> "$restore"
+
+          docker exec letovo-postgres-1 \
+            pg_dump -U scv -d letovo_db -t public.role > "$role_backup_tmp"
+          test -s "$role_backup_tmp"
+          as_root mkdir -p "$backup_root"
+          as_root install -m 0600 "$role_backup_tmp" "$role_backup"
+          docker cp "$migration" letovo-postgres-1:/tmp/avatar_upload_role_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
+              -f /tmp/avatar_upload_role_migration.sql
+          docker exec letovo-postgres-1 rm -f /tmp/avatar_upload_role_migration.sql
 
           sed \
             -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${BACKEND_IMAGE}#" \

--- a/docs/avatar_upload_role_migration.sql
+++ b/docs/avatar_upload_role_migration.sql
@@ -1,14 +1,32 @@
 BEGIN;
+
+CREATE TEMP TABLE avatar_upload_migration_state ON COMMIT DROP AS
+SELECT NOT EXISTS (
+  SELECT 1
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'role'
+    AND column_name = 'ava_upload'
+) AS column_was_missing;
+
 ALTER TABLE public.role
   ADD COLUMN IF NOT EXISTS ava_upload boolean NOT NULL DEFAULT false;
 
-UPDATE public.role r SET ava_upload = true
-FROM public."user" u
-WHERE r.username = u.username
+UPDATE public.role r
+SET ava_upload = true
+FROM public."user" u, avatar_upload_migration_state state
+WHERE state.column_was_missing
+  AND r.username = u.username
   AND COALESCE(u.userrights <> 'child', false);
 
 INSERT INTO public.role (username, ava_upload)
-SELECT u.username, true FROM public."user" u
-WHERE COALESCE(u.userrights <> 'child', false)
-  AND NOT EXISTS (SELECT 1 FROM public.role r WHERE r.username = u.username);
+SELECT u.username, true
+FROM public."user" u
+CROSS JOIN avatar_upload_migration_state state
+WHERE state.column_was_missing
+  AND COALESCE(u.userrights <> 'child', false)
+  AND NOT EXISTS (
+    SELECT 1 FROM public.role r WHERE r.username = u.username
+  );
+
 COMMIT;

--- a/docs/avatar_upload_role_migration.sql
+++ b/docs/avatar_upload_role_migration.sql
@@ -4,10 +4,11 @@ ALTER TABLE public.role
 
 UPDATE public.role r SET ava_upload = true
 FROM public."user" u
-WHERE r.username = u.username AND u.userrights <> 'child';
+WHERE r.username = u.username
+  AND COALESCE(u.userrights <> 'child', false);
 
 INSERT INTO public.role (username, ava_upload)
 SELECT u.username, true FROM public."user" u
-WHERE u.userrights <> 'child'
+WHERE COALESCE(u.userrights <> 'child', false)
   AND NOT EXISTS (SELECT 1 FROM public.role r WHERE r.username = u.username);
 COMMIT;

--- a/docs/avatar_upload_role_migration.sql
+++ b/docs/avatar_upload_role_migration.sql
@@ -1,0 +1,13 @@
+BEGIN;
+ALTER TABLE public.role
+  ADD COLUMN IF NOT EXISTS ava_upload boolean NOT NULL DEFAULT false;
+
+UPDATE public.role r SET ava_upload = true
+FROM public."user" u
+WHERE r.username = u.username AND u.userrights <> 'child';
+
+INSERT INTO public.role (username, ava_upload)
+SELECT u.username, true FROM public."user" u
+WHERE u.userrights <> 'child'
+  AND NOT EXISTS (SELECT 1 FROM public.role r WHERE r.username = u.username);
+COMMIT;

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -681,7 +681,8 @@ CREATE TABLE public.role (
     admin boolean,
     moder boolean,
     main_page boolean,
-    whireable boolean DEFAULT false
+    whireable boolean DEFAULT false,
+    ava_upload boolean DEFAULT false NOT NULL
 );
 
 

--- a/src/basic/auth.cc
+++ b/src/basic/auth.cc
@@ -281,7 +281,7 @@ bool is_rights_by_username(const std::string& username,
                            std::shared_ptr<cp::ConnectionsManager> pool_ptr,
                            const std::string& rights) {
   static const std::unordered_set<std::string> allowed = {
-      "write_posts", "admin", "moder", "main_page", "whireable"};
+      "write_posts", "admin", "moder", "main_page", "whireable", "ava_upload"};
   if (!allowed.count(rights)) {
     return false;
   }
@@ -486,10 +486,10 @@ created_user AS (
   RETURNING username, display_name, userrights, role, active, registered, chattable
 ),
 created_permission AS (
-  INSERT INTO role (username, write_posts, admin, moder, main_page)
+  INSERT INTO role (username, write_posts, admin, moder, main_page, ava_upload)
   SELECT
     created_user.username, ($12)::boolean, ($13)::boolean,
-    ($14)::boolean, ($15)::boolean
+    ($14)::boolean, ($15)::boolean, created_user.userrights <> 'child'
   FROM created_user
   -- RETURNING created_user.username
   RETURNING username
@@ -958,18 +958,22 @@ void am_i_uploader(
           return req->create_response(restinio::status_unauthorized()).done();
         }
         std::string username = auth::get_username(token, pool_ptr);
-        if (auth::is_rights_by_username(username, pool_ptr, "moder") ||
-            auth::is_rights_by_username(username, pool_ptr, "admin")) {
-          return req->create_response(restinio::status_ok())
-              .set_body("{\"status\": \"t\"}")
+        if (username.empty()) return req->create_response(restinio::status_unauthorized()).done();
+        const bool generic = auth::is_rights_by_username(username, pool_ptr, "moder") ||
+                             auth::is_rights_by_username(username, pool_ptr, "admin");
+        cp::SafeCon con{pool_ptr};
+        const auto avatar_rows = con->execute_params(
+            "SELECT 1 FROM \"user\" u LEFT JOIN \"role\" r ON r.username=u.username "
+            "WHERE u.username=($1) AND u.active=true AND u.userrights <> 'child' AND "
+            "(COALESCE(r.ava_upload,false)=true OR COALESCE(r.admin,false)=true OR COALESCE(r.moder,false)=true);",
+            std::vector<std::string>{username});
+        const bool avatar = !avatar_rows.empty();
+        return req->create_response(restinio::status_ok())
+              .set_body("{\"status\": \"" + std::string(generic ? "t" : "f") +
+                        "\", \"avatar_status\": \"" + std::string(avatar ? "t" : "f") +
+                        "\", \"username\": \"" + username + "\"}")
               .append_header("Content-Type", "application/json; charset=utf-8")
               .done();
-        } else {
-          return req->create_response(restinio::status_ok())
-              .set_body("{\"status\": \"f\"}")
-              .append_header("Content-Type", "application/json; charset=utf-8")
-              .done();
-        }
       });
 }
 

--- a/src/basic/auth.cc
+++ b/src/basic/auth.cc
@@ -4,6 +4,8 @@
 #include "../market/transactions.h"
 
 #include <regex>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 #include <stdexcept>
 #include <sstream>
 
@@ -68,10 +70,39 @@ bool post_reveal_tokens_columns_exist(
   return !result.empty() && result[0]["count"].as<int>() == 6;
 }
 
+bool avatar_upload_column_exists(
+    std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+  cp::SafeCon con{pool_ptr};
+  std::vector<std::string> params = {};
+  pqxx::result result = con->execute_params(
+      "SELECT COUNT(*) AS count FROM information_schema.columns "
+      "WHERE table_schema = 'public' AND table_name = 'role' "
+      "AND column_name = 'ava_upload';",
+      params);
+  return !result.empty() && result[0]["count"].as<int>() == 1;
+}
+
 bool auth_migrations_ready(std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
   return password_metadata_columns_exist(pool_ptr) &&
          user_sessions_columns_exist(pool_ptr) &&
-         post_reveal_tokens_columns_exist(pool_ptr);
+         post_reveal_tokens_columns_exist(pool_ptr) &&
+         avatar_upload_column_exists(pool_ptr);
+}
+
+std::string uploader_capabilities_json(bool generic, bool avatar,
+                                       const std::string &username) {
+  rapidjson::Document doc;
+  doc.SetObject();
+  auto &allocator = doc.GetAllocator();
+  doc.AddMember("status", generic ? "t" : "f", allocator);
+  doc.AddMember("avatar_status", avatar ? "t" : "f", allocator);
+  doc.AddMember("username",
+                rapidjson::Value(username.c_str(), username.size(), allocator),
+                allocator);
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  doc.Accept(writer);
+  return std::string(buffer.GetString(), buffer.GetSize());
 }
 
 const std::regex kAdminUsernameRegex("^[A-Za-z0-9_-]{4,32}$");
@@ -970,9 +1001,7 @@ void am_i_uploader(
             avatar_params);
         const bool avatar = !avatar_rows.empty();
         return req->create_response(restinio::status_ok())
-              .set_body("{\"status\": \"" + std::string(generic ? "t" : "f") +
-                        "\", \"avatar_status\": \"" + std::string(avatar ? "t" : "f") +
-                        "\", \"username\": \"" + username + "\"}")
+              .set_body(uploader_capabilities_json(generic, avatar, username))
               .append_header("Content-Type", "application/json; charset=utf-8")
               .done();
       });

--- a/src/basic/auth.cc
+++ b/src/basic/auth.cc
@@ -520,7 +520,8 @@ created_permission AS (
   INSERT INTO role (username, write_posts, admin, moder, main_page, ava_upload)
   SELECT
     created_user.username, ($12)::boolean, ($13)::boolean,
-    ($14)::boolean, ($15)::boolean, created_user.userrights <> 'child'
+    ($14)::boolean, ($15)::boolean,
+    COALESCE(created_user.userrights <> 'child', false)
   FROM created_user
   -- RETURNING created_user.username
   RETURNING username

--- a/src/basic/auth.cc
+++ b/src/basic/auth.cc
@@ -962,11 +962,12 @@ void am_i_uploader(
         const bool generic = auth::is_rights_by_username(username, pool_ptr, "moder") ||
                              auth::is_rights_by_username(username, pool_ptr, "admin");
         cp::SafeCon con{pool_ptr};
+        std::vector<std::string> avatar_params = {username};
         const auto avatar_rows = con->execute_params(
             "SELECT 1 FROM \"user\" u LEFT JOIN \"role\" r ON r.username=u.username "
             "WHERE u.username=($1) AND u.active=true AND u.userrights <> 'child' AND "
             "(COALESCE(r.ava_upload,false)=true OR COALESCE(r.admin,false)=true OR COALESCE(r.moder,false)=true);",
-            std::vector<std::string>{username});
+            avatar_params);
         const bool avatar = !avatar_rows.empty();
         return req->create_response(restinio::status_ok())
               .set_body("{\"status\": \"" + std::string(generic ? "t" : "f") +

--- a/src/basic/checks.cc
+++ b/src/basic/checks.cc
@@ -35,7 +35,8 @@ void check_auth_migrations(std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
   if (!auth::migrations_ready(pool_ptr)) {
     pre_run_checks::print(
         "auth/session migration is missing or incomplete; apply "
-        "docs/security_sessions_migration.sql before starting this binary",
+        "docs/security_sessions_migration.sql and "
+        "docs/avatar_upload_role_migration.sql before starting this binary",
         91);
     throw std::runtime_error("auth/session migrations are required");
   }

--- a/src/basic/user_data.cc
+++ b/src/basic/user_data.cc
@@ -989,6 +989,10 @@ void set_avatar(std::unique_ptr<restinio::router::express_router_t<>> &router,
     logger_ptr->trace([] { return "called /user/set_avatar"; });
     rapidjson::Document new_body;
     new_body.Parse(req->body().c_str());
+    if (new_body.HasParseError() || !new_body.IsObject() ||
+        !new_body.HasMember("avatar") || !new_body["avatar"].IsString()) {
+      return req->create_response(restinio::status_bad_request()).done();
+    }
 
     std::string token = security::bearer_or_cookie_token(req->header());
             if(token.empty()) {

--- a/src/basic/user_data.cc
+++ b/src/basic/user_data.cc
@@ -128,6 +128,11 @@ pqxx::result full_user_info(std::string username,
       "\"user\".balance, \"user\".registered, \"user\".jointime, "
       "\"user\".avatar_pic, \"user\".active, \"user\".times_visited, "
       "\"user\".brigade, "
+      "(CASE WHEN (COALESCE(permission_role.ava_upload, false) = true "
+      "OR COALESCE(permission_role.admin, false) = true "
+      "OR COALESCE(permission_role.moder, false) = true) "
+      "AND \"user\".active=true AND \"user\".userrights <> 'child' "
+      "THEN true ELSE false END) AS can_upload_avatar, "
       "(CASE WHEN COALESCE(permission_role.admin, false) = true "
       "OR COALESCE(permission_role.moder, false) = true "
       "OR COALESCE(\"user\".userrights, '') IN ('admin', 'moder') "
@@ -456,7 +461,15 @@ void set_avatar(std::string username, std::string avatar,
 
 }
 
-std::vector<std::string> all_avatars(bool is_admin) {
+static std::string personal_avatar_relative(const std::string &username) {
+  return "/images/personal_avatars/" + security::sha256_hex(username) + "/";
+}
+
+static std::filesystem::path media_root() {
+  return std::filesystem::path(Config::giveMe().pages_config.media_path.absolute);
+}
+
+std::vector<std::string> all_avatars(const std::string &username, bool is_admin) {
   std::vector<std::string> avatars;
   for (const auto &entry : std::filesystem::directory_iterator(
            Config::giveMe().pages_config.user_avatars_path.absolute)) {
@@ -476,7 +489,31 @@ std::vector<std::string> all_avatars(bool is_admin) {
       }
     }
   }
+  const auto relative = personal_avatar_relative(username);
+  const auto directory = media_root() / relative.substr(1);
+  if (std::filesystem::exists(directory)) {
+    for (const auto &entry : std::filesystem::directory_iterator(directory)) {
+      if (std::filesystem::is_regular_file(entry.status()))
+        avatars.push_back(relative + entry.path().filename().string());
+    }
+  }
   return avatars;
+}
+
+bool can_use_avatar(const std::string &username, const std::string &avatar,
+                    bool is_admin) {
+  if (avatar.empty() || avatar[0] != '/' || avatar.find("..") != std::string::npos ||
+      avatar.find('\\') != std::string::npos) return false;
+  const auto shared = Config::giveMe().pages_config.user_avatars_path.relative;
+  const auto admin = Config::giveMe().pages_config.admin_avatars_path.relative;
+  const auto personal = personal_avatar_relative(username);
+  if (avatar.rfind(shared, 0) != 0 && !(is_admin && avatar.rfind(admin, 0) == 0) &&
+      avatar.rfind(personal, 0) != 0) return false;
+  std::error_code ec;
+  const auto root = std::filesystem::weakly_canonical(media_root(), ec);
+  const auto file = std::filesystem::weakly_canonical(media_root() / avatar.substr(1), ec);
+  return !ec && file.string().rfind(root.string() + "/", 0) == 0 &&
+         std::filesystem::is_regular_file(file, ec);
 }
 } // namespace user
 
@@ -932,10 +969,14 @@ void all_avatars(
             if(token.empty()) {
                 return req->create_response(restinio::status_unauthorized()).done();
             }
+    std::string username = auth::get_username(token, pool_ptr);
+    if (username.empty()) {
+      return req->create_response(restinio::status_unauthorized()).done();
+    }
     return req->create_response()
         .append_header("Content-Type", "application/json; charset=utf-8")
-        .set_body(
-            cp::serialize(user::all_avatars(auth::is_admin(token, pool_ptr))))
+        .set_body(cp::serialize(
+            user::all_avatars(username, auth::is_admin(token, pool_ptr))))
         .done();
   });
 }
@@ -965,6 +1006,9 @@ void set_avatar(std::unique_ptr<restinio::router::express_router_t<>> &router,
     if (new_body.HasMember("avatar")) {
       std::string username = auth::get_username(token, pool_ptr);
       std::string avatar = new_body["avatar"].GetString();
+      if (!user::can_use_avatar(username, avatar, auth::is_admin(token, pool_ptr))) {
+        return req->create_response(restinio::status_forbidden()).done();
+      }
       if (media::check_if_file_exists(avatar).empty()) {
         return req->create_response(restinio::status_bad_request())
             .append_header("Content-Type", "text/plain; charset=utf-8")

--- a/src/basic/user_data.h
+++ b/src/basic/user_data.h
@@ -76,7 +76,9 @@ pqxx::result all_departments(std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 void set_avatar(std::string username, std::string avatar,
                 std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
-std::vector<std::string> all_avatars(bool is_admin);
+std::vector<std::string> all_avatars(const std::string &username, bool is_admin);
+bool can_use_avatar(const std::string &username, const std::string &avatar,
+                    bool is_admin);
 
 } // namespace user
 

--- a/src/python-helpers/UploaderConfig.json
+++ b/src/python-helpers/UploaderConfig.json
@@ -2,6 +2,8 @@
     "admins": [],
     "media_url": "http://localhost/api/media/get/",
     "ava_path": "images/admin_avatars",
+    "personal_ava_path": "images/personal_avatars",
+    "max_avatar_size": 5242880,
     "paths": {
         "images": "images/uploaded",
         "videos": "videos/uploaded",

--- a/src/python-helpers/flask_uploader.py
+++ b/src/python-helpers/flask_uploader.py
@@ -35,9 +35,7 @@ def api_get_upload_capabilities(token: str, cookie: str = ""):
         result = r.json()
         if not isinstance(result, dict):
             return None
-        if result.get("status") not in {"t", "f"} or result.get("avatar_status") not in {"t", "f"}:
-            return None
-        if not isinstance(result.get("username"), str) or not result["username"]:
+        if result.get("status") not in {"t", "f"}:
             return None
         return result
     except (requests.RequestException, ValueError, TypeError, KeyError):
@@ -88,7 +86,8 @@ def upload_avatar():
     token = flask.request.headers.get('Bearer', None)
     capabilities = api_get_upload_capabilities(
         token, flask.request.headers.get('Cookie', ''))
-    if capabilities is None or capabilities.get("avatar_status") != "t":
+    if (capabilities is None or capabilities.get("avatar_status") != "t" or
+            not isinstance(capabilities.get("username"), str) or not capabilities["username"]):
         return "Forbidden", 403
     supplied_extension = file.filename.rsplit('.', 1)[-1].lower() if '.' in file.filename else ""
     if supplied_extension not in {"png", "jpg", "jpeg", "webp"}:

--- a/src/python-helpers/flask_uploader.py
+++ b/src/python-helpers/flask_uploader.py
@@ -3,25 +3,58 @@ import json, os
 import requests
 from datetime import datetime
 import hashlib
+import uuid
 
 # docker build -f dockerfile.uploader -t flask-uploader:latest .
 
 app = flask.Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 100 * 1024 * 1024 * 10
 
+
 ROOT_PATH = "/app/pages"
 current_path = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(current_path, 'UploaderConfig.json'), 'r') as f:
     config = json.load(f)
+MAX_AVATAR_SIZE = int(config.get("max_avatar_size", 5 * 1024 * 1024))
 
-def api_check_admin(token: str):
+def api_get_upload_capabilities(token: str, cookie: str = ""):
     if not config["check_admin"]:
-        return True
-    if not token:
-        return False
+        return {"status": "t", "avatar_status": "t", "username": "local"}
+    if not token and not cookie:
+        return None
     auth_url = config.get("auth_check_url", "https://letovocorp.ru/letovo-api/auth/amiuploader")
-    r = requests.get(auth_url, headers={"Bearer": token})
-    return json.loads(r.text)["status"] == 't'
+    try:
+        headers = {}
+        if token:
+            headers["Bearer"] = token
+        if cookie:
+            headers["Cookie"] = cookie
+        r = requests.get(auth_url, headers=headers, timeout=5)
+        if r.status_code != 200:
+            return None
+        result = r.json()
+        if not isinstance(result, dict):
+            return None
+        if result.get("status") not in {"t", "f"} or result.get("avatar_status") not in {"t", "f"}:
+            return None
+        if not isinstance(result.get("username"), str) or not result["username"]:
+            return None
+        return result
+    except (requests.RequestException, ValueError, TypeError, KeyError):
+        return None
+
+def api_check_admin(token: str, cookie: str = ""):
+    capabilities = api_get_upload_capabilities(token, cookie)
+    return capabilities is not None and capabilities.get("status") == "t"
+
+def _detect_image_extension(data: bytes):
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "jpg"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "webp"
+    return None
 
 @app.route('/', methods=['POST'])
 def upload_file():
@@ -36,7 +69,7 @@ def upload_file():
     upload_category = config["supported"].get(extention, "other")
     file_path = os.path.join(ROOT_PATH, config["paths"][upload_category])
     token = flask.request.headers.get('Bearer', None)
-    if not api_check_admin(token):
+    if not api_check_admin(token, flask.request.headers.get('Cookie', '')):
         return "Forbidden", 403
     
     file.save(os.path.join(file_path, file.filename))
@@ -45,19 +78,37 @@ def upload_file():
 
 @app.route('/avatar', methods=['POST'])
 def upload_avatar():
+    if flask.request.content_length and flask.request.content_length > MAX_AVATAR_SIZE + 1024 * 1024:
+        return flask.jsonify(error="Файл аватара слишком большой"), 413
     if 'file' not in flask.request.files:
         return "No file part", 400
     file = flask.request.files['file']
     if file.filename == '':
         return "No selected file", 400
-    file_path = os.path.join(ROOT_PATH, config["ava_path"])
     token = flask.request.headers.get('Bearer', None)
-    if not api_check_admin(token):
+    capabilities = api_get_upload_capabilities(
+        token, flask.request.headers.get('Cookie', ''))
+    if capabilities is None or capabilities.get("avatar_status") != "t":
         return "Forbidden", 403
-    file.filename.replace(" ", "_")
-    file.filename = str(datetime.now().timestamp()).replace('.', '_') + "_" + file.filename
-    file.save(os.path.join(file_path, file.filename))
-    return '{"file": "/' + str(os.path.join(config["ava_path"], file.filename)) + '"}'
+    supplied_extension = file.filename.rsplit('.', 1)[-1].lower() if '.' in file.filename else ""
+    if supplied_extension not in {"png", "jpg", "jpeg", "webp"}:
+        return flask.jsonify(error="Поддерживаются только PNG, JPEG и WebP"), 400
+    data = file.read(MAX_AVATAR_SIZE + 1)
+    if not data:
+        return flask.jsonify(error="Файл аватара пуст"), 400
+    if len(data) > MAX_AVATAR_SIZE:
+        return flask.jsonify(error="Файл аватара слишком большой"), 413
+    extension = _detect_image_extension(data)
+    if extension is None or (extension == "jpg" and supplied_extension not in {"jpg", "jpeg"}) or (extension != "jpg" and extension != supplied_extension):
+        return flask.jsonify(error="Содержимое файла не является допустимым изображением"), 400
+    user_key = hashlib.sha256(capabilities["username"].encode("utf-8")).hexdigest()
+    relative_dir = os.path.join(config.get("personal_ava_path", "images/personal_avatars"), user_key)
+    file_path = os.path.join(ROOT_PATH, relative_dir)
+    os.makedirs(file_path, exist_ok=True)
+    filename = uuid.uuid4().hex + "." + extension
+    with open(os.path.join(file_path, filename), "wb") as target:
+        target.write(data)
+    return flask.jsonify(file="/" + os.path.join(relative_dir, filename).replace(os.sep, "/"))
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8880, debug=False, threaded=True, use_reloader=False)

--- a/test/e2e/live-platform-smoke.mjs
+++ b/test/e2e/live-platform-smoke.mjs
@@ -121,6 +121,21 @@ async function fetchAuthenticated(page, path, options = {}) {
   );
 }
 
+async function fillLoginForm(page, login, loginPassword) {
+  const loginInput = page.locator('#form_login');
+  const passwordInput = page.locator('#form_password');
+  const button = page.getByRole('button', { name: 'Войти' });
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await loginInput.fill(login);
+    await passwordInput.fill(loginPassword);
+    if (await button.isEnabled()) return button;
+    await page.waitForTimeout(250);
+  }
+
+  throw new Error('Login form did not become enabled after hydration');
+}
+
 async function loginAs(page, login, loginPassword) {
   await page.context().clearCookies();
   await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
@@ -132,15 +147,14 @@ async function loginAs(page, login, loginPassword) {
   await page.goto(`${baseUrl}/login`, { waitUntil: 'domcontentloaded' });
   await page.locator('#form_login').waitFor({ state: 'visible' });
   await page.locator('#form_password').waitFor({ state: 'visible' });
-  await page.locator('#form_login').fill(login);
-  await page.locator('#form_password').fill(loginPassword);
+  const loginButton = await fillLoginForm(page, login, loginPassword);
 
   const [loginResponse] = await Promise.all([
     page.waitForResponse((response) => {
       const url = new URL(response.url());
       return url.pathname.endsWith('/auth/login');
     }, { timeout: 60_000 }),
-    page.getByRole('button', { name: 'Войти' }).click(),
+    loginButton.click(),
   ]);
   assert(
     loginResponse.status() === 200,

--- a/test/test_flask_uploader.py
+++ b/test/test_flask_uploader.py
@@ -1,0 +1,68 @@
+import hashlib
+import importlib.util
+import io
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).parents[1] / "src/python-helpers/flask_uploader.py"
+spec = importlib.util.spec_from_file_location("flask_uploader", MODULE_PATH)
+uploader = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(uploader)
+PNG = b"\x89PNG\r\n\x1a\n" + b"x" * 32
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(uploader, "ROOT_PATH", str(tmp_path))
+    uploader.app.config["TESTING"] = True
+    return uploader.app.test_client(), tmp_path
+
+
+def auth(avatar="t", generic="f", username="alice"):
+    return {"avatar_status": avatar, "status": generic, "username": username}
+
+
+def test_avatar_permission_does_not_grant_generic_upload(client, monkeypatch):
+    c, _ = client
+    monkeypatch.setattr(uploader, "api_get_upload_capabilities", lambda token, cookie="": auth())
+    assert c.post("/", data={"file": (io.BytesIO(PNG), "x.png")}, headers={"Bearer": "x"}).status_code == 403
+    assert c.post("/avatar", data={"file": (io.BytesIO(PNG), "x.png")}, headers={"Bearer": "x"}).status_code == 200
+
+
+def test_avatar_generated_owner_path_and_magic_validation(client, monkeypatch):
+    c, root = client
+    monkeypatch.setattr(uploader, "api_get_upload_capabilities", lambda token, cookie="": auth())
+    response = c.post("/avatar", data={"file": (io.BytesIO(PNG), "../../evil.png")}, headers={"Bearer": "x"})
+    path = response.get_json()["file"]
+    key = hashlib.sha256(b"alice").hexdigest()
+    assert path.startswith(f"/images/personal_avatars/{key}/")
+    assert "evil" not in path and (root / path.lstrip("/")).is_file()
+    bad = c.post("/avatar", data={"file": (io.BytesIO(b"not image"), "x.png")}, headers={"Bearer": "x"})
+    assert bad.status_code == 400
+
+
+def test_avatar_rejects_bad_extension_and_oversize(client, monkeypatch):
+    c, _ = client
+    monkeypatch.setattr(uploader, "api_get_upload_capabilities", lambda token, cookie="": auth())
+    assert c.post("/avatar", data={"file": (io.BytesIO(PNG), "x.svg")}, headers={"Bearer": "x"}).status_code == 400
+    huge = PNG + b"x" * uploader.MAX_AVATAR_SIZE
+    assert c.post("/avatar", data={"file": (io.BytesIO(huge), "x.png")}, headers={"Bearer": "x"}).status_code == 413
+
+
+def test_cookie_auth_is_forwarded_to_backend(monkeypatch):
+    captured = {}
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return auth()
+
+    def fake_get(url, headers, timeout):
+        captured.update(headers)
+        return Response()
+
+    monkeypatch.setattr(uploader.requests, "get", fake_get)
+    assert uploader.api_get_upload_capabilities(None, "letovo_session=secret") == auth()
+    assert captured == {"Cookie": "letovo_session=secret"}

--- a/test/test_flask_uploader.py
+++ b/test/test_flask_uploader.py
@@ -66,3 +66,24 @@ def test_cookie_auth_is_forwarded_to_backend(monkeypatch):
     monkeypatch.setattr(uploader.requests, "get", fake_get)
     assert uploader.api_get_upload_capabilities(None, "letovo_session=secret") == auth()
     assert captured == {"Cookie": "letovo_session=secret"}
+
+
+def test_generic_upload_accepts_legacy_auth_response(monkeypatch, tmp_path):
+    monkeypatch.setitem(uploader.config, "check_admin", True)
+    monkeypatch.setattr(uploader, "ROOT_PATH", str(tmp_path))
+    monkeypatch.setitem(uploader.config, "paths", {"images": "images"})
+    monkeypatch.setitem(uploader.config, "supported", {"png": "images"})
+    (tmp_path / "images").mkdir()
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"status": "t"}
+
+    monkeypatch.setattr(uploader.requests, "get", lambda *args, **kwargs: Response())
+    response = uploader.app.test_client().post(
+        "/", data={"file": (io.BytesIO(PNG), "legacy.png")},
+        headers={"Bearer": "legacy"})
+    assert response.status_code == 200

--- a/test/test_issue141_avatar_contract.py
+++ b/test/test_issue141_avatar_contract.py
@@ -8,6 +8,9 @@ def test_schema_and_migration_contract():
     migration = (ROOT / "docs/avatar_upload_role_migration.sql").read_text()
     assert "ava_upload boolean DEFAULT false NOT NULL" in schema
     assert "ADD COLUMN IF NOT EXISTS ava_upload boolean NOT NULL DEFAULT false" in migration
+    assert "CREATE TEMP TABLE avatar_upload_migration_state" in migration
+    assert "column_was_missing" in migration
+    assert "state.column_was_missing" in migration
     assert "COALESCE(u.userrights <> 'child', false)" in migration
     assert "NOT EXISTS" in migration
 

--- a/test/test_issue141_avatar_contract.py
+++ b/test/test_issue141_avatar_contract.py
@@ -21,6 +21,8 @@ def test_backend_capability_and_path_authorization_contract():
     assert "userrights" in auth and "child" in auth
     assert "main_page, ava_upload" in auth
     assert "created_user.userrights <> 'child'" in auth
+    assert "std::vector<std::string> avatar_params" in auth
+    assert "avatar_params);" in auth
     assert "can_upload_avatar" in user
     assert "personal_avatars" in user
     assert "can_use_avatar" in user

--- a/test/test_issue141_avatar_contract.py
+++ b/test/test_issue141_avatar_contract.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_schema_and_migration_contract():
+    schema = (ROOT / "docs/schema.sql").read_text()
+    migration = (ROOT / "docs/avatar_upload_role_migration.sql").read_text()
+    assert "ava_upload boolean DEFAULT false NOT NULL" in schema
+    assert "ADD COLUMN IF NOT EXISTS ava_upload boolean NOT NULL DEFAULT false" in migration
+    assert "userrights <> 'child'" in migration
+    assert "NOT EXISTS" in migration
+
+
+def test_backend_capability_and_path_authorization_contract():
+    auth = (ROOT / "src/basic/auth.cc").read_text()
+    user = (ROOT / "src/basic/user_data.cc").read_text()
+    assert '"ava_upload"' in auth
+    assert "avatar_status" in auth
+    assert "username" in auth
+    assert "userrights" in auth and "child" in auth
+    assert "main_page, ava_upload" in auth
+    assert "created_user.userrights <> 'child'" in auth
+    assert "can_upload_avatar" in user
+    assert "personal_avatars" in user
+    assert "can_use_avatar" in user
+
+
+def test_uploader_is_scoped_and_validates_images():
+    uploader = (ROOT / "src/python-helpers/flask_uploader.py").read_text()
+    assert "api_get_upload_capabilities" in uploader
+    assert "avatar_status" in uploader
+    assert "personal_avatars" in uploader
+    assert "sha256" in uploader
+    assert "MAX_AVATAR_SIZE" in uploader
+    assert "_detect_image_extension" in uploader

--- a/test/test_issue141_avatar_contract.py
+++ b/test/test_issue141_avatar_contract.py
@@ -23,6 +23,10 @@ def test_backend_capability_and_path_authorization_contract():
     assert "created_user.userrights <> 'child'" in auth
     assert "std::vector<std::string> avatar_params" in auth
     assert "avatar_params);" in auth
+    assert "avatar_upload_column_exists" in auth
+    assert "uploader_capabilities_json" in auth
+    assert "HasParseError()" in user
+    assert 'new_body["avatar"].IsString()' in user
     assert "can_upload_avatar" in user
     assert "personal_avatars" in user
     assert "can_use_avatar" in user

--- a/test/test_issue141_avatar_contract.py
+++ b/test/test_issue141_avatar_contract.py
@@ -8,8 +8,15 @@ def test_schema_and_migration_contract():
     migration = (ROOT / "docs/avatar_upload_role_migration.sql").read_text()
     assert "ava_upload boolean DEFAULT false NOT NULL" in schema
     assert "ADD COLUMN IF NOT EXISTS ava_upload boolean NOT NULL DEFAULT false" in migration
-    assert "userrights <> 'child'" in migration
+    assert "COALESCE(u.userrights <> 'child', false)" in migration
     assert "NOT EXISTS" in migration
+
+
+def test_registration_grants_avatar_upload_fail_closed_for_nullable_userrights():
+    auth = (ROOT / "src/basic/auth.cc").read_text()
+
+    assert "COALESCE(created_user.userrights <> 'child', false)" in auth
+    assert "created_user.userrights <> 'child'\n" not in auth
 
 
 def test_backend_capability_and_path_authorization_contract():
@@ -20,7 +27,7 @@ def test_backend_capability_and_path_authorization_contract():
     assert "username" in auth
     assert "userrights" in auth and "child" in auth
     assert "main_page, ava_upload" in auth
-    assert "created_user.userrights <> 'child'" in auth
+    assert "COALESCE(created_user.userrights <> 'child', false)" in auth
     assert "std::vector<std::string> avatar_params" in auth
     assert "avatar_params);" in auth
     assert "avatar_upload_column_exists" in auth

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -78,6 +78,10 @@ def test_pr_build_publishes_candidate_images_before_live_e2e_gate():
     assert "LETOVO_E2E_DEPLOY_SSH_KEY" in workflow
     assert "LETOVO_E2E_DEPLOY_PROJECT" in workflow
     assert "Deploy PR candidate images to live e2e" in workflow
+    assert "scp -i ~/.ssh/live-e2e docs/avatar_upload_role_migration.sql" in workflow
+    assert "pg_dump -U scv -d letovo_db -t public.role" in workflow
+    assert "psql -v ON_ERROR_STOP=1 -U scv -d letovo_db" in workflow
+    assert "avatar_upload_role_migration.sql" in workflow
     assert "docker compose -p \"$PROJECT_NAME\" -f \"$candidate\" up -d letovo-server letovo-registration-server letovo-front" in workflow
     assert "Restore live deployment images" in workflow
 
@@ -132,6 +136,10 @@ def test_production_release_is_manual_deploy_with_required_live_e2e_gate():
     assert "scp -i ~/.ssh/letovo-production-release docs/otel-collector-config.yaml" in workflow
     assert "scp -i ~/.ssh/letovo-production-release frontend/front-env.env" in workflow
     assert "scp -i ~/.ssh/letovo-production-release scripts/patch_nginx_otel.py" in workflow
+    assert "scp -i ~/.ssh/letovo-production-release docs/avatar_upload_role_migration.sql" in workflow
+    assert "pg_dump -U scv -d letovo_db -t public.role" in workflow
+    assert "psql -v ON_ERROR_STOP=1 -U scv -d letovo_db" in workflow
+    assert "role.before-avatar-migration.sql" in workflow
     assert "otel-collector-config.yaml.before-release" in workflow
     assert "letovo-front.env.before-release" in workflow
     assert "nginx-site.before-release" in workflow

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -202,6 +202,9 @@ def test_live_e2e_uses_condition_polling_and_browser_level_checks():
     assert "page.goto(`${baseUrl}/login`" in script
     assert "page.locator('#form_login')" in script
     assert "page.locator('#form_password')" in script
+    assert "async function fillLoginForm" in script
+    assert "await button.isEnabled()" in script
+    assert "Login form did not become enabled after hydration" in script
     assert "page.getByRole('button', { name: 'Войти' })" in script
     assert "url.pathname.endsWith('/auth/login')" in script
     assert "JSON.parse(response.text)" in script


### PR DESCRIPTION
Closes #141

## Что сделано

- добавлена capability `role.ava_upload`; миграция выдаёт её существующим non-child аккаунтам независимо от текущего `active`, а runtime отдельно требует `user.active = true`
- child определяется строго как `user.userrights = 'child'`; `NULL` обрабатывается fail-closed через `COALESCE(..., false)`
- `/auth/amiuploader` по-прежнему разрешает общий media upload только admin/moder, но отдельно возвращает право личного аватара и доверенный username
- uploader принимает только PNG/JPEG/WebP до 5 MiB, проверяет magic bytes и сохраняет случайное имя в `images/personal_avatars/<sha256(username)>/`
- список аватаров включает только общие и личные файлы текущего пользователя
- `set_avatar` запрещает traversal и выбор чужого personal avatar
- frontend: letovo-dev/letovo-all-frontend#34

## Безопасное развёртывание

- PR live E2E и production release перед запуском нового backend сохраняют дамп `public.role`
- затем автоматически применяют `docs/avatar_upload_role_migration.sql` с `ON_ERROR_STOP=1`; backfill выполняется только при первом добавлении колонки и не возвращает позднее отозванные права
- миграция выполняется до pre-deploy smoke, потому что новый backend намеренно отказывается стартовать без `role.ava_upload`
- миграция forward-only: добавленная колонка обратно совместима со старым backend, поэтому image rollback не восстанавливает всю таблицу `role` и не затирает параллельные изменения прав; дамп сохраняется для явного operator recovery

## Проверка

- focused Python contracts: `18 passed`
- SQL migration: два последовательных запуска на PostgreSQL 16; adult=true, child=false, NULL=false
- frontend contract + `npx tsc --noEmit`
- frontend production build
- полный CI собирает C++ images и запускает live browser E2E на candidate images

