### PR TITLE
Fix department payout error handling

### DIFF
--- a/src/market/transactions.cc
+++ b/src/market/transactions.cc
@@ -470,6 +470,23 @@ namespace transactions {
 } // namespace transactions
 
 namespace transactions::server {
+    static const char* department_payout_status_name(
+        transactions::DepartmentPayoutStatus status) {
+        switch (status) {
+        case transactions::DepartmentPayoutStatus::Success:
+            return "success";
+        case transactions::DepartmentPayoutStatus::DepartmentNotFound:
+            return "department_not_found";
+        case transactions::DepartmentPayoutStatus::NoRecipients:
+            return "no_recipients";
+        case transactions::DepartmentPayoutStatus::PreviewChanged:
+            return "preview_changed";
+        case transactions::DepartmentPayoutStatus::Error:
+        default:
+            return "error";
+        }
+    }
+
     static std::string department_payout_json(
         const transactions::DepartmentPayoutResult& payout) {
         rapidjson::Document body(rapidjson::kObjectType);
@@ -548,17 +565,23 @@ namespace transactions::server {
                         .done();
                 }
 
+                const std::string actor = auth::get_username(token, pool_ptr);
                 transactions::DepartmentPayoutResult payout = confirm
                     ? transactions::apply_department_payout(
-                        department_id, amount, auth::get_username(token, pool_ptr),
+                        department_id, amount, actor,
                         request_id, body["expected_recipient_count"].GetInt(), pool_ptr)
                     : transactions::preview_department_payout(department_id, amount, pool_ptr);
+                logger_ptr->info([department_id, confirm, status = payout.status] {
+                    return fmt::format(
+                        "department_payout department_id={} confirm={} outcome={}",
+                        department_id, confirm, department_payout_status_name(status));
+                });
 
                 switch (payout.status) {
                 case transactions::DepartmentPayoutStatus::Success:
                     if (confirm && payout.applied) {
                         analytics::record_event(
-                            auth::get_username(token, pool_ptr), token,
+                            actor, token,
                             req->remote_endpoint().address().to_string(),
                             req->header().has_field("User-Agent")
                                 ? req->header().get_field("User-Agent") : "",

--- a/test/test_issue155_department_payout_contract.py
+++ b/test/test_issue155_department_payout_contract.py
@@ -41,6 +41,27 @@ def test_apply_is_atomic_auditable_and_idempotent():
     assert "reason character varying DEFAULT 'wire transfer'" in SCHEMA
 
 
+def test_payout_does_not_read_or_debit_admin_balance():
+    handler = TRANSACTIONS.split(
+        '"/transactions/department-payout"', 1
+    )[1].split('"/transactions/prepare"', 1)[0]
+    assert "get_balance(" not in handler
+    assert 'SET balance = u.balance + $2::integer' in TRANSACTIONS
+    assert "SET balance = u.balance -" not in TRANSACTIONS.split(
+        "DepartmentPayoutResult apply_department_payout", 1
+    )[1].split("prepare_transaction", 1)[0]
+
+
+def test_preview_confirm_inputs_and_safe_outcome_logging_are_explicit():
+    assert "department_id, amount, actor" in TRANSACTIONS
+    assert 'body["expected_recipient_count"].GetInt()' in TRANSACTIONS
+    assert '"department_payout department_id={} confirm={} outcome={}"' in TRANSACTIONS
+    assert "department_payout_status_name(status)" in TRANSACTIONS
+    assert "request_id" not in TRANSACTIONS.split(
+        '"department_payout department_id={} confirm={} outcome={}"', 1
+    )[1].split("switch (payout.status)", 1)[0]
+
+
 def test_amount_and_request_id_are_validated():
     assert "amount <= 0" in TRANSACTIONS
     assert "valid_payout_request_id" in TRANSACTIONS


### PR DESCRIPTION
## What changed
- preserve the no-admin-balance payout path and cover it with a regression assertion
- log department ID, confirmation flag, and payout outcome without tokens or request IDs
- update the frontend so payout API errors are shown instead of the generic page-not-found message
- verify confirm reuses the preview department ID and recipient count

## Verification
- g++ C++20 syntax check for src/market/transactions.cc
- 18 targeted backend test functions passed
- frontend npm run test:department-payout
- frontend npx tsc --noEmit
- frontend npm run build

Frontend: letovo-dev/letovo-all-frontend#38

Closes #158.