### PR TITLE
Restore child avatar restrictions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -398,11 +398,16 @@ jobs:
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
               -f /tmp/avatar_upload_role_migration.sql
           docker exec letovo-postgres-1 rm -f /tmp/avatar_upload_role_migration.sql
+          docker cp "$child_avatar_preview" \
+            letovo-postgres-1:/tmp/child_avatar_approved_preview.csv
+          docker exec letovo-postgres-1 \
+            chmod 0644 /tmp/child_avatar_approved_preview.csv
           docker exec letovo-postgres-1 \
             psql -v ON_ERROR_STOP=1 -v apply=true -U scv -d letovo_db \
               -f /tmp/child_avatar_access_migration.sql
           docker exec letovo-postgres-1 \
-            rm -f /tmp/child_avatar_access_migration.sql
+            rm -f /tmp/child_avatar_access_migration.sql \
+              /tmp/child_avatar_approved_preview.csv
 
           sed -E \
             -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${BACKEND_IMAGE}#" \

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -353,19 +353,26 @@ jobs:
           ssh -i ~/.ssh/live-e2e "$remote" "mkdir -p '$state_dir'"
           scp -i ~/.ssh/live-e2e docs/avatar_upload_role_migration.sql \
             "$remote:$state_dir/avatar_upload_role_migration.sql"
+          scp -i ~/.ssh/live-e2e docs/child_avatar_access_migration.sql \
+            "$remote:$state_dir/child_avatar_access_migration.sql"
           ssh -i ~/.ssh/live-e2e "$remote" \
             "BACKEND_IMAGE='$BACKEND_CANDIDATE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_CANDIDATE_IMAGE' FRONTEND_IMAGE='$FRONTEND_CANDIDATE_IMAGE' COMPOSE_FILE='$LETOVO_E2E_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_E2E_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
           set -euo pipefail
+          umask 077
           test -f "$COMPOSE_FILE"
           state_dir="/tmp/letovo-live-e2e-${RUN_ID}"
           mkdir -p "$state_dir"
           restore="$state_dir/restore.env"
           candidate="$state_dir/docker-compose.yaml"
           migration="$state_dir/avatar_upload_role_migration.sql"
+          child_avatar_migration="$state_dir/child_avatar_access_migration.sql"
           backup_root="$HOME/backups/letovo-live-e2e-${RUN_ID}"
           role_backup="$backup_root/role.before-avatar-migration.sql"
+          user_backup="$backup_root/user.before-child-avatar-migration.sql"
+          child_avatar_preview="$backup_root/child-avatar-migration-preview.csv"
 
           test -f "$migration"
+          test -f "$child_avatar_migration"
           mkdir -p "$backup_root"
 
           docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
@@ -375,6 +382,15 @@ jobs:
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.role > "$role_backup"
           test -s "$role_backup"
+          docker exec letovo-postgres-1 \
+            pg_dump -U scv -d letovo_db -t 'public."user"' > "$user_backup"
+          test -s "$user_backup"
+          docker cp "$child_avatar_migration" \
+            letovo-postgres-1:/tmp/child_avatar_access_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -q --csv -v ON_ERROR_STOP=1 -v apply=false \
+              -U scv -d letovo_db \
+              -f /tmp/child_avatar_access_migration.sql > "$child_avatar_preview"
           # Forward-only additive migration: never restore the whole role table
           # automatically, because that could erase concurrent permission edits.
           docker cp "$migration" letovo-postgres-1:/tmp/avatar_upload_role_migration.sql
@@ -382,6 +398,11 @@ jobs:
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
               -f /tmp/avatar_upload_role_migration.sql
           docker exec letovo-postgres-1 rm -f /tmp/avatar_upload_role_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -v ON_ERROR_STOP=1 -v apply=true -U scv -d letovo_db \
+              -f /tmp/child_avatar_access_migration.sql
+          docker exec letovo-postgres-1 \
+            rm -f /tmp/child_avatar_access_migration.sql
 
           sed -E \
             -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${BACKEND_IMAGE}#" \

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -254,9 +254,12 @@ jobs:
           scp -i ~/.ssh/letovo-production-release scripts/patch_nginx_otel.py "$remote:$state_dir/patch_nginx_otel.py"
           scp -i ~/.ssh/letovo-production-release docs/avatar_upload_role_migration.sql \
             "$remote:$state_dir/avatar_upload_role_migration.sql"
+          scp -i ~/.ssh/letovo-production-release docs/child_avatar_access_migration.sql \
+            "$remote:$state_dir/child_avatar_access_migration.sql"
           ssh -i ~/.ssh/letovo-production-release "$remote" \
             "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' NGINX_SITE='$LETOVO_PROD_NGINX_SITE' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
           set -euo pipefail
+          umask 077
           test -f "$COMPOSE_FILE"
           test -f "$NGINX_SITE"
           state_dir="/tmp/letovo-production-release-${RUN_ID}"
@@ -271,6 +274,7 @@ jobs:
           repo_otel="$state_dir/otel-collector-config.yaml.from-repo"
           repo_front_env="$state_dir/letovo-front.env.from-repo"
           migration="$state_dir/avatar_upload_role_migration.sql"
