### PR TITLE
docs(api): add non-admin OpenAPI inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@
 
 ---
 
+## API-документация
+
+`docs/openapi.json` — OpenAPI 3.1-инвентаризация backend-маршрутов, доступных не только администраторам. Production server: `https://letovocorp.ru/letovo-api`.
+
+Перегенерировать спецификацию после изменения маршрутов:
+
+```bash
+python3 docs/generate_openapi.py
+python3 -m pytest -q test/test_openapi_non_admin_coverage.py
+```
+
+Строго admin-only обработчики и development-пробы намеренно не входят в документ.
+
 ## Разработка
 
 ### Как добавить свои модули - С++

--- a/docs/generate_openapi.py
+++ b/docs/generate_openapi.py
@@ -1,0 +1,147 @@
+"""Generate the source-derived non-admin OpenAPI inventory.
+
+Run from the repository root:
+    python3 docs/generate_openapi.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "docs"))
+from openapi_inventory import registered_non_admin_routes  # noqa: E402
+
+OUTPUT_PATH = ROOT / "docs" / "openapi.json"
+
+SECURITY_REQUIRED_PREFIXES = {
+    "/analytics/activity/ping",
+    "/auth/amiauthed",
+    "/auth/amiadmin",
+    "/auth/amiuploader",
+    "/auth/logout",
+    "/auth/delete",
+    "/auth/change_username",
+    "/auth/change_password",
+    "/auth/register_true",
+    "/user/all_avatars",
+    "/user/set_avatar",
+    "/ws",
+    "/post/add_page",
+    "/post/update_likes",
+    "/post/favourite",
+    "/social/saved",
+    "/social/save",
+    "/social/like",
+    "/social/dislike",
+    "/social/comments",
+    "/transactions/",
+    "/chats/",
+    "/chat/",
+    "/new_message",
+    "/deals/",
+    "/actives/user_",
+}
+
+
+def requires_auth(path: str) -> bool:
+    return any(path == prefix or path.startswith(prefix) for prefix in SECURITY_REQUIRED_PREFIXES)
+
+
+def operation(method: str, path: str) -> dict:
+    tag = path.strip("/").split("/")[0] or "system"
+    result = {
+        "tags": [tag],
+        "summary": f"{method.upper()} {path}",
+        "description": (
+            "Маршрут доступен не только администраторам. Точные права и формат "
+            "данных проверяются backend-обработчиком."
+        ),
+        "responses": {
+            "200": {"description": "Successful response"},
+            "400": {"description": "Invalid request"},
+            "401": {"description": "Authentication or authorization failed"},
+            "500": {"description": "Internal server error"},
+        },
+    }
+    parameters = []
+    for segment in path.split("/"):
+        if segment.startswith("{") and segment.endswith("}"):
+            parameters.append(
+                {
+                    "name": segment[1:-1],
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            )
+    if parameters:
+        result["parameters"] = parameters
+    if requires_auth(path):
+        result["security"] = [{"bearerHeader": []}, {"authSession": []}]
+    if method in {"post", "put", "delete"}:
+        result["requestBody"] = {
+            "required": False,
+            "content": {
+                "application/json": {
+                    "schema": {"type": "object", "additionalProperties": True}
+                }
+            },
+        }
+    return result
+
+
+def main() -> None:
+    paths = {}
+    for method, path in sorted(
+        registered_non_admin_routes(), key=lambda item: (item[1], item[0])
+    ):
+        paths.setdefault(path, {})[method] = operation(method, path)
+
+    document = {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "Letovo portal API (non-admin routes)",
+            "version": "1.0.0",
+            "description": (
+                "Исходная OpenAPI-инвентаризация маршрутов, доступных не только "
+                "администраторам. Строго admin-only и development-пробы исключены. "
+                "API-prefix: `/letovo-api`."
+            ),
+        },
+        "servers": [{"url": "https://letovocorp.ru/letovo-api"}],
+        "tags": [
+            {"name": name}
+            for name in sorted(
+                {path.strip("/").split("/")[0] or "system" for path in paths}
+            )
+        ],
+        "components": {
+            "securitySchemes": {
+                "bearerHeader": {
+                    "type": "apiKey",
+                    "in": "header",
+                    "name": "Bearer",
+                    "description": "Session token in the backend-supported `Bearer` header.",
+                },
+                "authSession": {
+                    "type": "apiKey",
+                    "in": "cookie",
+                    "name": "AuthSession",
+                    "description": "Session cookie issued by `/auth/login`.",
+                },
+            }
+        },
+        "paths": paths,
+    }
+    OUTPUT_PATH.write_text(
+        json.dumps(document, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(
+        f"generated {OUTPUT_PATH.relative_to(ROOT)}: "
+        f"{len(paths)} paths, {sum(len(item) for item in paths.values())} operations"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -411,12 +411,12 @@
         ]
       }
     },
-    "/actives/active/{id}": {
+    "/actives/active/{identifier}": {
       "get": {
         "tags": [
           "actives"
         ],
-        "summary": "GET /actives/active/{id}",
+        "summary": "GET /actives/active/{identifier}",
         "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
         "responses": {
           "200": {
@@ -434,40 +434,7 @@
         },
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/actives/active/{ticker}": {
-      "get": {
-        "tags": [
-          "actives"
-        ],
-        "summary": "GET /actives/active/{ticker}",
-        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
-        "responses": {
-          "200": {
-            "description": "Successful response"
-          },
-          "400": {
-            "description": "Invalid request"
-          },
-          "401": {
-            "description": "Authentication or authorization failed"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "parameters": [
-          {
-            "name": "ticker",
+            "name": "identifier",
             "in": "path",
             "required": true,
             "schema": {
@@ -500,12 +467,12 @@
         }
       }
     },
-    "/actives/history/{id}": {
+    "/actives/history/{identifier}": {
       "get": {
         "tags": [
           "actives"
         ],
-        "summary": "GET /actives/history/{id}",
+        "summary": "GET /actives/history/{identifier}",
         "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
         "responses": {
           "200": {
@@ -523,40 +490,7 @@
         },
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
-    "/actives/history/{ticker}": {
-      "get": {
-        "tags": [
-          "actives"
-        ],
-        "summary": "GET /actives/history/{ticker}",
-        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
-        "responses": {
-          "200": {
-            "description": "Successful response"
-          },
-          "400": {
-            "description": "Invalid request"
-          },
-          "401": {
-            "description": "Authentication or authorization failed"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "parameters": [
-          {
-            "name": "ticker",
+            "name": "identifier",
             "in": "path",
             "required": true,
             "schema": {
@@ -1757,39 +1691,6 @@
         }
       }
     },
-    "/post/qr/{post_id}": {
-      "get": {
-        "tags": [
-          "post"
-        ],
-        "summary": "GET /post/qr/{post_id}",
-        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
-        "responses": {
-          "200": {
-            "description": "Successful response"
-          },
-          "400": {
-            "description": "Invalid request"
-          },
-          "401": {
-            "description": "Authentication or authorization failed"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "parameters": [
-          {
-            "name": "post_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
     "/post/reveal_secret/{token}": {
       "get": {
         "tags": [
@@ -2714,6 +2615,40 @@
             "authSession": []
           }
         ]
+      }
+    },
+    "/user/create_role": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "POST /user/create_role",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
       }
     },
     "/user/delete_role": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,3081 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Letovo portal API (non-admin routes)",
+    "version": "1.0.0",
+    "description": "Исходная OpenAPI-инвентаризация маршрутов, доступных не только администраторам. Строго admin-only и development-пробы исключены. API-prefix: `/letovo-api`."
+  },
+  "servers": [
+    {
+      "url": "https://letovocorp.ru/letovo-api"
+    }
+  ],
+  "tags": [
+    {
+      "name": "achivements"
+    },
+    {
+      "name": "actives"
+    },
+    {
+      "name": "analytics"
+    },
+    {
+      "name": "auth"
+    },
+    {
+      "name": "authors_list"
+    },
+    {
+      "name": "calendar"
+    },
+    {
+      "name": "chat"
+    },
+    {
+      "name": "chats"
+    },
+    {
+      "name": "deals"
+    },
+    {
+      "name": "media"
+    },
+    {
+      "name": "new_message"
+    },
+    {
+      "name": "post"
+    },
+    {
+      "name": "social"
+    },
+    {
+      "name": "transactions"
+    },
+    {
+      "name": "user"
+    },
+    {
+      "name": "ws"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Bearer",
+        "description": "Session token in the backend-supported `Bearer` header."
+      },
+      "authSession": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "AuthSession",
+        "description": "Session cookie issued by `/auth/login`."
+      }
+    }
+  },
+  "paths": {
+    "/achivements/add": {
+      "post": {
+        "tags": [
+          "achivements"
+        ],
+        "summary": "POST /achivements/add",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/achivements/by_user": {
+      "get": {
+        "tags": [
+          "achivements"
+        ],
+        "summary": "GET /achivements/by_user",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/achivements/info/{achivement_id}": {
+      "get": {
+        "tags": [
+          "achivements"
+        ],
+        "summary": "GET /achivements/info/{achivement_id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "achivement_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/achivements/no_dep": {
+      "get": {
+        "tags": [
+          "achivements"
+        ],
+        "summary": "GET /achivements/no_dep",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/achivements/pictures": {
+      "get": {
+        "tags": [
+          "achivements"
+        ],
+        "summary": "GET /achivements/pictures",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/achivements/qr/{achivement_id}": {
+      "get": {
+        "tags": [
+          "achivements"
+        ],
+        "summary": "GET /achivements/qr/{achivement_id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "achivement_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/achivements/qr_code/{achivement_id}": {
+      "get": {
+        "tags": [
+          "achivements"
+        ],
+        "summary": "GET /achivements/qr_code/{achivement_id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "achivement_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/achivements/tree/{tree_id}": {
+      "get": {
+        "tags": [
+          "achivements"
+        ],
+        "summary": "GET /achivements/tree/{tree_id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "tree_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/achivements/user/departments/{username}": {
+      "get": {
+        "tags": [
+          "achivements"
+        ],
+        "summary": "GET /achivements/user/departments/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/achivements/user/full/{username}": {
+      "get": {
+        "tags": [
+          "achivements"
+        ],
+        "summary": "GET /achivements/user/full/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/achivements/user/{username}": {
+      "get": {
+        "tags": [
+          "achivements"
+        ],
+        "summary": "GET /achivements/user/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/actives/active/{id}": {
+      "get": {
+        "tags": [
+          "actives"
+        ],
+        "summary": "GET /actives/active/{id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/actives/active/{ticker}": {
+      "get": {
+        "tags": [
+          "actives"
+        ],
+        "summary": "GET /actives/active/{ticker}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/actives/all_actives": {
+      "get": {
+        "tags": [
+          "actives"
+        ],
+        "summary": "GET /actives/all_actives",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/actives/history/{id}": {
+      "get": {
+        "tags": [
+          "actives"
+        ],
+        "summary": "GET /actives/history/{id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/actives/history/{ticker}": {
+      "get": {
+        "tags": [
+          "actives"
+        ],
+        "summary": "GET /actives/history/{ticker}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/actives/user_actives": {
+      "get": {
+        "tags": [
+          "actives"
+        ],
+        "summary": "GET /actives/user_actives",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/actives/user_history": {
+      "get": {
+        "tags": [
+          "actives"
+        ],
+        "summary": "GET /actives/user_history",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/analytics/activity/ping": {
+      "post": {
+        "tags": [
+          "analytics"
+        ],
+        "summary": "POST /analytics/activity/ping",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/amiadmin": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "GET /auth/amiadmin",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/auth/amiauthed": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "GET /auth/amiauthed",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/auth/amiuploader": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "GET /auth/amiuploader",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/auth/change_password": {
+      "put": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "PUT /auth/change_password",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/change_username": {
+      "put": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "PUT /auth/change_username",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/delete": {
+      "delete": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "DELETE /auth/delete",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/isactive/{username}": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "GET /auth/isactive/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/auth/isadmin/{username}": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "GET /auth/isadmin/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/auth/isuser/{username}": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "GET /auth/isuser/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "POST /auth/login",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "put": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "PUT /auth/logout",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/reg": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "POST /auth/reg",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/register_true": {
+      "put": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "PUT /auth/register_true",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/authors_list": {
+      "get": {
+        "tags": [
+          "authors_list"
+        ],
+        "summary": "GET /authors_list",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/calendar/day": {
+      "get": {
+        "tags": [
+          "calendar"
+        ],
+        "summary": "GET /calendar/day",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/chat/message/{id}": {
+      "delete": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "DELETE /chat/message/{id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/chat/{username}": {
+      "get": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "GET /chat/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/chats/": {
+      "get": {
+        "tags": [
+          "chats"
+        ],
+        "summary": "GET /chats/",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/deals/add_bid": {
+      "post": {
+        "tags": [
+          "deals"
+        ],
+        "summary": "POST /deals/add_bid",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/deals/remove_bid": {
+      "delete": {
+        "tags": [
+          "deals"
+        ],
+        "summary": "DELETE /deals/remove_bid",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/deals/users_bids": {
+      "get": {
+        "tags": [
+          "deals"
+        ],
+        "summary": "GET /deals/users_bids",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/media/get/{filename}": {
+      "get": {
+        "tags": [
+          "media"
+        ],
+        "summary": "GET /media/get/{filename}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "filename",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/media/top-downloads": {
+      "get": {
+        "tags": [
+          "media"
+        ],
+        "summary": "GET /media/top-downloads",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/new_message": {
+      "post": {
+        "tags": [
+          "new_message"
+        ],
+        "summary": "POST /new_message",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/post/add_page": {
+      "post": {
+        "tags": [
+          "post"
+        ],
+        "summary": "POST /post/add_page",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/post/author/{username}": {
+      "get": {
+        "tags": [
+          "post"
+        ],
+        "summary": "GET /post/author/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/post/delete": {
+      "delete": {
+        "tags": [
+          "post"
+        ],
+        "summary": "DELETE /post/delete",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/post/favourite": {
+      "post": {
+        "tags": [
+          "post"
+        ],
+        "summary": "POST /post/favourite",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/post/favourite/": {
+      "get": {
+        "tags": [
+          "post"
+        ],
+        "summary": "GET /post/favourite/",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/post/favourite/{id}": {
+      "delete": {
+        "tags": [
+          "post"
+        ],
+        "summary": "DELETE /post/favourite/{id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/post/qr/{post_id}": {
+      "get": {
+        "tags": [
+          "post"
+        ],
+        "summary": "GET /post/qr/{post_id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "post_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/post/reveal_secret/{token}": {
+      "get": {
+        "tags": [
+          "post"
+        ],
+        "summary": "GET /post/reveal_secret/{token}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/post/update_likes": {
+      "put": {
+        "tags": [
+          "post"
+        ],
+        "summary": "PUT /post/update_likes",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/post/{id}": {
+      "get": {
+        "tags": [
+          "post"
+        ],
+        "summary": "GET /post/{id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/social/authors": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/authors",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/social/bycat/{category}": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/bycat/{category}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "category",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/social/categories": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/categories",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/social/comments": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/comments",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "social"
+        ],
+        "summary": "POST /social/comments",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/social/dislike": {
+      "delete": {
+        "tags": [
+          "social"
+        ],
+        "summary": "DELETE /social/dislike",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "social"
+        ],
+        "summary": "POST /social/dislike",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/social/like": {
+      "delete": {
+        "tags": [
+          "social"
+        ],
+        "summary": "DELETE /social/like",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "social"
+        ],
+        "summary": "POST /social/like",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/social/media/pics/{post_id}": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/media/pics/{post_id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "post_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/social/new/{post_id}": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/new/{post_id}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "post_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/social/news": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/news",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/social/news/related": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/news/related",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/social/posts": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/posts",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/social/posts/author/{username}": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/posts/author/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/social/save": {
+      "delete": {
+        "tags": [
+          "social"
+        ],
+        "summary": "DELETE /social/save",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "social"
+        ],
+        "summary": "POST /social/save",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/social/saved": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/saved",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/social/search": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/search",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/social/titles": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "GET /social/titles",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/transactions/balance": {
+      "get": {
+        "tags": [
+          "transactions"
+        ],
+        "summary": "GET /transactions/balance",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/transactions/my": {
+      "get": {
+        "tags": [
+          "transactions"
+        ],
+        "summary": "GET /transactions/my",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/transactions/prepare": {
+      "post": {
+        "tags": [
+          "transactions"
+        ],
+        "summary": "POST /transactions/prepare",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transactions/send": {
+      "post": {
+        "tags": [
+          "transactions"
+        ],
+        "summary": "POST /transactions/send",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/all_avatars": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "GET /user/all_avatars",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    },
+    "/user/delete_role": {
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "DELETE /user/delete_role",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/department/name/{department}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "GET /user/department/name/{department}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "department",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/user/department/roles": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "GET /user/department/roles",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/user/department/roles/{department}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "GET /user/department/roles/{department}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "department",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/user/department/start/{department}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "GET /user/department/start/{department}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "department",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/user/full/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "GET /user/full/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/user/roles/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "GET /user/roles/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/user/set_avatar": {
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "PUT /user/set_avatar",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/unactive_roles/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "GET /user/unactive_roles/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "GET /user/{username}",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/ws": {
+      "get": {
+        "tags": [
+          "ws"
+        ],
+        "summary": "GET /ws",
+        "description": "Маршрут доступен не только администраторам. Точные права и формат данных проверяются backend-обработчиком.",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authentication or authorization failed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerHeader": []
+          },
+          {
+            "authSession": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/docs/openapi_inventory.py
+++ b/docs/openapi_inventory.py
@@ -1,0 +1,70 @@
+"""Source inventory for the non-admin OpenAPI document.
+
+A route belongs here when a regular portal user can invoke it, including
+self-scoped and moderator/publisher operations. Strictly administrator-only
+handlers and development probes are excluded.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ADMIN_ONLY_HANDLERS = {
+    ("src/basic/analytics.cc", "register_routes", "/analytics/activity/summary"),
+    ("src/basic/analytics.cc", "register_routes", "/analytics/activity/daily:search(.*)"),
+    ("src/basic/analytics.cc", "register_routes", "/analytics/activity/active-users:search(.*)"),
+    ("src/basic/analytics.cc", "register_routes", "/analytics/activity/users/:username([a-zA-Z0-9_.@\\-]+)"),
+    ("src/basic/auth.cc", "add_userrights", "/auth/add_userrights"),
+    ("src/basic/auth.cc", "admin_create_user", "/auth/admin_create_user"),
+    ("src/basic/auth.cc", "add_new_user", "/auth/add_user"),
+    ("src/basic/user_data.cc", "add_user_role", "/user/add_role"),
+    ("src/basic/user_data.cc", "create_role", "/user/create_role"),
+    ("src/basic/user_data.cc", "set_users_department", "/user/set_department"),
+    ("src/basic/ws_endpoint.cc", "list_active_sessions", "/ws/sessions/active"),
+    ("src/letovo-soc-net/achivements.cc", "delete_achivement", "/achivements/delete"),
+    ("src/letovo-soc-net/achivements.cc", "create_achivement", "/achivements/create"),
+    ("src/letovo-soc-net/chat.cc", "set_permission", "/chat/permission"),
+    ("src/letovo-soc-net/chat.cc", "clear_permission", "/chat/permission"),
+    ("src/letovo-soc-net/page_server.cc", "rename_category", "/post/rename_category"),
+    ("src/letovo-soc-net/page_server.cc", "update_post", "/post/update"),
+    ("src/letovo-soc-net/page_server.cc", "reveal_secret_page", "/post/reveal_secret_link/:id(\\d+)"),
+    ("src/letovo-soc-net/page_server.cc", "add_media", "/post/add_media"),
+    ("src/letovo-soc-net/page_server.cc", "delete_media", "/post/delete_media"),
+    ("src/market/transactions.cc", "department_payout", "/transactions/department-payout"),
+}
+
+DEVELOPMENT_ONLY_HANDLERS = {
+    ("src/server.cpp", "hi", "/hi"),
+    ("src/server.cpp", "hi", "/test"),
+    ("src/server.cpp", "hi", "/token_getter"),
+    ("src/server.cpp", "hi", "/test_file"),
+}
+
+ROUTE_RE = re.compile(
+    r'http_(get|post|put|delete)\s*\(\s*(?:R"\(([^\n]*?)\)"|"([^"\n]+)")'
+)
+FUNCTION_RE = re.compile(r"\bvoid\s+([A-Za-z_][\w]*)\s*\(")
+PARAM_RE = re.compile(r":([A-Za-z_][\w]*)\([^)]*\)")
+
+
+def openapi_path(route: str) -> str:
+    return PARAM_RE.sub(
+        lambda match: "{" + match.group(1) + "}", route.replace(":search(.*)", "")
+    )
+
+
+def registered_non_admin_routes() -> set[tuple[str, str]]:
+    routes = set()
+    for source in sorted((ROOT / "src").rglob("*.cc")):
+        relative = source.relative_to(ROOT).as_posix()
+        text = source.read_text(encoding="utf-8")
+        for match in ROUTE_RE.finditer(text):
+            route = match.group(2) or match.group(3)
+            preceding = list(FUNCTION_RE.finditer(text, 0, match.start()))
+            function = preceding[-1].group(1) if preceding else ""
+            handler = (relative, function, route)
+            if handler in ADMIN_ONLY_HANDLERS or handler in DEVELOPMENT_ONLY_HANDLERS:
+                continue
+            routes.add((match.group(1).lower(), openapi_path(route)))
+    return routes

