### PR TITLE
Fix personal avatar uploader deployment

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,6 +21,7 @@ env:
   BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-server
   FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-all-frontend
   REGISTRATION_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-registration-server
+  UPLOADER_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-flask-uploader
   LIVE_E2E_BASE_URL: ${{ vars.LIVE_E2E_BASE_URL || 'https://ya.sergeiscv.ru' }}
 
 jobs:
@@ -76,6 +77,20 @@ jobs:
 
       - name: Inspect registration backend image
         run: docker image inspect letovo-registration-server:${{ github.sha }} >/dev/null
+
+      - name: Build uploader image locally
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src/python-helpers
+          file: ./src/python-helpers/dockerfile.uploader
+          load: true
+          push: false
+          tags: letovo-flask-uploader:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Inspect uploader image
+        run: docker image inspect letovo-flask-uploader:${{ github.sha }} >/dev/null
 
   publish-pr-candidate:
     if: github.event_name == 'pull_request'
@@ -160,6 +175,18 @@ jobs:
             NEXT_PUBLIC_OTEL_TRACES_SAMPLER_RATIO=0.1
             NEXT_PUBLIC_LETOVO_BUILD_SHA=${{ github.sha }}
           tags: ${{ env.FRONTEND_IMAGE }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push PR uploader image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src/python-helpers
+          file: ./src/python-helpers/dockerfile.uploader
+          push: true
+          build-args: |
+            UPLOADER_CAPABILITIES_URL=${{ env.LIVE_E2E_BASE_URL }}/letovo-api/auth/amiuploader
+          tags: ${{ env.UPLOADER_IMAGE }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -248,6 +275,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push uploader image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src/python-helpers
+          file: ./src/python-helpers/dockerfile.uploader
+          push: true
+          build-args: |
+            UPLOADER_CAPABILITIES_URL=${{ vars.PRODUCTION_BASE_URL || 'https://letovocorp.ru' }}/letovo-api/auth/amiuploader
+          tags: |
+            ${{ env.UPLOADER_IMAGE }}:latest
+            ${{ env.UPLOADER_IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   frontend-verify:
     runs-on: ubuntu-latest
     steps:
@@ -323,6 +364,7 @@ jobs:
             echo "BACKEND_CANDIDATE_IMAGE=${BACKEND_IMAGE}:${tag}"
             echo "REGISTRATION_CANDIDATE_IMAGE=${REGISTRATION_IMAGE}:${tag}"
             echo "FRONTEND_CANDIDATE_IMAGE=${FRONTEND_IMAGE}:${tag}"
+            echo "UPLOADER_CANDIDATE_IMAGE=${UPLOADER_IMAGE}:${tag}"
           } >> "$GITHUB_ENV"
 
       - name: Validate live e2e deployment secrets
@@ -333,6 +375,7 @@ jobs:
           test -n "$BACKEND_CANDIDATE_IMAGE" || { echo "backend candidate image is required"; exit 1; }
           test -n "$REGISTRATION_CANDIDATE_IMAGE" || { echo "registration candidate image is required"; exit 1; }
           test -n "$FRONTEND_CANDIDATE_IMAGE" || { echo "frontend candidate image is required"; exit 1; }
+          test -n "$UPLOADER_CANDIDATE_IMAGE" || { echo "uploader candidate image is required"; exit 1; }
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -358,7 +401,7 @@ jobs:
           scp -i ~/.ssh/live-e2e docs/department_payout_migration.sql \
             "$remote:$state_dir/department_payout_migration.sql"
           ssh -i ~/.ssh/live-e2e "$remote" \
-            "BACKEND_IMAGE='$BACKEND_CANDIDATE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_CANDIDATE_IMAGE' FRONTEND_IMAGE='$FRONTEND_CANDIDATE_IMAGE' COMPOSE_FILE='$LETOVO_E2E_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_E2E_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
+            "BACKEND_IMAGE='$BACKEND_CANDIDATE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_CANDIDATE_IMAGE' FRONTEND_IMAGE='$FRONTEND_CANDIDATE_IMAGE' UPLOADER_IMAGE='$UPLOADER_CANDIDATE_IMAGE' COMPOSE_FILE='$LETOVO_E2E_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_E2E_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
           set -euo pipefail
           umask 077
           test -f "$COMPOSE_FILE"
@@ -391,6 +434,7 @@ jobs:
           docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
           docker inspect -f 'letovo-registration-server={{.Config.Image}}' letovo-registration-server >> "$restore"
           docker inspect -f 'letovo-front={{.Config.Image}}' letovo-front >> "$restore"
+          docker inspect -f 'flask-uploader={{.Config.Image}}' flask-uploader >> "$restore"
 
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.role > "$role_backup"
@@ -426,13 +470,15 @@ jobs:
             -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${BACKEND_IMAGE}#" \
             -e "s#image: ghcr.io/letovo-dev/letovo-registration-server:.*#image: ${REGISTRATION_IMAGE}#" \
             -e "/^    letovo-front:/,/^    [[:alnum:]_-]+:$/ s#^([[:space:]]*)image:.*#\\1image: ${FRONTEND_IMAGE}#" \
+            -e "/^    letovo-flask-uploader:/,/^    [[:alnum:]_-]+:$/ s#^([[:space:]]*)image:.*#\\1image: ${UPLOADER_IMAGE}#" \
             "$COMPOSE_FILE" > "$candidate"
 
-          docker compose -p "$PROJECT_NAME" -f "$candidate" pull letovo-server letovo-registration-server letovo-front
-          docker compose -p "$PROJECT_NAME" -f "$candidate" up -d letovo-server letovo-registration-server letovo-front
+          docker compose -p "$PROJECT_NAME" -f "$candidate" pull letovo-server letovo-registration-server letovo-front letovo-flask-uploader
+          docker compose -p "$PROJECT_NAME" -f "$candidate" up -d letovo-server letovo-registration-server letovo-front letovo-flask-uploader
           test "$(docker inspect -f '{{.Config.Image}}' letovo-server)" = "$BACKEND_IMAGE"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-registration-server)" = "$REGISTRATION_IMAGE"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-front)" = "$FRONTEND_IMAGE"
+          test "$(docker inspect -f '{{.Config.Image}}' flask-uploader)" = "$UPLOADER_IMAGE"
           REMOTE
 
       - name: Set up Node.js
@@ -475,19 +521,23 @@ jobs:
           backend_image="$(awk -F= '$1 == "letovo-server" { print $2 }' "$restore" | tail -n 1)"
           registration_image="$(awk -F= '$1 == "letovo-registration-server" { print $2 }' "$restore" | tail -n 1)"
           frontend_image="$(awk -F= '$1 == "letovo-front" { print $2 }' "$restore" | tail -n 1)"
+          uploader_image="$(awk -F= '$1 == "flask-uploader" { print $2 }' "$restore" | tail -n 1)"
           test -n "$backend_image"
           test -n "$registration_image"
           test -n "$frontend_image"
+          test -n "$uploader_image"
 
           candidate="$state_dir/docker-compose.restore.yaml"
           sed -E \
             -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${backend_image}#" \
             -e "s#image: ghcr.io/letovo-dev/letovo-registration-server:.*#image: ${registration_image}#" \
             -e "/^    letovo-front:/,/^    [[:alnum:]_-]+:$/ s#^([[:space:]]*)image:.*#\\1image: ${frontend_image}#" \
+            -e "/^    letovo-flask-uploader:/,/^    [[:alnum:]_-]+:$/ s#^([[:space:]]*)image:.*#\\1image: ${uploader_image}#" \
             "$COMPOSE_FILE" > "$candidate"
 
-          docker compose -p "$PROJECT_NAME" -f "$candidate" pull letovo-server letovo-registration-server letovo-front || true
-          docker compose -p "$PROJECT_NAME" -f "$candidate" up -d letovo-server letovo-registration-server letovo-front
+          docker compose -p "$PROJECT_NAME" -f "$candidate" pull letovo-server letovo-registration-server letovo-front letovo-flask-uploader || true
+          docker compose -p "$PROJECT_NAME" -f "$candidate" up -d letovo-server letovo-registration-server letovo-front letovo-flask-uploader
+          test "$(docker inspect -f '{{.Config.Image}}' flask-uploader)" = "$uploader_image"
           # The additive schema migration intentionally remains in place. The
           # retained role dump is for explicit operator recovery only.
           rm -rf "$state_dir"

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -445,7 +445,21 @@ jobs:
           docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
           docker inspect -f 'letovo-registration-server={{.Config.Image}}' letovo-registration-server >> "$restore"
           docker inspect -f 'letovo-front={{.Config.Image}}' letovo-front >> "$restore"
-          docker inspect -f 'flask-uploader={{.Config.Image}}' flask-uploader >> "$restore"
+          uploader_container=""
+          for candidate_name in letovo-uploader flask-uploader; do
+            if docker inspect "$candidate_name" >/dev/null 2>&1; then
+              uploader_container="$candidate_name"
+              break
+            fi
+          done
+          test -n "$uploader_container"
+          uploader_service="$(docker inspect -f '{{ index .Config.Labels "com.docker.compose.service" }}' "$uploader_container")"
+          if [ -z "$uploader_service" ]; then
+            uploader_service="letovo-flask-uploader"
+          fi
+          docker inspect -f 'uploader-image={{.Config.Image}}' "$uploader_container" >> "$restore"
+          printf 'uploader-container=%s\n' "$uploader_container" >> "$restore"
+          printf 'uploader-service=%s\n' "$uploader_service" >> "$restore"
 
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.role > "$role_backup_tmp"
@@ -548,6 +562,9 @@ jobs:
           fi
           as_root nginx -s reload || as_root systemctl reload nginx
 
+          if [ "$uploader_container" != "flask-uploader" ]; then
+            docker rm -f "$uploader_container"
+          fi
           docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d jaeger otel-collector letovo-server letovo-registration-server letovo-front letovo-flask-uploader
           test "$(docker inspect -f '{{.State.Running}}' jaeger)" = "true"
           test "$(docker inspect -f '{{.State.Running}}' otel-collector)" = "true"
@@ -555,6 +572,19 @@ jobs:
           test "$(docker inspect -f '{{.Config.Image}}' letovo-registration-server)" = "$REGISTRATION_IMAGE"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-front)" = "$FRONTEND_IMAGE"
           test "$(docker inspect -f '{{.Config.Image}}' flask-uploader)" = "$UPLOADER_IMAGE"
+
+          uploader_status=""
+          for _ in $(seq 1 30); do
+            uploader_status="$(curl --connect-timeout 2 --max-time 5 -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:8880/ || true)"
+            if [ "$uploader_status" = "405" ]; then
+              break
+            fi
+            sleep 2
+          done
+          if [ "$uploader_status" != "405" ]; then
+            echo "Expected flask-uploader on 127.0.0.1:8880 to return 405 for GET /, got ${uploader_status:-no response}"
+            exit 1
+          fi
 
           backend_status=""
           for _ in $(seq 1 30); do
@@ -668,21 +698,26 @@ jobs:
           backend_image="$(awk -F= '$1 == "letovo-server" { print $2 }' "$restore" | tail -n 1)"
           registration_image="$(awk -F= '$1 == "letovo-registration-server" { print $2 }' "$restore" | tail -n 1)"
           frontend_image="$(awk -F= '$1 == "letovo-front" { print $2 }' "$restore" | tail -n 1)"
-          uploader_image="$(awk -F= '$1 == "flask-uploader" { print $2 }' "$restore" | tail -n 1)"
+          uploader_image="$(awk -F= '$1 == "uploader-image" { print $2 }' "$restore" | tail -n 1)"
+          uploader_container="$(awk -F= '$1 == "uploader-container" { print $2 }' "$restore" | tail -n 1)"
+          uploader_service="$(awk -F= '$1 == "uploader-service" { print $2 }' "$restore" | tail -n 1)"
           test -n "$backend_image"
           test -n "$registration_image"
           test -n "$frontend_image"
           test -n "$uploader_image"
+          test -n "$uploader_container"
+          test -n "$uploader_service"
           docker image inspect "$backend_image" >/dev/null
           docker image inspect "$registration_image" >/dev/null
           docker image inspect "$frontend_image" >/dev/null
           docker image inspect "$uploader_image" >/dev/null
 
-          docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d letovo-server letovo-registration-server letovo-front letovo-flask-uploader
+          docker rm -f flask-uploader letovo-uploader >/dev/null 2>&1 || true
+          docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d letovo-server letovo-registration-server letovo-front "$uploader_service"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-server)" = "$backend_image"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-registration-server)" = "$registration_image"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-front)" = "$frontend_image"
-          test "$(docker inspect -f '{{.Config.Image}}' flask-uploader)" = "$uploader_image"
+          test "$(docker inspect -f '{{.Config.Image}}' "$uploader_container")" = "$uploader_image"
           # Keep the backward-compatible schema migration. The durable role
           # dump is reserved for deliberate operator recovery, not blind rollback.
           rm -rf "$state_dir"

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -52,6 +52,7 @@ env:
   BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-server
   FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-all-frontend
   REGISTRATION_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-registration-server
