### PR TITLE
fix: report department payout database failures

### DIFF
--- a/src/basic/pqxx_cp.cc
+++ b/src/basic/pqxx_cp.cc
@@ -532,6 +532,20 @@ pqxx::result AsyncConnection::execute_params(const std::string &sql,
   return r;
 }
 
+pqxx::result AsyncConnection::execute_params_or_throw(
+    const std::string &sql, std::vector<std::string> &params, bool commit) {
+  if (!is_open()) {
+    con = std::make_shared<pqxx::connection>(connect_string);
+  }
+  pqxx::work w(*con);
+  pqxx::result r = w.exec_params(sql, pqxx::prepare::make_dynamic_params(params));
+  if (commit) {
+    w.commit();
+  }
+  last_used = std::chrono::system_clock::now();
+  return r;
+}
+
 pqxx::result AsyncConnection::execute_params(const std::string &sql,
                                              std::vector<int> &params,
                                              bool commit) {

--- a/src/basic/pqxx_cp.h
+++ b/src/basic/pqxx_cp.h
@@ -50,6 +50,9 @@ public:
   pqxx::result execute_params(const std::string &sql,
                               std::vector<std::string> &params,
                               bool commit = false);
+  pqxx::result execute_params_or_throw(const std::string &sql,
+                                       std::vector<std::string> &params,
+                                       bool commit = false);
   pqxx::result execute_many(std::vector<Request> &);
   pqxx::result execute_params(const std::string &sql, std::vector<int> &params,
                               bool commit = false);

--- a/src/market/transactions.cc
+++ b/src/market/transactions.cc
@@ -312,11 +312,11 @@ namespace transactions {
         payout.department_id = department_id;
         payout.amount = amount;
 
-        auto con = std::move(pool_ptr->getConnection());
+        cp::SafeCon con{pool_ptr};
         std::vector<std::string> params = {
             std::to_string(department_id), std::to_string(amount), actor,
             request_id, std::to_string(expected_recipient_count)};
-        pqxx::result rows = con->execute_params(
+        pqxx::result rows = con->execute_params_or_throw(
             R"(WITH request_lock AS (
                    SELECT pg_advisory_xact_lock(hashtext($4))
                ),
@@ -390,10 +390,16 @@ namespace transactions {
                CROSS JOIN recipient_totals totals
                CROSS JOIN existing prior)",
             params, true);
-        pool_ptr->returnConnection(std::move(con));
 
         if (rows.empty()) {
-            payout.status = DepartmentPayoutStatus::DepartmentNotFound;
+            std::vector<std::string> department_params = {
+                std::to_string(department_id)};
+            pqxx::result department = con->execute_params_or_throw(
+                R"(SELECT 1 FROM "department" WHERE departmentid = $1::integer)",
+                department_params);
+            payout.status = department.empty()
+                ? DepartmentPayoutStatus::DepartmentNotFound
+                : DepartmentPayoutStatus::Error;
             return payout;
         }
 
@@ -566,11 +572,32 @@ namespace transactions::server {
                 }
 
                 const std::string actor = auth::get_username(token, pool_ptr);
-                transactions::DepartmentPayoutResult payout = confirm
-                    ? transactions::apply_department_payout(
-                        department_id, amount, actor,
-                        request_id, body["expected_recipient_count"].GetInt(), pool_ptr)
-                    : transactions::preview_department_payout(department_id, amount, pool_ptr);
+                transactions::DepartmentPayoutResult payout;
+                try {
+                    payout = confirm
+                        ? transactions::apply_department_payout(
+                            department_id, amount, actor,
+                            request_id, body["expected_recipient_count"].GetInt(), pool_ptr)
+                        : transactions::preview_department_payout(department_id, amount, pool_ptr);
+                } catch (const pqxx::sql_error& error) {
+                    const std::string sqlstate = error.sqlstate();
+                    const std::string message = error.what();
+                    logger_ptr->error([sqlstate, message] {
+                        return "department payout database failure: SQLSTATE=" +
+                            sqlstate + " message=" + message;
+                    });
+                    return req->create_response(restinio::status_internal_server_error())
+                        .append_header("Content-Type", "application/json; charset=utf-8")
+                        .set_body(R"({"error":"department payout failed"})").done();
+                } catch (const std::exception& error) {
+                    const std::string message = error.what();
+                    logger_ptr->error([message] {
+                        return "department payout database failure: " + message;
+                    });
+                    return req->create_response(restinio::status_internal_server_error())
+                        .append_header("Content-Type", "application/json; charset=utf-8")
+                        .set_body(R"({"error":"department payout failed"})").done();
+                }
                 logger_ptr->info([department_id, confirm, status = payout.status] {
                     return fmt::format(
                         "department_payout department_id={} confirm={} outcome={}",

--- a/test/test_issue155_department_payout_contract.py
+++ b/test/test_issue155_department_payout_contract.py
@@ -60,6 +60,13 @@ def test_preview_confirm_inputs_and_safe_outcome_logging_are_explicit():
     assert "request_id" not in TRANSACTIONS.split(
         '"department_payout department_id={} confirm={} outcome={}"', 1
     )[1].split("switch (payout.status)", 1)[0]
+def test_apply_does_not_report_database_errors_as_missing_departments():
+    assert "execute_params_or_throw" in TRANSACTIONS
+    assert 'SELECT 1 FROM "department" WHERE departmentid = $1::integer' in TRANSACTIONS
+    assert "DepartmentPayoutStatus::DepartmentNotFound" in TRANSACTIONS
+    assert "catch (const pqxx::sql_error& error)" in TRANSACTIONS
+    assert "department payout database failure: SQLSTATE=" in TRANSACTIONS
+    assert 'R"({"error":"department payout failed"})"' in TRANSACTIONS
 
 
 def test_amount_and_request_id_are_validated():


### PR DESCRIPTION
Fixes #161

- execute the payout CTE through a throwing database path so SQL failures are not treated as empty results
- return `500 department payout failed` and log SQLSTATE plus the database message
- check department existence separately before returning 404
- add regression coverage for the error/404 distinction

Validation:
- payout backend contract assertions
- `node scripts/test-department-payout.mjs` (frontend)
- `git diff --check`

Note: CMake configuration did not complete its dependency setup in this environment, so it produced no cache and no backend compilation result.