### PR TITLE
Переводы: покрыть правило whireable регрессионными тестами

### DIFF
--- a/src/market/transaction_rules.h
+++ b/src/market/transaction_rules.h
@@ -13,4 +13,8 @@ inline bool can_transfer_amount(int sender_balance, int amount, bool sender_is_a
     return effective_sender_balance >= amount;
 }
 
+inline bool has_whireable_participant(bool sender_whireable, bool receiver_whireable) {
+    return sender_whireable || receiver_whireable;
+}
+
 } // namespace transactions

--- a/src/market/transactions.cc
+++ b/src/market/transactions.cc
@@ -74,7 +74,11 @@ namespace transactions {
     }
 
     bool has_whireable_participant(std::string sender, std::string receiver, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
-        return can_receive_transfer(sender, pool_ptr) || can_receive_transfer(receiver, pool_ptr);
+        const bool sender_whireable = can_receive_transfer(sender, pool_ptr);
+        if (sender_whireable) {
+            return true;
+        }
+        return has_whireable_participant(sender_whireable, can_receive_transfer(receiver, pool_ptr));
     }
 
     int transfer_cooldown_seconds_remaining(std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {

--- a/test/test_transaction_rules.py
+++ b/test/test_transaction_rules.py
@@ -34,12 +34,46 @@ def test_admin_negative_transaction_ignores_receiver_balance(tmp_path):
     subprocess.run([str(binary)], check=True)
 
 
+def test_whireable_role_allows_either_transfer_participant(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    source = tmp_path / "whireable_transfer_rules_check.cpp"
+    binary = tmp_path / "whireable_transfer_rules_check"
+
+    source.write_text(
+        textwrap.dedent(
+            f"""
+            #include "{repo_root / "src/market/transaction_rules.h"}"
+
+            int main() {{
+                if (!transactions::has_whireable_participant(true, false)) {{
+                    return 1;
+                }}
+                if (!transactions::has_whireable_participant(false, true)) {{
+                    return 2;
+                }}
+                if (transactions::has_whireable_participant(false, false)) {{
+                    return 3;
+                }}
+                return 0;
+            }}
+            """
+        )
+    )
+
+    subprocess.run(
+        ["g++", "-std=c++20", str(source), "-o", str(binary)],
+        check=True,
+    )
+    subprocess.run([str(binary)], check=True)
+
+
 def test_whireable_role_is_required_for_at_least_one_transfer_participant():
     repo_root = Path(__file__).resolve().parents[1]
     auth_header = (repo_root / "src/basic/auth.h").read_text()
     auth_source = (repo_root / "src/basic/auth.cc").read_text()
     transaction_source = (repo_root / "src/market/transactions.cc").read_text()
     transaction_header = (repo_root / "src/market/transactions.h").read_text()
+    transaction_rules = (repo_root / "src/market/transaction_rules.h").read_text()
     schema = (repo_root / "docs/schema.sql").read_text()
     migration = (repo_root / "docs/whireable_role_migration.sql").read_text()
 
@@ -48,7 +82,8 @@ def test_whireable_role_is_required_for_at_least_one_transfer_participant():
     assert "bool can_receive_transfer" in transaction_header
     assert "bool has_whireable_participant" in transaction_header
     assert 'auth::is_rights_by_username(username, pool_ptr, "whireable")' in transaction_source
-    assert "can_receive_transfer(sender, pool_ptr) || can_receive_transfer(receiver, pool_ptr)" in transaction_source
+    assert "return sender_whireable || receiver_whireable;" in transaction_rules
+    assert "has_whireable_participant(sender_whireable, can_receive_transfer(receiver, pool_ptr))" in transaction_source
     assert "TransactionStatus::NotReceiver" in transaction_source
     assert "sender or receiver must be whireable" in transaction_source
     assert "whireable boolean DEFAULT false" in schema


### PR DESCRIPTION
## Что изменено
- вынесено правило `sender.whireable || receiver.whireable` в отдельно тестируемую backend-функцию;
- обе серверные проверки (`/transactions/prepare` и `/transactions/send`) продолжают использовать единый путь проверки;
- добавлен исполняемый регрессионный тест для комбинаций `true/false`, `false/true` и `false/false`;
- отсутствие строки `role` по-прежнему даёт `false` через `is_rights_by_username`, без SQL-ошибки.

## Проверка
- `python3 -m pytest test/test_transaction_rules.py -q` — 6 passed
- `git diff --check` — успешно
- локальная сборка Docker была запущена, но не завершилась в 10-минутный лимит во время сборки OpenTelemetry; полную backend-сборку проверит CI.

Closes #149