+  UPLOADER_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-flask-uploader
   PLAYWRIGHT_VERSION: "1.55.1"
   LIVE_E2E_BASE_URL: https://letovocorp.ru
   LIVE_E2E_WAIT_TIMEOUT_SECONDS: ${{ inputs.wait_timeout_seconds }}
@@ -165,6 +166,7 @@ jobs:
             echo "BACKEND_RELEASE_IMAGE=${BACKEND_IMAGE}:${release_sha}"
             echo "REGISTRATION_RELEASE_IMAGE=${REGISTRATION_IMAGE}:${release_sha}"
             echo "FRONTEND_RELEASE_IMAGE=${FRONTEND_IMAGE}:${release_sha}"
+            echo "UPLOADER_RELEASE_IMAGE=${UPLOADER_IMAGE}:${release_sha}"
             echo "LIVE_E2E_EXPECTED_BACKEND_SHA=$release_sha"
             echo "LIVE_E2E_EXPECTED_FRONTEND_SHA=$release_sha"
           } >> "$GITHUB_ENV"
@@ -175,6 +177,7 @@ jobs:
             echo "backend_image=${BACKEND_IMAGE}:${release_sha}"
             echo "registration_image=${REGISTRATION_IMAGE}:${release_sha}"
             echo "frontend_image=${FRONTEND_IMAGE}:${release_sha}"
