### PR TITLE
fix: migrate department payout audit column

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -355,6 +355,8 @@ jobs:
             "$remote:$state_dir/avatar_upload_role_migration.sql"
           scp -i ~/.ssh/live-e2e docs/child_avatar_access_migration.sql \
             "$remote:$state_dir/child_avatar_access_migration.sql"
+          scp -i ~/.ssh/live-e2e docs/department_payout_migration.sql \
+            "$remote:$state_dir/department_payout_migration.sql"
           ssh -i ~/.ssh/live-e2e "$remote" \
             "BACKEND_IMAGE='$BACKEND_CANDIDATE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_CANDIDATE_IMAGE' FRONTEND_IMAGE='$FRONTEND_CANDIDATE_IMAGE' COMPOSE_FILE='$LETOVO_E2E_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_E2E_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
           set -euo pipefail
@@ -366,6 +368,7 @@ jobs:
           candidate="$state_dir/docker-compose.yaml"
           migration="$state_dir/avatar_upload_role_migration.sql"
           child_avatar_migration="$state_dir/child_avatar_access_migration.sql"
+          payout_migration="$state_dir/department_payout_migration.sql"
           backup_root="$HOME/backups/letovo-live-e2e-${RUN_ID}"
           role_backup="$backup_root/role.before-avatar-migration.sql"
           user_backup="$backup_root/user.before-child-avatar-migration.sql"
@@ -373,6 +376,12 @@ jobs:
 
           test -f "$migration"
           test -f "$child_avatar_migration"
+          test -f "$payout_migration"
+          docker cp "$payout_migration" letovo-postgres-1:/tmp/department_payout_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
+              -f /tmp/department_payout_migration.sql
+          docker exec letovo-postgres-1 rm -f /tmp/department_payout_migration.sql
           mkdir -p "$backup_root"
 
           docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -372,17 +372,21 @@ jobs:
           backup_root="$HOME/backups/letovo-live-e2e-${RUN_ID}"
           role_backup="$backup_root/role.before-avatar-migration.sql"
           user_backup="$backup_root/user.before-child-avatar-migration.sql"
+          transactions_backup="$backup_root/transactions.before-department-payout-migration.sql"
           child_avatar_preview="$backup_root/child-avatar-migration-preview.csv"
 
           test -f "$migration"
           test -f "$child_avatar_migration"
           test -f "$payout_migration"
+          mkdir -p "$backup_root"
+          docker exec letovo-postgres-1 \
+            pg_dump -U scv -d letovo_db -t public.transactions > "$transactions_backup"
+          test -s "$transactions_backup"
           docker cp "$payout_migration" letovo-postgres-1:/tmp/department_payout_migration.sql
           docker exec letovo-postgres-1 \
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
               -f /tmp/department_payout_migration.sql
           docker exec letovo-postgres-1 rm -f /tmp/department_payout_migration.sql
-          mkdir -p "$backup_root"
 
           docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
           docker inspect -f 'letovo-registration-server={{.Config.Image}}' letovo-registration-server >> "$restore"

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -379,6 +379,8 @@ jobs:
           role_backup_tmp="$state_dir/role.before-avatar-migration.sql"
           user_backup="$backup_root/user.before-child-avatar-migration.sql"
           user_backup_tmp="$state_dir/user.before-child-avatar-migration.sql"
+          transactions_backup="$backup_root/transactions.before-department-payout-migration.sql"
+          transactions_backup_tmp="$state_dir/transactions.before-department-payout-migration.sql"
           child_avatar_preview="$backup_root/child-avatar-migration-preview.csv"
           child_avatar_preview_tmp="$state_dir/child-avatar-migration-preview.csv"
 
@@ -399,6 +401,11 @@ jobs:
           test -f "$migration"
           test -f "$child_avatar_migration"
           test -f "$payout_migration"
+          as_root mkdir -p "$backup_root"
+          docker exec letovo-postgres-1 \
+            pg_dump -U scv -d letovo_db -t public.transactions > "$transactions_backup_tmp"
+          test -s "$transactions_backup_tmp"
+          as_root install -m 0600 "$transactions_backup_tmp" "$transactions_backup"
           docker cp "$payout_migration" letovo-postgres-1:/tmp/department_payout_migration.sql
           docker exec letovo-postgres-1 \
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -347,6 +347,8 @@ jobs:
             "$remote:$state_dir/avatar_upload_role_migration.sql"
           scp -i ~/.ssh/letovo-production-release docs/child_avatar_access_migration.sql \
             "$remote:$state_dir/child_avatar_access_migration.sql"
+          scp -i ~/.ssh/letovo-production-release docs/department_payout_migration.sql \
+            "$remote:$state_dir/department_payout_migration.sql"
           ssh -i ~/.ssh/letovo-production-release "$remote" \
             "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' NGINX_SITE='$LETOVO_PROD_NGINX_SITE' RUN_ID='${{ github.run_id }}' EXPECTED_CHILD_AVATAR_COUNT='$CHILD_AVATAR_EXPECTED_COUNT' EXPECTED_CHILD_AVATAR_SHA256='$CHILD_AVATAR_EXPECTED_SHA256' bash -s" <<'REMOTE'
           set -euo pipefail
@@ -366,6 +368,7 @@ jobs:
           repo_front_env="$state_dir/letovo-front.env.from-repo"
           migration="$state_dir/avatar_upload_role_migration.sql"
           child_avatar_migration="$state_dir/child_avatar_access_migration.sql"