--- a/docs/openapi_inventory.py
+++ b/docs/openapi_inventory.py
@@ -19,9 +19,9 @@ ADMIN_ONLY_HANDLERS = {
     ("src/basic/auth.cc", "admin_create_user", "/auth/admin_create_user"),
     ("src/basic/auth.cc", "add_new_user", "/auth/add_user"),
     ("src/basic/user_data.cc", "add_user_role", "/user/add_role"),
-    ("src/basic/user_data.cc", "create_role", "/user/create_role"),
     ("src/basic/user_data.cc", "set_users_department", "/user/set_department"),
     ("src/basic/ws_endpoint.cc", "list_active_sessions", "/ws/sessions/active"),
+    ("src/basic/qr_worker.cc", "page_qr", "/post/qr/:post_id([0-9]+)"),
     ("src/letovo-soc-net/achivements.cc", "delete_achivement", "/achivements/delete"),
     ("src/letovo-soc-net/achivements.cc", "create_achivement", "/achivements/create"),
     ("src/letovo-soc-net/chat.cc", "set_permission", "/chat/permission"),
@@ -49,8 +49,14 @@ PARAM_RE = re.compile(r":([A-Za-z_][\w]*)\([^)]*\)")
 
 
 def openapi_path(route: str) -> str:
-    return PARAM_RE.sub(
+    normalized = PARAM_RE.sub(
         lambda match: "{" + match.group(1) + "}", route.replace(":search(.*)", "")
+    )
+    return (
+        normalized.replace("/actives/active/{id}", "/actives/active/{identifier}")
+        .replace("/actives/active/{ticker}", "/actives/active/{identifier}")
+        .replace("/actives/history/{id}", "/actives/history/{identifier}")
+        .replace("/actives/history/{ticker}", "/actives/history/{identifier}")
     )
 
 

--- a/test/test_openapi_non_admin_coverage.py
+++ b/test/test_openapi_non_admin_coverage.py
@@ -29,4 +29,8 @@ def test_openapi_is_portal_scoped_and_excludes_admin_only_handlers():
     documented_paths = set(spec["paths"])
     assert "/auth/admin_create_user" not in documented_paths
     assert "/transactions/department-payout" not in documented_paths
+    assert "/post/qr/{post_id}" not in documented_paths
+    assert "/user/create_role" in documented_paths
     assert all("{search}" not in path for path in documented_paths)
+    assert "/actives/active/{identifier}" in documented_paths
+    assert "/actives/history/{identifier}" in documented_paths

--- a/test/test_openapi_non_admin_coverage.py
+++ b/test/test_openapi_non_admin_coverage.py
@@ -1,0 +1,32 @@
+"""Keep the published OpenAPI inventory aligned with non-admin backend routes."""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "docs"))
+from openapi_inventory import registered_non_admin_routes  # noqa: E402
+
+SPEC_PATH = ROOT / "docs" / "openapi.json"
+
+
+def test_openapi_documents_every_registered_non_admin_route():
+    spec = json.loads(SPEC_PATH.read_text(encoding="utf-8"))
+    documented = {
+        (method.lower(), path)
+        for path, operations in spec["paths"].items()
+        for method in operations
+        if method.lower() in {"get", "post", "put", "delete"}
+    }
+    assert registered_non_admin_routes() == documented
+
+
+def test_openapi_is_portal_scoped_and_excludes_admin_only_handlers():
+    spec = json.loads(SPEC_PATH.read_text(encoding="utf-8"))
+    assert spec["openapi"].startswith("3.1.")
+    assert spec["servers"] == [{"url": "https://letovocorp.ru/letovo-api"}]
+    documented_paths = set(spec["paths"])
+    assert "/auth/admin_create_user" not in documented_paths
+    assert "/transactions/department-payout" not in documented_paths
+    assert all("{search}" not in path for path in documented_paths)


### PR DESCRIPTION
## Что добавлено
- `docs/openapi.json`: OpenAPI 3.1-инвентаризация 85 путей / 89 операций backend, доступных не только администраторам.
- `docs/openapi_inventory.py` и `docs/generate_openapi.py`: генерация из фактически зарегистрированных RESTinio-маршрутов.
- `test/test_openapi_non_admin_coverage.py`: защита от расхождения спецификации с исходниками; strict admin-only и development-пробы исключаются.
- README с командой регенерации.

## Вне scope
- Строго admin-only обработчики и development-пробы не документируются.
- Описание форматов response/body пока общее: точные контрактные схемы в исходниках неоднородны и требуют отдельной нормализации.

## Проверка
- `python3 docs/generate_openapi.py`
- `python3 -m pytest -q test/test_openapi_non_admin_coverage.py` → 2 passed
- `uv run --with openapi-spec-validator ...` → OpenAPI validation passed
- `python3 -m pytest -q` не прошёл collection из-за существующих проблем окружения/тестов: отсутствуют `psycopg2`, `flask`, `clang`; также есть тесты с жёстко заданными отсутствующими путями.