+            echo "uploader_image=${UPLOADER_IMAGE}:${release_sha}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Validate production deployment secrets
@@ -297,6 +300,18 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push production uploader image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src/python-helpers
+          file: ./src/python-helpers/dockerfile.uploader
+          build-args: |
+            UPLOADER_CAPABILITIES_URL=${{ steps.release.outputs.base_url }}/letovo-api/auth/amiuploader
+          push: true
+          tags: ${{ steps.release.outputs.uploader_image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Configure production SSH
         env:
           LETOVO_PROD_DEPLOY_HOST: ${{ vars.LETOVO_PROD_DEPLOY_HOST || '84.201.185.37' }}
@@ -319,6 +334,7 @@ jobs:
             "$BACKEND_RELEASE_IMAGE"
             "$REGISTRATION_RELEASE_IMAGE"
             "$FRONTEND_RELEASE_IMAGE"
+            "$UPLOADER_RELEASE_IMAGE"
           )
           for image in "${images[@]}"; do
             docker pull "$image"
@@ -350,7 +366,7 @@ jobs:
           scp -i ~/.ssh/letovo-production-release docs/department_payout_migration.sql \
             "$remote:$state_dir/department_payout_migration.sql"
           ssh -i ~/.ssh/letovo-production-release "$remote" \
-            "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' NGINX_SITE='$LETOVO_PROD_NGINX_SITE' RUN_ID='${{ github.run_id }}' EXPECTED_CHILD_AVATAR_COUNT='$CHILD_AVATAR_EXPECTED_COUNT' EXPECTED_CHILD_AVATAR_SHA256='$CHILD_AVATAR_EXPECTED_SHA256' bash -s" <<'REMOTE'
+            "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' UPLOADER_IMAGE='$UPLOADER_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' NGINX_SITE='$LETOVO_PROD_NGINX_SITE' RUN_ID='${{ github.run_id }}' EXPECTED_CHILD_AVATAR_COUNT='$CHILD_AVATAR_EXPECTED_COUNT' EXPECTED_CHILD_AVATAR_SHA256='$CHILD_AVATAR_EXPECTED_SHA256' bash -s" <<'REMOTE'
           set -euo pipefail
           umask 077
           test -f "$COMPOSE_FILE"
@@ -395,6 +411,7 @@ jobs:
           docker image inspect "$BACKEND_IMAGE" >/dev/null
           docker image inspect "$REGISTRATION_IMAGE" >/dev/null
           docker image inspect "$FRONTEND_IMAGE" >/dev/null
+          docker image inspect "$UPLOADER_IMAGE" >/dev/null
           test -f "$repo_compose"
           test -f "$repo_otel"
           test -f "$repo_front_env"
@@ -428,6 +445,7 @@ jobs:
           docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
           docker inspect -f 'letovo-registration-server={{.Config.Image}}' letovo-registration-server >> "$restore"
           docker inspect -f 'letovo-front={{.Config.Image}}' letovo-front >> "$restore"
+          docker inspect -f 'flask-uploader={{.Config.Image}}' flask-uploader >> "$restore"
 
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.role > "$role_backup_tmp"
@@ -476,6 +494,7 @@ jobs:
 
           sed \
             -e "s#image: ghcr.io/letovo-dev/letovo-server:.*#image: ${BACKEND_IMAGE}#" \
+            -e "s#image: .*flask-uploader.*#image: ${UPLOADER_IMAGE}#" \
             -e "s#image: ghcr.io/letovo-dev/letovo-registration-server:.*#image: ${REGISTRATION_IMAGE}#" \
             -e "s#image: .*letovo.*front.*:.*#image: ${FRONTEND_IMAGE}#" \
             -e "s#LETOVO_BUILD_SHA: \".*\"#LETOVO_BUILD_SHA: \"${RELEASE_SHA}\"#" \
@@ -529,12 +548,13 @@ jobs:
           fi
           as_root nginx -s reload || as_root systemctl reload nginx
 
-          docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d jaeger otel-collector letovo-server letovo-registration-server letovo-front
+          docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d jaeger otel-collector letovo-server letovo-registration-server letovo-front letovo-flask-uploader
           test "$(docker inspect -f '{{.State.Running}}' jaeger)" = "true"
           test "$(docker inspect -f '{{.State.Running}}' otel-collector)" = "true"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-server)" = "$BACKEND_IMAGE"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-registration-server)" = "$REGISTRATION_IMAGE"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-front)" = "$FRONTEND_IMAGE"