+          payout_migration="$state_dir/department_payout_migration.sql"
           nginx_candidate="$state_dir/nginx-site.candidate"
           compose_dir="$(dirname "$COMPOSE_FILE")"
           otel_config="$compose_dir/otel-collector-config.yaml"
@@ -395,6 +398,12 @@ jobs:
           test -f "$repo_front_env"
           test -f "$migration"
           test -f "$child_avatar_migration"
+          test -f "$payout_migration"
+          docker cp "$payout_migration" letovo-postgres-1:/tmp/department_payout_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
+              -f /tmp/department_payout_migration.sql
+          docker exec letovo-postgres-1 rm -f /tmp/department_payout_migration.sql
           docker rm -f "$smoke_name" >/dev/null 2>&1 || true
           cleanup_smoke() {
             docker rm -f "$smoke_name" >/dev/null 2>&1 || true

--- a/docs/department_payout_migration.sql
+++ b/docs/department_payout_migration.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS reason character varying NOT NULL DEFAULT 'wire transfer';
+
+COMMIT;

--- a/src/market/transactions.cc
+++ b/src/market/transactions.cc
@@ -366,11 +366,11 @@ namespace transactions {
                ),
                inserted AS (
                    INSERT INTO "transactions" (sender, receiver, amount, reason)
-                   SELECT $3,
+                   SELECT $3::character varying,
                           updated.username,
                           $2::integer,
                           'department payout: ' || d.departmentname ||
-                          '; issued by ' || $3 || '; request ' || $4
+                          '; issued by ' || $3::character varying || '; request ' || $4
                    FROM updated
                    CROSS JOIN department_row d
                    RETURNING transactionid

--- a/test/test_issue155_department_payout_contract.py
+++ b/test/test_issue155_department_payout_contract.py
@@ -6,6 +6,9 @@ TRANSACTIONS = (ROOT / "src/market/transactions.cc").read_text()
 HEADER = (ROOT / "src/market/transactions.h").read_text()
 SERVER = (ROOT / "src/server.cpp").read_text()
 SCHEMA = (ROOT / "docs/schema.sql").read_text()
+MIGRATION = (ROOT / "docs/department_payout_migration.sql").read_text()
+BUILD_WORKFLOW = (ROOT / ".github/workflows/docker-image.yml").read_text()
+RELEASE_WORKFLOW = (ROOT / ".github/workflows/production-release.yml").read_text()
 
 
 def test_admin_only_endpoint_is_registered():
@@ -39,6 +42,14 @@ def test_apply_is_atomic_auditable_and_idempotent():
     assert "BOOL_AND(u.balance <= 2147483647 - $2::integer)" in TRANSACTIONS
     assert "params, true" in TRANSACTIONS
     assert "reason character varying DEFAULT 'wire transfer'" in SCHEMA
+
+
+def test_reason_column_migration_runs_before_candidate_and_production_payouts():
+    assert "ADD COLUMN IF NOT EXISTS reason character varying NOT NULL DEFAULT 'wire transfer'" in MIGRATION
+    for workflow in (BUILD_WORKFLOW, RELEASE_WORKFLOW):
+        assert "docs/department_payout_migration.sql" in workflow
+        assert "department_payout_migration.sql" in workflow
+        assert "psql -v ON_ERROR_STOP=1 -U scv -d letovo_db" in workflow
 
 
 def test_payout_does_not_read_or_debit_admin_balance():

--- a/test/test_issue155_department_payout_contract.py
+++ b/test/test_issue155_department_payout_contract.py
@@ -50,6 +50,8 @@ def test_reason_column_migration_runs_before_candidate_and_production_payouts():
         assert "docs/department_payout_migration.sql" in workflow
         assert "department_payout_migration.sql" in workflow
         assert "psql -v ON_ERROR_STOP=1 -U scv -d letovo_db" in workflow
+        assert "pg_dump -U scv -d letovo_db -t public.transactions" in workflow
+        assert workflow.index("pg_dump -U scv -d letovo_db -t public.transactions") < workflow.index('docker cp "$payout_migration"')
 
 
 def test_payout_does_not_read_or_debit_admin_balance():

--- a/test/test_issue155_department_payout_contract.py
+++ b/test/test_issue155_department_payout_contract.py
@@ -53,6 +53,10 @@ def test_reason_column_migration_runs_before_candidate_and_production_payouts():
         assert "pg_dump -U scv -d letovo_db -t public.transactions" in workflow
         assert workflow.index("pg_dump -U scv -d letovo_db -t public.transactions") < workflow.index('docker cp "$payout_migration"')
 
+def test_apply_casts_actor_parameter_to_transactions_sender_type():
+    assert "SELECT $3::character varying," in TRANSACTIONS
+    assert "; issued by ' || $3::character varying ||" in TRANSACTIONS
+
 
 def test_payout_does_not_read_or_debit_admin_balance():
     handler = TRANSACTIONS.split(


### PR DESCRIPTION
Fixes #161

The payout CTE requires `transactions.reason` for idempotency/audit matching. A safe reproduction on the live-test database showed the column absent, causing the observed HTTP 500.

- add an idempotent `department_payout_migration.sql`
- apply it before candidate and production deployment
- cover the migration/deployment contract

Validation: payout contract assertions and `git diff --check`.