### PR TITLE
fix: снять кулдаун переводов для администраторов

### DIFF
--- a/src/market/transaction_rules.h
+++ b/src/market/transaction_rules.h
@@ -5,6 +5,10 @@ namespace transactions {
 constexpr int kAdminBalanceLimit = 999999999;
 constexpr int kTransferCooldownSeconds = 5;
 
+inline bool is_transfer_cooldown_active(int seconds_remaining, bool sender_is_admin) {
+    return !sender_is_admin && seconds_remaining > 0;
+}
+
 inline bool can_transfer_amount(int sender_balance, int amount, bool sender_is_admin) {
     if (!sender_is_admin && amount < 0) {
         return false;

--- a/src/market/transactions.cc
+++ b/src/market/transactions.cc
@@ -121,7 +121,9 @@ namespace transactions {
         result.amount = amount;
         bool sender_is_admin = auth::is_rights_by_username(transaction->sender, pool_ptr);
 
-        if (transfer_cooldown_seconds_remaining(transaction->sender, pool_ptr) > 0) {
+        if (is_transfer_cooldown_active(
+                transfer_cooldown_seconds_remaining(transaction->sender, pool_ptr),
+                sender_is_admin)) {
             result.status = TransactionStatus::Cooldown;
             return result;
         }
@@ -467,7 +469,9 @@ namespace transactions {
         if (!sender_is_admin && !has_whireable_participant(sender, reciver, pool_ptr)) {
             return {TransactionStatus::NotReceiver, ""};
         }
-        if (transfer_cooldown_seconds_remaining(sender, pool_ptr) > 0) {
+        if (is_transfer_cooldown_active(
+                transfer_cooldown_seconds_remaining(sender, pool_ptr),
+                sender_is_admin)) {
             return {TransactionStatus::Cooldown, ""};
         }
         

--- a/test/test_market.py
+++ b/test/test_market.py
@@ -308,6 +308,47 @@ def test_prepared_transfer_ids_obey_send_cooldown():
     assert second_send_response.text == "transfer cooldown active"
 
 
+def test_admin_transactions_bypass_prepare_and_send_cooldown(admin_user, sender_user):
+    """Admins can prepare and send immediate transfers, including pre-created IDs."""
+    headers = {"Bearer": admin_user["token"]}
+    payload = {"receiver": sender_user["login"], "amount": 0}
+
+    prepared_ids = []
+    for _ in range(2):
+        response = requests.post(
+            f"{BASE_URL}/transactions/prepare",
+            headers=headers,
+            json=payload,
+            verify=False,
+        )
+        assert response.status_code == 200, response.text
+        prepared_ids.append(response.text)
+
+    first_send = requests.post(
+        f"{BASE_URL}/transactions/send",
+        headers=headers,
+        json={"tr_id": prepared_ids[0]},
+        verify=False,
+    )
+    assert first_send.status_code == 200, first_send.text
+
+    prepare_during_cooldown = requests.post(
+        f"{BASE_URL}/transactions/prepare",
+        headers=headers,
+        json=payload,
+        verify=False,
+    )
+    assert prepare_during_cooldown.status_code == 200, prepare_during_cooldown.text
+
+    second_send = requests.post(
+        f"{BASE_URL}/transactions/send",
+        headers=headers,
+        json={"tr_id": prepared_ids[1]},
+        verify=False,
+    )
+    assert second_send.status_code == 200, second_send.text
+
+
 def test_prepare_negative_transaction_as_admin(admin_user, sender_user):
     """Admins can prepare negative transactions without receiver balance checks."""
     response = requests.post(
@@ -320,10 +361,7 @@ def test_prepare_negative_transaction_as_admin(admin_user, sender_user):
         verify=False
     )
 
-    assert response.status_code in [200, 429]
-    if response.status_code == 429:
-        assert response.headers.get("Retry-After") == "5"
-        return
+    assert response.status_code == 200, response.text
     assert response.text
 
 

--- a/test/test_transaction_rules.py
+++ b/test/test_transaction_rules.py
@@ -34,6 +34,39 @@ def test_admin_negative_transaction_ignores_receiver_balance(tmp_path):
     subprocess.run([str(binary)], check=True)
 
 
+def test_admin_bypasses_transfer_cooldown(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    source = tmp_path / "transaction_cooldown_rules_check.cpp"
+    binary = tmp_path / "transaction_cooldown_rules_check"
+
+    source.write_text(
+        textwrap.dedent(
+            f"""
+            #include "{repo_root / "src/market/transaction_rules.h"}"
+
+            int main() {{
+                if (transactions::is_transfer_cooldown_active(5, true)) {{
+                    return 1;
+                }}
+                if (!transactions::is_transfer_cooldown_active(5, false)) {{
+                    return 2;
+                }}
+                if (transactions::is_transfer_cooldown_active(0, false)) {{
+                    return 3;
+                }}
+                return 0;
+            }}
+            """
+        )
+    )
+
+    subprocess.run(
+        ["g++", "-std=c++20", str(source), "-o", str(binary)],
+        check=True,
+    )
+    subprocess.run([str(binary)], check=True)
+
+
 def test_whireable_role_allows_either_transfer_participant(tmp_path):
     repo_root = Path(__file__).resolve().parents[1]
     source = tmp_path / "whireable_transfer_rules_check.cpp"
@@ -118,7 +151,7 @@ def test_admin_sender_bypasses_transaction_recipient_restrictions():
     assert transaction_source.count("if (!sender_is_admin && !transactions::can_use_transactions(") >= 2
 
 
-def test_transfer_prepare_has_five_second_cooldown_for_all_senders():
+def test_transfer_cooldown_is_enforced_for_non_admin_senders():
     repo_root = Path(__file__).resolve().parents[1]
     transaction_source = (repo_root / "src/market/transactions.cc").read_text()
     transaction_header = (repo_root / "src/market/transactions.h").read_text()
@@ -131,8 +164,10 @@ def test_transfer_prepare_has_five_second_cooldown_for_all_senders():
     assert "WHERE sender = $1" in transaction_source
     assert "MAX(transactiontime)" in transaction_source
     assert "LOCALTIMESTAMP - MAX(transactiontime)" in transaction_source
-    assert "transfer_cooldown_seconds_remaining(sender, pool_ptr) > 0" in transaction_source
-    assert "transfer_cooldown_seconds_remaining(transaction->sender, pool_ptr) > 0" in transaction_source
+    assert "transfer_cooldown_seconds_remaining(sender, pool_ptr)" in transaction_source
+    assert "transfer_cooldown_seconds_remaining(transaction->sender, pool_ptr)" in transaction_source
+    assert transaction_source.count("if (is_transfer_cooldown_active(") == 2
+    assert transaction_source.count("sender_is_admin))") >= 2
     assert transaction_source.count("TransactionStatus::Cooldown") >= 3
     assert transaction_source.count("restinio::status_too_many_requests()") >= 2
     assert transaction_source.count('append_header("Retry-After", std::to_string(kTransferCooldownSeconds))') >= 2


### PR DESCRIPTION
## Summary
- exempt administrators from the five-second transfer cooldown at both `/transactions/prepare` and `/transactions/send`
- keep the send-side cooldown check for non-admin pre-created transaction IDs
- add a pure C++ regression rule plus endpoint-level coverage for immediate admin prepares/sends
- tighten the existing admin negative-transfer test so `429` is no longer accepted

## Verification
All development and verification ran on `ya.sergeiscv.ru`; nothing was built or tested on the local machine.

- `python -m pytest -q test/test_transaction_rules.py` — **7 passed**
- `python -m py_compile test/test_market.py test/test_transaction_rules.py` — passed
- backend Docker build with the same source list/build arguments as CI — passed
  - image: `sha256:409dd4ea2a20d62b365452269c4fee71e72cc9ddf883cbf00ad75d3d2a17ab38`
- `git diff --check` — passed

Closes #165