+          test "$(docker inspect -f '{{.Config.Image}}' flask-uploader)" = "$UPLOADER_IMAGE"
 
           backend_status=""
           for _ in $(seq 1 30); do
@@ -648,17 +668,21 @@ jobs:
           backend_image="$(awk -F= '$1 == "letovo-server" { print $2 }' "$restore" | tail -n 1)"
           registration_image="$(awk -F= '$1 == "letovo-registration-server" { print $2 }' "$restore" | tail -n 1)"
           frontend_image="$(awk -F= '$1 == "letovo-front" { print $2 }' "$restore" | tail -n 1)"
+          uploader_image="$(awk -F= '$1 == "flask-uploader" { print $2 }' "$restore" | tail -n 1)"
           test -n "$backend_image"
           test -n "$registration_image"
           test -n "$frontend_image"
+          test -n "$uploader_image"
           docker image inspect "$backend_image" >/dev/null
           docker image inspect "$registration_image" >/dev/null
           docker image inspect "$frontend_image" >/dev/null
+          docker image inspect "$uploader_image" >/dev/null
 
-          docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d letovo-server letovo-registration-server letovo-front
+          docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d letovo-server letovo-registration-server letovo-front letovo-flask-uploader
           test "$(docker inspect -f '{{.Config.Image}}' letovo-server)" = "$backend_image"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-registration-server)" = "$registration_image"
           test "$(docker inspect -f '{{.Config.Image}}' letovo-front)" = "$frontend_image"