+          child_avatar_migration="$state_dir/child_avatar_access_migration.sql"
           nginx_candidate="$state_dir/nginx-site.candidate"
           compose_dir="$(dirname "$COMPOSE_FILE")"
           otel_config="$compose_dir/otel-collector-config.yaml"
@@ -279,6 +283,10 @@ jobs:
           backup_root="$(dirname "$(dirname "$COMPOSE_FILE")")/backups/production-release-${RUN_ID}"
           role_backup="$backup_root/role.before-avatar-migration.sql"
           role_backup_tmp="$state_dir/role.before-avatar-migration.sql"
+          user_backup="$backup_root/user.before-child-avatar-migration.sql"
+          user_backup_tmp="$state_dir/user.before-child-avatar-migration.sql"
+          child_avatar_preview="$backup_root/child-avatar-migration-preview.csv"
+          child_avatar_preview_tmp="$state_dir/child-avatar-migration-preview.csv"
 
           as_root() {
             if [ "$(id -u)" -eq 0 ]; then
@@ -295,6 +303,7 @@ jobs:
           test -f "$repo_otel"
           test -f "$repo_front_env"
           test -f "$migration"
+          test -f "$child_avatar_migration"
           docker rm -f "$smoke_name" >/dev/null 2>&1 || true
           cleanup_smoke() {
             docker rm -f "$smoke_name" >/dev/null 2>&1 || true
@@ -316,8 +325,20 @@ jobs:
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.role > "$role_backup_tmp"
           test -s "$role_backup_tmp"
+          docker exec letovo-postgres-1 \
+            pg_dump -U scv -d letovo_db -t 'public."user"' > "$user_backup_tmp"
+          test -s "$user_backup_tmp"
           as_root mkdir -p "$backup_root"
           as_root install -m 0600 "$role_backup_tmp" "$role_backup"
+          as_root install -m 0600 "$user_backup_tmp" "$user_backup"
+          docker cp "$child_avatar_migration" \
+            letovo-postgres-1:/tmp/child_avatar_access_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -q --csv -v ON_ERROR_STOP=1 -v apply=false \
+              -U scv -d letovo_db \
+              -f /tmp/child_avatar_access_migration.sql > "$child_avatar_preview_tmp"
+          as_root install -m 0600 "$child_avatar_preview_tmp" \
+            "$child_avatar_preview"
           # Forward-only additive migration: automatic table restoration could
           # erase permission edits made while release verification is running.
           docker cp "$migration" letovo-postgres-1:/tmp/avatar_upload_role_migration.sql
@@ -325,6 +346,11 @@ jobs:
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
               -f /tmp/avatar_upload_role_migration.sql
           docker exec letovo-postgres-1 rm -f /tmp/avatar_upload_role_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -v ON_ERROR_STOP=1 -v apply=true -U scv -d letovo_db \
+              -f /tmp/child_avatar_access_migration.sql
+          docker exec letovo-postgres-1 \
+            rm -f /tmp/child_avatar_access_migration.sql
 
           sed \
             -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${BACKEND_IMAGE}#" \

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -447,11 +447,16 @@ jobs:
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
               -f /tmp/avatar_upload_role_migration.sql
           docker exec letovo-postgres-1 rm -f /tmp/avatar_upload_role_migration.sql
+          docker cp "$child_avatar_preview_tmp" \
+            letovo-postgres-1:/tmp/child_avatar_approved_preview.csv
+          docker exec letovo-postgres-1 \
+            chmod 0644 /tmp/child_avatar_approved_preview.csv
           docker exec letovo-postgres-1 \
             psql -v ON_ERROR_STOP=1 -v apply=true -U scv -d letovo_db \
               -f /tmp/child_avatar_access_migration.sql
           docker exec letovo-postgres-1 \
-            rm -f /tmp/child_avatar_access_migration.sql
+            rm -f /tmp/child_avatar_access_migration.sql \
+              /tmp/child_avatar_approved_preview.csv
 
           sed \
             -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${BACKEND_IMAGE}#" \

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -15,6 +15,22 @@ on:
         description: Run mutating authenticated e2e checks after deployment
         required: false
         default: "false"
+      child_avatar_migration_mode:
+        description: Preview child avatar changes or apply an approved preview
+        required: true
+        type: choice
+        options:
+          - preview
+          - apply
+        default: preview
+      child_avatar_expected_count:
+        description: Required for apply; affected-row count from the approved preview
+        required: false
+        default: ""
+      child_avatar_expected_sha256:
+        description: Required for apply; SHA-256 of the approved preview CSV
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -44,7 +60,76 @@ env:
   LIVE_E2E_REQUIRE_OTEL: "true"
 
 jobs:
+  preview-child-avatar-migration:
+    if: inputs.child_avatar_migration_mode == 'preview'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout migration
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Configure production SSH
+        env:
+          LETOVO_PROD_DEPLOY_HOST: ${{ vars.LETOVO_PROD_DEPLOY_HOST || '84.201.185.37' }}
+          LETOVO_PROD_DEPLOY_SSH_KEY: ${{ secrets.LETOVO_PROD_DEPLOY_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$LETOVO_PROD_DEPLOY_SSH_KEY" > ~/.ssh/letovo-production-release
+          chmod 600 ~/.ssh/letovo-production-release
+          ssh-keyscan -H "$LETOVO_PROD_DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: Preserve child avatar migration preview
+        env:
+          LETOVO_PROD_DEPLOY_HOST: ${{ vars.LETOVO_PROD_DEPLOY_HOST || '84.201.185.37' }}
+          LETOVO_PROD_DEPLOY_USER: ${{ secrets.LETOVO_PROD_DEPLOY_USER }}
+          LETOVO_PROD_DEPLOY_COMPOSE: ${{ vars.LETOVO_PROD_DEPLOY_COMPOSE || '/srv/letovo/compose/docker-compose.yaml' }}
+        run: |
+          set -euo pipefail
+          remote="${LETOVO_PROD_DEPLOY_USER}@${LETOVO_PROD_DEPLOY_HOST}"
+          state_dir="/tmp/letovo-child-avatar-preview-${{ github.run_id }}"
+          ssh -i ~/.ssh/letovo-production-release "$remote" "mkdir -p '$state_dir'"
+          scp -i ~/.ssh/letovo-production-release docs/child_avatar_access_migration.sql \
+            "$remote:$state_dir/child_avatar_access_migration.sql"
+          ssh -i ~/.ssh/letovo-production-release "$remote" \
+            "COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
+          set -euo pipefail
+          umask 077
+          state_dir="/tmp/letovo-child-avatar-preview-${RUN_ID}"
+          migration="$state_dir/child_avatar_access_migration.sql"
+          preview_tmp="$state_dir/child-avatar-migration-preview.csv"
+          metadata_tmp="$state_dir/child-avatar-migration-preview.txt"
+          backup_root="$(dirname "$(dirname "$COMPOSE_FILE")")/backups/child-avatar-preview-${RUN_ID}"
+
+          as_root() {
+            if [ "$(id -u)" -eq 0 ]; then
+              "$@"
+            else
+              sudo -n "$@"
+            fi
+          }
+
+          test -f "$migration"
+          docker cp "$migration" letovo-postgres-1:/tmp/child_avatar_access_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -q --csv -v ON_ERROR_STOP=1 -v apply=false \
+              -U scv -d letovo_db \
+              -f /tmp/child_avatar_access_migration.sql > "$preview_tmp"
+          docker exec letovo-postgres-1 rm -f /tmp/child_avatar_access_migration.sql
+          preview_count="$(tail -n +2 "$preview_tmp" | wc -l | tr -d ' ')"
+          preview_sha256="$(sha256sum "$preview_tmp" | cut -d ' ' -f 1)"
+          printf 'count=%s\nsha256=%s\n' "$preview_count" "$preview_sha256" > "$metadata_tmp"
+          as_root mkdir -p "$backup_root"
+          as_root install -m 0600 "$preview_tmp" "$backup_root/child-avatar-migration-preview.csv"
+          as_root install -m 0600 "$metadata_tmp" "$backup_root/child-avatar-migration-preview.txt"
+          echo "Child avatar preview preserved: count=$preview_count sha256=$preview_sha256 path=$backup_root"
+          REMOTE
+
   release:
+    if: inputs.child_avatar_migration_mode == 'apply'
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -100,6 +185,8 @@ jobs:
           LETOVO_PROD_DEPLOY_COMPOSE: ${{ vars.LETOVO_PROD_DEPLOY_COMPOSE || '/srv/letovo/compose/docker-compose.yaml' }}
           LETOVO_PROD_DEPLOY_PROJECT: ${{ vars.LETOVO_PROD_DEPLOY_PROJECT || 'compose' }}
           LETOVO_PROD_NGINX_SITE: ${{ vars.LETOVO_PROD_NGINX_SITE || '/etc/nginx/sites-available/default' }}
+          CHILD_AVATAR_EXPECTED_COUNT: ${{ inputs.child_avatar_expected_count }}
+          CHILD_AVATAR_EXPECTED_SHA256: ${{ inputs.child_avatar_expected_sha256 }}
         run: |
           set -euo pipefail
           test -n "$LETOVO_PROD_DEPLOY_USER" || { echo "LETOVO_PROD_DEPLOY_USER secret is required"; exit 1; }
@@ -109,6 +196,8 @@ jobs:
           test -n "$LETOVO_PROD_DEPLOY_PROJECT" || { echo "LETOVO_PROD_DEPLOY_PROJECT is required"; exit 1; }
           test -n "$LETOVO_PROD_NGINX_SITE" || { echo "LETOVO_PROD_NGINX_SITE is required"; exit 1; }
           test "$LIVE_E2E_REQUIRE_AUTH" = "true"
+          [[ "$CHILD_AVATAR_EXPECTED_COUNT" =~ ^[0-9]+$ ]] || { echo "child_avatar_expected_count must be a non-negative integer"; exit 1; }
+          [[ "$CHILD_AVATAR_EXPECTED_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo "child_avatar_expected_sha256 must be a lowercase SHA-256"; exit 1; }
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -243,6 +332,8 @@ jobs:
           LETOVO_PROD_DEPLOY_COMPOSE: ${{ vars.LETOVO_PROD_DEPLOY_COMPOSE || '/srv/letovo/compose/docker-compose.yaml' }}
           LETOVO_PROD_DEPLOY_PROJECT: ${{ vars.LETOVO_PROD_DEPLOY_PROJECT || 'compose' }}
           LETOVO_PROD_NGINX_SITE: ${{ vars.LETOVO_PROD_NGINX_SITE || '/etc/nginx/sites-available/default' }}
+          CHILD_AVATAR_EXPECTED_COUNT: ${{ inputs.child_avatar_expected_count }}
+          CHILD_AVATAR_EXPECTED_SHA256: ${{ inputs.child_avatar_expected_sha256 }}
         run: |
           set -euo pipefail
           remote="${LETOVO_PROD_DEPLOY_USER}@${LETOVO_PROD_DEPLOY_HOST}"
@@ -257,7 +348,7 @@ jobs:
           scp -i ~/.ssh/letovo-production-release docs/child_avatar_access_migration.sql \
             "$remote:$state_dir/child_avatar_access_migration.sql"
           ssh -i ~/.ssh/letovo-production-release "$remote" \
-            "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' NGINX_SITE='$LETOVO_PROD_NGINX_SITE' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
+            "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' NGINX_SITE='$LETOVO_PROD_NGINX_SITE' RUN_ID='${{ github.run_id }}' EXPECTED_CHILD_AVATAR_COUNT='$CHILD_AVATAR_EXPECTED_COUNT' EXPECTED_CHILD_AVATAR_SHA256='$CHILD_AVATAR_EXPECTED_SHA256' bash -s" <<'REMOTE'
           set -euo pipefail
           umask 077
           test -f "$COMPOSE_FILE"
@@ -337,6 +428,16 @@ jobs:
             psql -q --csv -v ON_ERROR_STOP=1 -v apply=false \
               -U scv -d letovo_db \
               -f /tmp/child_avatar_access_migration.sql > "$child_avatar_preview_tmp"
+          child_avatar_preview_count="$(tail -n +2 "$child_avatar_preview_tmp" | wc -l | tr -d ' ')"
+          child_avatar_preview_sha256="$(sha256sum "$child_avatar_preview_tmp" | cut -d ' ' -f 1)"
+          test "$child_avatar_preview_count" = "$EXPECTED_CHILD_AVATAR_COUNT" || {
+            echo "Child avatar preview count changed: expected $EXPECTED_CHILD_AVATAR_COUNT, got $child_avatar_preview_count"
+            exit 1
+          }
+          test "$child_avatar_preview_sha256" = "$EXPECTED_CHILD_AVATAR_SHA256" || {
+            echo "Child avatar preview hash changed: expected $EXPECTED_CHILD_AVATAR_SHA256, got $child_avatar_preview_sha256"
+            exit 1
+          }
           as_root install -m 0600 "$child_avatar_preview_tmp" \
             "$child_avatar_preview"
           # Forward-only additive migration: automatic table restoration could

--- a/docs/child_avatar_access_migration.sql
+++ b/docs/child_avatar_access_migration.sql
@@ -1,0 +1,94 @@
+\set ON_ERROR_STOP on
+
+CREATE TEMP TABLE approved_child_avatar (
+  path text PRIMARY KEY
+) ON COMMIT PRESERVE ROWS;
+
+INSERT INTO approved_child_avatar(path) VALUES
+  ('images/avatars/1.png'),
+  ('images/avatars/2.png'),
+  ('images/avatars/3.png'),
+  ('images/avatars/4.png'),
+  ('images/avatars/5.png'),
+  ('images/avatars/6.png'),
+  ('images/avatars/7.png'),
+  ('images/avatars/8.png'),
+  ('images/avatars/9.png'),
+  ('images/avatars/10.png'),
+  ('images/avatars/11.png'),
+  ('images/avatars/12.png'),
+  ('images/avatars/13.png'),
+  ('images/avatars/14.png'),
+  ('images/avatars/15.png'),
+  ('images/avatars/16.png'),
+  ('images/avatars/17.png'),
+  ('images/avatars/18.png'),
+  ('images/avatars/19.png'),
+  ('images/avatars/20.png'),
+  ('images/avatars/21.png'),
+  ('images/avatars/22.png'),
+  ('images/avatars/23.png'),
+  ('images/avatars/24.png'),
+  ('images/avatars/25.png'),
+  ('images/avatars/26.png'),
+  ('images/avatars/27.png'),
+  ('images/avatars/28.png'),
+  ('images/avatars/29.png'),
+  ('images/avatars/30.png');
+
+\if :apply
+BEGIN;
+LOCK TABLE public."user" IN SHARE ROW EXCLUSIVE MODE;
+
+CREATE TEMP TABLE child_avatar_migration_preview ON COMMIT DROP AS
+SELECT username, avatar_pic AS previous_avatar
+FROM public."user" u
+WHERE u.userrights = 'child'
+  AND NULLIF(u.avatar_pic, '') IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM approved_child_avatar approved
+    WHERE approved.path = ltrim(u.avatar_pic, '/')
+  );
+
+UPDATE public."user" u
+SET avatar_pic = 'images/avatars/12.png'
+FROM child_avatar_migration_preview preview
+WHERE u.username = preview.username;
+
+DO $$
+DECLARE
+  remaining_count integer;
+BEGIN
+  SELECT count(*) INTO remaining_count
+  FROM public."user" u
+  WHERE u.userrights = 'child'
+    AND NULLIF(u.avatar_pic, '') IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM approved_child_avatar approved
+      WHERE approved.path = ltrim(u.avatar_pic, '/')
+    );
+  IF remaining_count <> 0 THEN
+    RAISE EXCEPTION '% child avatars remain outside the approved list',
+      remaining_count;
+  END IF;
+END
+$$;
+
+COMMIT;
+\else
+SELECT username, avatar_pic AS previous_avatar,
+       'images/avatars/12.png' AS fallback_avatar
+FROM public."user" u
+WHERE u.userrights = 'child'
+  AND NULLIF(u.avatar_pic, '') IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM approved_child_avatar approved
+    WHERE approved.path = ltrim(u.avatar_pic, '/')
+  )
+ORDER BY username;
+\endif
+
+DROP TABLE approved_child_avatar;

--- a/docs/child_avatar_access_migration.sql
+++ b/docs/child_avatar_access_migration.sql
@@ -40,6 +40,18 @@ INSERT INTO approved_child_avatar(path) VALUES
 BEGIN;
 LOCK TABLE public."user" IN SHARE ROW EXCLUSIVE MODE;
 
+CREATE TEMP TABLE expected_child_avatar_migration (
+  username text NOT NULL,
+  previous_avatar text NOT NULL,
+  fallback_avatar text NOT NULL
+) ON COMMIT DROP;
+
+COPY expected_child_avatar_migration (
+  username, previous_avatar, fallback_avatar
+)
+FROM '/tmp/child_avatar_approved_preview.csv'
+WITH (FORMAT csv, HEADER true);
+
 CREATE TEMP TABLE child_avatar_migration_preview ON COMMIT DROP AS
 SELECT username, avatar_pic AS previous_avatar
 FROM public."user" u
@@ -50,6 +62,26 @@ WHERE u.userrights = 'child'
     FROM approved_child_avatar approved
     WHERE approved.path = ltrim(u.avatar_pic, '/')
   );
+
+DO $$
+BEGIN
+  IF EXISTS (
+    (SELECT username, previous_avatar, 'images/avatars/12.png' AS fallback_avatar
+     FROM child_avatar_migration_preview
+     EXCEPT
+     SELECT username, previous_avatar, fallback_avatar
+     FROM expected_child_avatar_migration)
+    UNION ALL
+    (SELECT username, previous_avatar, fallback_avatar
+     FROM expected_child_avatar_migration
+     EXCEPT
+     SELECT username, previous_avatar, 'images/avatars/12.png' AS fallback_avatar
+     FROM child_avatar_migration_preview)
+  ) THEN
+    RAISE EXCEPTION 'current child avatar candidates differ from approved preview';
+  END IF;
+END
+$$;
 
 UPDATE public."user" u
 SET avatar_pic = 'images/avatars/12.png'

--- a/src/basic/avatar_policy.h
+++ b/src/basic/avatar_policy.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+
+namespace avatar_policy {
+
+inline constexpr std::string_view fallback = "images/avatars/12.png";
+
+inline constexpr std::array<std::string_view, 30> approved_for_children = {
+    "images/avatars/1.png",  "images/avatars/2.png",  "images/avatars/3.png",
+    "images/avatars/4.png",  "images/avatars/5.png",  "images/avatars/6.png",
+    "images/avatars/7.png",  "images/avatars/8.png",  "images/avatars/9.png",
+    "images/avatars/10.png", "images/avatars/11.png", "images/avatars/12.png",
+    "images/avatars/13.png", "images/avatars/14.png", "images/avatars/15.png",
+    "images/avatars/16.png", "images/avatars/17.png", "images/avatars/18.png",
+    "images/avatars/19.png", "images/avatars/20.png", "images/avatars/21.png",
+    "images/avatars/22.png", "images/avatars/23.png", "images/avatars/24.png",
+    "images/avatars/25.png", "images/avatars/26.png", "images/avatars/27.png",
+    "images/avatars/28.png", "images/avatars/29.png", "images/avatars/30.png",
+};
+
+inline std::string_view normalize(std::string_view path) {
+  while (!path.empty() && path.front() == '/')
+    path.remove_prefix(1);
+  return path;
+}
+
+inline bool is_approved_for_child(std::string_view path) {
+  path = normalize(path);
+  return std::find(approved_for_children.begin(), approved_for_children.end(),
+                   path) != approved_for_children.end();
+}
+
+} // namespace avatar_policy

--- a/src/basic/user_data.cc
+++ b/src/basic/user_data.cc
@@ -1,4 +1,5 @@
 #include "user_data.h"
+#include "avatar_policy.h"
 #include "security.h"
 #include "../market/transactions.h"
 
@@ -469,17 +470,38 @@ static std::filesystem::path media_root() {
   return std::filesystem::path(Config::giveMe().pages_config.media_path.absolute);
 }
 
-std::vector<std::string> all_avatars(const std::string &username, bool is_admin) {
+AvatarAccess avatar_access(
+    const std::string &username,
+    std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
+  cp::SafeCon con{pool_ptr};
+  std::vector<std::string> params = {username};
+  const auto rows = con->execute_params(
+      "SELECT COALESCE(u.userrights = 'child', false) AS is_child, "
+      "(COALESCE(u.userrights <> 'child', false) AND u.active = true AND "
+      "(COALESCE(r.ava_upload, false) OR COALESCE(r.admin, false) OR "
+      "COALESCE(r.moder, false))) AS can_upload_personal "
+      "FROM public.\"user\" u LEFT JOIN public.role r ON r.username = u.username "
+      "WHERE u.username = ($1);",
+      params);
+  if (rows.empty()) return {};
+  return {rows[0]["is_child"].as<bool>(),
+          rows[0]["can_upload_personal"].as<bool>()};
+}
+
+std::vector<std::string> all_avatars(const std::string &username, bool is_admin,
+                                     const AvatarAccess &access) {
   std::vector<std::string> avatars;
   for (const auto &entry : std::filesystem::directory_iterator(
            Config::giveMe().pages_config.user_avatars_path.absolute)) {
     if (std::filesystem::is_regular_file(entry.status())) {
-      avatars.push_back(
+      const auto avatar =
           Config::giveMe().pages_config.user_avatars_path.relative +
-          entry.path().filename().string());
+          entry.path().filename().string();
+      if (!access.is_child || avatar_policy::is_approved_for_child(avatar))
+        avatars.push_back(avatar);
     }
   }
-  if (is_admin) {
+  if (!access.is_child && is_admin) {
     for (const auto &entry : std::filesystem::directory_iterator(
              Config::giveMe().pages_config.admin_avatars_path.absolute)) {
       if (std::filesystem::is_regular_file(entry.status())) {
@@ -491,7 +513,8 @@ std::vector<std::string> all_avatars(const std::string &username, bool is_admin)
   }
   const auto relative = personal_avatar_relative(username);
   const auto directory = media_root() / relative.substr(1);
-  if (std::filesystem::exists(directory)) {
+  if (!access.is_child && access.can_upload_personal &&
+      std::filesystem::exists(directory)) {
     for (const auto &entry : std::filesystem::directory_iterator(directory)) {
       if (std::filesystem::is_regular_file(entry.status()))
         avatars.push_back(relative + entry.path().filename().string());
@@ -501,17 +524,27 @@ std::vector<std::string> all_avatars(const std::string &username, bool is_admin)
 }
 
 bool can_use_avatar(const std::string &username, const std::string &avatar,
-                    bool is_admin) {
-  if (avatar.empty() || avatar[0] != '/' || avatar.find("..") != std::string::npos ||
+                    bool is_admin, const AvatarAccess &access) {
+  if (avatar.empty() || avatar.find("..") != std::string::npos ||
       avatar.find('\\') != std::string::npos) return false;
-  const auto shared = Config::giveMe().pages_config.user_avatars_path.relative;
-  const auto admin = Config::giveMe().pages_config.admin_avatars_path.relative;
-  const auto personal = personal_avatar_relative(username);
-  if (avatar.rfind(shared, 0) != 0 && !(is_admin && avatar.rfind(admin, 0) == 0) &&
-      avatar.rfind(personal, 0) != 0) return false;
+  const auto normalized = avatar_policy::normalize(avatar);
+  const auto shared = avatar_policy::normalize(
+      Config::giveMe().pages_config.user_avatars_path.relative);
+  const auto admin = avatar_policy::normalize(
+      Config::giveMe().pages_config.admin_avatars_path.relative);
+  const auto personal = avatar_policy::normalize(personal_avatar_relative(username));
+  if (access.is_child) {
+    if (!avatar_policy::is_approved_for_child(normalized)) return false;
+  } else if (normalized.rfind(shared, 0) != 0 &&
+             !(is_admin && normalized.rfind(admin, 0) == 0) &&
+             !(access.can_upload_personal &&
+               normalized.rfind(personal, 0) == 0)) {
+    return false;
+  }
   std::error_code ec;
   const auto root = std::filesystem::weakly_canonical(media_root(), ec);
-  const auto file = std::filesystem::weakly_canonical(media_root() / avatar.substr(1), ec);
+  const auto file =
+      std::filesystem::weakly_canonical(media_root() / normalized, ec);
   return !ec && file.string().rfind(root.string() + "/", 0) == 0 &&
          std::filesystem::is_regular_file(file, ec);
 }
@@ -975,8 +1008,9 @@ void all_avatars(
     }
     return req->create_response()
         .append_header("Content-Type", "application/json; charset=utf-8")
-        .set_body(cp::serialize(
-            user::all_avatars(username, auth::is_admin(token, pool_ptr))))
+        .set_body(cp::serialize(user::all_avatars(
+            username, auth::is_admin(token, pool_ptr),
+            user::avatar_access(username, pool_ptr))))
         .done();
   });
 }
@@ -1010,7 +1044,9 @@ void set_avatar(std::unique_ptr<restinio::router::express_router_t<>> &router,
     if (new_body.HasMember("avatar")) {
       std::string username = auth::get_username(token, pool_ptr);
       std::string avatar = new_body["avatar"].GetString();
-      if (!user::can_use_avatar(username, avatar, auth::is_admin(token, pool_ptr))) {
+      if (!user::can_use_avatar(username, avatar,
+                                auth::is_admin(token, pool_ptr),
+                                user::avatar_access(username, pool_ptr))) {
         return req->create_response(restinio::status_forbidden()).done();
       }
       if (media::check_if_file_exists(avatar).empty()) {

--- a/src/basic/user_data.h
+++ b/src/basic/user_data.h
@@ -11,6 +11,11 @@
 #include <vector>
 
 namespace user {
+struct AvatarAccess {
+  bool is_child = false;
+  bool can_upload_personal = false;
+};
+
 pqxx::result role(int role_id,
                   std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
@@ -76,9 +81,12 @@ pqxx::result all_departments(std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 void set_avatar(std::string username, std::string avatar,
                 std::shared_ptr<cp::ConnectionsManager> pool_ptr);
 
-std::vector<std::string> all_avatars(const std::string &username, bool is_admin);
+AvatarAccess avatar_access(const std::string &username,
+                           std::shared_ptr<cp::ConnectionsManager> pool_ptr);
+std::vector<std::string> all_avatars(const std::string &username, bool is_admin,
+                                     const AvatarAccess &access);
 bool can_use_avatar(const std::string &username, const std::string &avatar,
-                    bool is_admin);
+                    bool is_admin, const AvatarAccess &access);
 
 } // namespace user
 

--- a/test/test_issue153_avatar_access_contract.py
+++ b/test/test_issue153_avatar_access_contract.py
@@ -1,0 +1,62 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+POLICY = ROOT / "src" / "basic" / "avatar_policy.h"
+USER_DATA = ROOT / "src" / "basic" / "user_data.cc"
+MIGRATION = ROOT / "docs" / "child_avatar_access_migration.sql"
+BUILD_WORKFLOW = ROOT / ".github" / "workflows" / "docker-image.yml"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "production-release.yml"
+
+
+def _approved_paths(source: str) -> set[str]:
+    return set(re.findall(r"[\"'](images/avatars/\d+\.png)[\"']", source))
+
+
+def test_child_allowlist_and_fallback_match_approved_production_batch():
+    policy = POLICY.read_text()
+    migration = MIGRATION.read_text()
+    expected = {f"images/avatars/{number}.png" for number in range(1, 31)}
+
+    assert _approved_paths(policy) == expected
+    assert _approved_paths(migration) == expected
+    assert 'fallback = "images/avatars/12.png"' in policy
+    assert "SET avatar_pic = 'images/avatars/12.png'" in migration
+
+
+def test_backend_enforces_child_policy_on_list_and_direct_selection():
+    source = USER_DATA.read_text()
+
+    assert "COALESCE(u.userrights = 'child', false) AS is_child" in source
+    assert "avatar_policy::is_approved_for_child(avatar)" in source
+    assert "if (access.is_child)" in source
+    assert "avatar_policy::is_approved_for_child(normalized)" in source
+    assert "access.can_upload_personal" in source
+    assert "user::avatar_access(username, pool_ptr)" in source
+    assert "restinio::status_forbidden()" in source
+
+
+def test_migration_has_preview_apply_backup_safe_contract():
+    migration = MIGRATION.read_text()
+
+    assert "\\if :apply" in migration
+    assert "LOCK TABLE public.\"user\" IN SHARE ROW EXCLUSIVE MODE" in migration
+    assert "u.userrights = 'child'" in migration
+    assert "NULLIF(u.avatar_pic, '') IS NOT NULL" in migration
+    assert "approved.path = ltrim(u.avatar_pic, '/')" in migration
+    assert "child_avatar_migration_preview" in migration
+    assert "remaining_count <> 0" in migration
+    assert "BEGIN;" in migration and "COMMIT;" in migration
+
+
+def test_candidate_and_production_deploy_preview_backup_and_apply_policy():
+    for workflow_path in (BUILD_WORKFLOW, RELEASE_WORKFLOW):
+        workflow = workflow_path.read_text()
+        assert "docs/child_avatar_access_migration.sql" in workflow
+        assert "user.before-child-avatar-migration.sql" in workflow
+        assert "child-avatar-migration-preview.csv" in workflow
+        assert "pg_dump -U scv -d letovo_db -t 'public.\"user\"'" in workflow
+        assert "-v apply=false" in workflow
+        assert "-v apply=true" in workflow
+        assert "umask 077" in workflow

--- a/test/test_issue153_avatar_access_contract.py
+++ b/test/test_issue153_avatar_access_contract.py
@@ -60,3 +60,13 @@ def test_candidate_and_production_deploy_preview_backup_and_apply_policy():
         assert "-v apply=false" in workflow
         assert "-v apply=true" in workflow
         assert "umask 077" in workflow
+
+    production = RELEASE_WORKFLOW.read_text()
+    assert "preview-child-avatar-migration:" in production
+    assert "inputs.child_avatar_migration_mode == 'preview'" in production
+    assert "inputs.child_avatar_migration_mode == 'apply'" in production
+    assert "child_avatar_expected_count" in production
+    assert "child_avatar_expected_sha256" in production
+    assert "Child avatar preview count changed" in production
+    assert "Child avatar preview hash changed" in production
+    assert "sha256sum" in production

--- a/test/test_issue153_avatar_access_contract.py
+++ b/test/test_issue153_avatar_access_contract.py
@@ -45,6 +45,10 @@ def test_migration_has_preview_apply_backup_safe_contract():
     assert "u.userrights = 'child'" in migration
     assert "NULLIF(u.avatar_pic, '') IS NOT NULL" in migration
     assert "approved.path = ltrim(u.avatar_pic, '/')" in migration
+    assert "expected_child_avatar_migration" in migration
+    assert "child_avatar_approved_preview.csv" in migration
+    assert "EXCEPT" in migration
+    assert "current child avatar candidates differ from approved preview" in migration
     assert "child_avatar_migration_preview" in migration
     assert "remaining_count <> 0" in migration
     assert "BEGIN;" in migration and "COMMIT;" in migration
@@ -59,6 +63,7 @@ def test_candidate_and_production_deploy_preview_backup_and_apply_policy():
         assert "pg_dump -U scv -d letovo_db -t 'public.\"user\"'" in workflow
         assert "-v apply=false" in workflow
         assert "-v apply=true" in workflow
+        assert "child_avatar_approved_preview.csv" in workflow
         assert "umask 077" in workflow
 
     production = RELEASE_WORKFLOW.read_text()

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -105,6 +105,12 @@ def test_production_release_is_manual_deploy_with_required_live_e2e_gate():
     workflow = _read(PRODUCTION_RELEASE_WORKFLOW)
 
     assert "workflow_dispatch:" in workflow
+    assert "child_avatar_migration_mode:" in workflow
+    assert "preview-child-avatar-migration:" in workflow
+    assert "inputs.child_avatar_migration_mode == 'preview'" in workflow
+    assert "inputs.child_avatar_migration_mode == 'apply'" in workflow
+    assert "child_avatar_expected_count:" in workflow
+    assert "child_avatar_expected_sha256:" in workflow
     assert "target_ref:" not in workflow
     assert "ref: main" in workflow
     assert "default: https://letovocorp.ru" in workflow

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -79,7 +79,10 @@ def test_pr_build_publishes_candidate_images_before_live_e2e_gate():
     assert "LETOVO_E2E_DEPLOY_PROJECT" in workflow
     assert "Deploy PR candidate images to live e2e" in workflow
     assert "scp -i ~/.ssh/live-e2e docs/avatar_upload_role_migration.sql" in workflow
+    assert "scp -i ~/.ssh/live-e2e docs/child_avatar_access_migration.sql" in workflow
     assert "pg_dump -U scv -d letovo_db -t public.role" in workflow
+    assert "user.before-child-avatar-migration.sql" in workflow
+    assert "child-avatar-migration-preview.csv" in workflow
     assert "psql -v ON_ERROR_STOP=1 -U scv -d letovo_db" in workflow
     assert "avatar_upload_role_migration.sql" in workflow
     assert "docker compose -p \"$PROJECT_NAME\" -f \"$candidate\" up -d letovo-server letovo-registration-server letovo-front" in workflow
@@ -137,7 +140,10 @@ def test_production_release_is_manual_deploy_with_required_live_e2e_gate():
     assert "scp -i ~/.ssh/letovo-production-release frontend/front-env.env" in workflow
     assert "scp -i ~/.ssh/letovo-production-release scripts/patch_nginx_otel.py" in workflow
     assert "scp -i ~/.ssh/letovo-production-release docs/avatar_upload_role_migration.sql" in workflow
+    assert "scp -i ~/.ssh/letovo-production-release docs/child_avatar_access_migration.sql" in workflow
     assert "pg_dump -U scv -d letovo_db -t public.role" in workflow
+    assert "user.before-child-avatar-migration.sql" in workflow
+    assert "child-avatar-migration-preview.csv" in workflow
     assert "psql -v ON_ERROR_STOP=1 -U scv -d letovo_db" in workflow
     assert "role.before-avatar-migration.sql" in workflow
     assert "otel-collector-config.yaml.before-release" in workflow


### PR DESCRIPTION
## Summary

- define the approved child avatar batch as `images/avatars/1.png` through `30.png`
- filter child avatar listings and reject direct selection outside the allowlist
- keep technical shared avatars available to non-child accounts and require the existing capability for personal avatars
- preview, back up, and transactionally migrate invalid child avatars to `images/avatars/12.png`
- validate the policy, migration, and deployment workflow with focused regression tests

## Verification

- `python3 -m pytest test/test_issue153_avatar_access_contract.py test/test_issue141_avatar_contract.py test/test_live_e2e_workflow_contract.py -q` (17 passed)
- `g++ -std=c++20 -Isrc -Isrc/basic -fsyntax-only src/basic/user_data.cc`
- PostgreSQL 16 fixture preview/apply verification
- workflow YAML parse
- `git diff --check`

Closes #153