+          test "$(docker inspect -f '{{.Config.Image}}' flask-uploader)" = "$uploader_image"
           # Keep the backward-compatible schema migration. The durable role
           # dump is reserved for deliberate operator recovery, not blind rollback.
           rm -rf "$state_dir"

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -512,7 +512,13 @@ jobs:
             -e "s#image: ghcr.io/letovo-dev/letovo-registration-server:.*#image: ${REGISTRATION_IMAGE}#" \
             -e "s#image: .*letovo.*front.*:.*#image: ${FRONTEND_IMAGE}#" \
             -e "s#LETOVO_BUILD_SHA: \".*\"#LETOVO_BUILD_SHA: \"${RELEASE_SHA}\"#" \
+            -e "/^    letovo-flask-uploader:/,/^    [[:alnum:]_-]\\+:/ s#- /mnt/server-media:/app/pages#- /srv/letovo/media:/app/pages#" \
+            -e "/^    letovo-flask-uploader:/,/^    [[:alnum:]_-]\\+:/ s#- \"8880:8880\"#- \"127.0.0.1:8880:8880\"#" \
             "$repo_compose" > "$candidate"
+
+          uploader_candidate_block="$(sed -n '/^    letovo-flask-uploader:/,/^    keycloak:/p' "$candidate")"
+          grep -F -- '- /srv/letovo/media:/app/pages' <<<"$uploader_candidate_block"
+          grep -F -- '- "127.0.0.1:8880:8880"' <<<"$uploader_candidate_block"
 
           docker run -d \
             --name "$smoke_name" \

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -134,13 +134,15 @@ services:
             max-file: "10"
 
     letovo-flask-uploader:
-        image: flask-uploader:latest
+        image: ghcr.io/letovo-dev/letovo-flask-uploader:latest
         container_name: flask-uploader
         restart: unless-stopped
         volumes:
           - /mnt/server-media:/app/pages
         ports:
           - "8880:8880"
+        labels:
+          - "com.centurylinklabs.watchtower.enable=true"
         logging:
           driver: json-file
           options:

--- a/src/python-helpers/dockerfile.uploader
+++ b/src/python-helpers/dockerfile.uploader
@@ -1,5 +1,8 @@
 FROM python:3.11-slim
 
+ARG UPLOADER_CAPABILITIES_URL=https://letovocorp.ru/letovo-api/auth/amiuploader
+ENV UPLOADER_CAPABILITIES_URL=${UPLOADER_CAPABILITIES_URL}
+
 WORKDIR /app
 
 COPY . .

--- a/src/python-helpers/flask_uploader.py
+++ b/src/python-helpers/flask_uploader.py
@@ -22,7 +22,8 @@ def api_get_upload_capabilities(token: str, cookie: str = ""):
         return {"status": "t", "avatar_status": "t", "username": "local"}
     if not token and not cookie:
         return None
-    auth_url = config.get("auth_check_url", "https://letovocorp.ru/letovo-api/auth/amiuploader")
+    auth_url = os.environ.get("UPLOADER_CAPABILITIES_URL") or config.get(
+        "auth_check_url", "https://letovocorp.ru/letovo-api/auth/amiuploader")
     try:
         headers = {}
         if token:

--- a/test/test_issue174_uploader_deployment_contract.py
+++ b/test/test_issue174_uploader_deployment_contract.py
@@ -57,6 +57,11 @@ def test_uploader_image_participates_in_production_deploy_and_rollback():
     assert "docker rm -f flask-uploader letovo-uploader" in workflow
     assert "letovo-flask-uploader" in workflow
     assert "http://127.0.0.1:8880/" in workflow
+    uploader_range = "/^    letovo-flask-uploader:/,/^    [[:alnum:]_-]\\\\+:/"
+    assert f"{uploader_range} s#- /mnt/server-media:/app/pages#- /srv/letovo/media:/app/pages#" in workflow
+    assert f'{uploader_range} s#- \\"8880:8880\\"#- \\"127.0.0.1:8880:8880\\"#' in workflow
+    assert "uploader_candidate_block=" in workflow
+    assert "grep -F -- '- /srv/letovo/media:/app/pages'" in workflow
     assert 'flask-uploader)" = "$UPLOADER_IMAGE"' in workflow
     assert '"$uploader_container")" = "$uploader_image"' in workflow
 

--- a/test/test_issue174_uploader_deployment_contract.py
+++ b/test/test_issue174_uploader_deployment_contract.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_personal_avatar_upload_uses_backend_owned_identity_and_namespace():
+    uploader = _read("src/python-helpers/flask_uploader.py")
+    avatar_handler = uploader.split("def upload_avatar():", 1)[1]
+
+    assert 'capabilities.get("avatar_status") != "t"' in avatar_handler
+    assert 'capabilities.get("username")' in avatar_handler
+    assert 'hashlib.sha256(capabilities["username"].encode("utf-8"))' in avatar_handler
+    assert 'config.get("personal_ava_path", "images/personal_avatars")' in avatar_handler
+    assert "os.makedirs(file_path, exist_ok=True)" in avatar_handler
+    assert "uuid.uuid4().hex" in avatar_handler
+
+    dockerfile = _read("src/python-helpers/dockerfile.uploader")
+    assert "ARG UPLOADER_CAPABILITIES_URL=" in dockerfile
+    assert "ENV UPLOADER_CAPABILITIES_URL=${UPLOADER_CAPABILITIES_URL}" in dockerfile
+    assert 'config["ava_path"]' not in avatar_handler
+
+
+def test_uploader_image_participates_in_pr_main_and_live_e2e_lifecycle():
+    workflow = _read(".github/workflows/docker-image.yml")
+
+    assert "UPLOADER_IMAGE: ghcr.io/${{ github.repository_owner }}/letovo-flask-uploader" in workflow
+    assert "Build uploader image locally" in workflow
+    assert "Build and push PR uploader image" in workflow
+    assert "Build and push uploader image" in workflow
+    assert "UPLOADER_CANDIDATE_IMAGE=${UPLOADER_IMAGE}:${tag}" in workflow
+    assert "UPLOADER_CAPABILITIES_URL=${{ env.LIVE_E2E_BASE_URL }}/letovo-api/auth/amiuploader" in workflow
+    assert "UPLOADER_IMAGE='$UPLOADER_CANDIDATE_IMAGE'" in workflow
+    assert "flask-uploader={{.Config.Image}}" in workflow
+    assert "letovo-flask-uploader" in workflow
+    assert 'flask-uploader)" = "$UPLOADER_IMAGE"' in workflow
+    assert 'flask-uploader)" = "$uploader_image"' in workflow
+
+
+def test_uploader_image_participates_in_production_deploy_and_rollback():
+    workflow = _read(".github/workflows/production-release.yml")
+
+    assert "UPLOADER_RELEASE_IMAGE=${UPLOADER_IMAGE}:${release_sha}" in workflow
+    assert "Build and push production uploader image" in workflow
+    assert '"$UPLOADER_RELEASE_IMAGE"' in workflow
+    assert "UPLOADER_IMAGE='$UPLOADER_RELEASE_IMAGE'" in workflow
+    assert 'docker image inspect "$UPLOADER_IMAGE"' in workflow
+    assert "UPLOADER_CAPABILITIES_URL=${{ steps.release.outputs.base_url }}/letovo-api/auth/amiuploader" in workflow
+    assert "flask-uploader={{.Config.Image}}" in workflow
+    assert "letovo-flask-uploader" in workflow
+    assert 'flask-uploader)" = "$UPLOADER_IMAGE"' in workflow
+    assert 'flask-uploader)" = "$uploader_image"' in workflow
+
+
+def test_checked_in_compose_uses_published_uploader_image():
+    compose = _read("docs/docker-compose.yaml")
+    uploader_service = compose.split("    letovo-flask-uploader:", 1)[1].split("\n    keycloak:", 1)[0]
+
+    assert "image: ghcr.io/letovo-dev/letovo-flask-uploader:latest" in uploader_service
+    assert 'com.centurylinklabs.watchtower.enable=true' in uploader_service

--- a/test/test_issue174_uploader_deployment_contract.py
+++ b/test/test_issue174_uploader_deployment_contract.py
@@ -50,10 +50,15 @@ def test_uploader_image_participates_in_production_deploy_and_rollback():
     assert "UPLOADER_IMAGE='$UPLOADER_RELEASE_IMAGE'" in workflow
     assert 'docker image inspect "$UPLOADER_IMAGE"' in workflow
     assert "UPLOADER_CAPABILITIES_URL=${{ steps.release.outputs.base_url }}/letovo-api/auth/amiuploader" in workflow
-    assert "flask-uploader={{.Config.Image}}" in workflow
+    assert "for candidate_name in letovo-uploader flask-uploader" in workflow
+    assert "uploader-container=%s" in workflow
+    assert "uploader-service=%s" in workflow
+    assert 'letovo-front "$uploader_service"' in workflow
+    assert "docker rm -f flask-uploader letovo-uploader" in workflow
     assert "letovo-flask-uploader" in workflow
+    assert "http://127.0.0.1:8880/" in workflow
     assert 'flask-uploader)" = "$UPLOADER_IMAGE"' in workflow
-    assert 'flask-uploader)" = "$uploader_image"' in workflow
+    assert '"$uploader_container")" = "$uploader_image"' in workflow
 
 
 def test_checked_in_compose_uses_published_uploader_image():


### PR DESCRIPTION
Closes #174

## What changed
- publish a versioned uploader image for PR, main, and production releases
- deploy and restore the uploader together with backend/frontend in live and production workflows
- configure the uploader capability endpoint per environment
- switch checked-in compose from the stale local image to GHCR
- add issue #174 deployment and personal-path contract coverage

## Verification
- 21 avatar/workflow contract tests passed
- workflow and compose YAML structure checks passed
- uploader Docker image built successfully
- isolated Flask upload returned a path under the authenticated user personal-avatar namespace