### PR TITLE
Fix publisher account visibility and author search

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -401,6 +401,8 @@ jobs:
             "$remote:$state_dir/child_avatar_access_migration.sql"
           scp -i ~/.ssh/live-e2e docs/department_payout_migration.sql \
             "$remote:$state_dir/department_payout_migration.sql"
+          scp -i ~/.ssh/live-e2e docs/publisher_authorization_migration.sql \
+            "$remote:$state_dir/publisher_authorization_migration.sql"
           ssh -i ~/.ssh/live-e2e "$remote" \
             "BACKEND_IMAGE='$BACKEND_CANDIDATE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_CANDIDATE_IMAGE' FRONTEND_IMAGE='$FRONTEND_CANDIDATE_IMAGE' UPLOADER_IMAGE='$UPLOADER_CANDIDATE_IMAGE' COMPOSE_FILE='$LETOVO_E2E_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_E2E_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
           set -euo pipefail
@@ -413,6 +415,7 @@ jobs:
           migration="$state_dir/avatar_upload_role_migration.sql"
           child_avatar_migration="$state_dir/child_avatar_access_migration.sql"
           payout_migration="$state_dir/department_payout_migration.sql"
+          publisher_authorization_migration="$state_dir/publisher_authorization_migration.sql"
           backup_root="$HOME/backups/letovo-live-e2e-${RUN_ID}"
           role_backup="$backup_root/role.before-avatar-migration.sql"
           user_backup="$backup_root/user.before-child-avatar-migration.sql"
@@ -422,6 +425,7 @@ jobs:
           test -f "$migration"
           test -f "$child_avatar_migration"
           test -f "$payout_migration"
+          test -f "$publisher_authorization_migration"
           mkdir -p "$backup_root"
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.transactions > "$transactions_backup"
@@ -431,6 +435,12 @@ jobs:
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
               -f /tmp/department_payout_migration.sql
           docker exec letovo-postgres-1 rm -f /tmp/department_payout_migration.sql
+          docker cp "$publisher_authorization_migration" \
+            letovo-postgres-1:/tmp/publisher_authorization_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
+              -f /tmp/publisher_authorization_migration.sql
+          docker exec letovo-postgres-1 rm -f /tmp/publisher_authorization_migration.sql
 
           docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
           docker inspect -f 'letovo-registration-server={{.Config.Image}}' letovo-registration-server >> "$restore"

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -365,6 +365,8 @@ jobs:
             "$remote:$state_dir/child_avatar_access_migration.sql"
           scp -i ~/.ssh/letovo-production-release docs/department_payout_migration.sql \
             "$remote:$state_dir/department_payout_migration.sql"
+          scp -i ~/.ssh/letovo-production-release docs/publisher_authorization_migration.sql \
+            "$remote:$state_dir/publisher_authorization_migration.sql"
           ssh -i ~/.ssh/letovo-production-release "$remote" \
             "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' UPLOADER_IMAGE='$UPLOADER_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' NGINX_SITE='$LETOVO_PROD_NGINX_SITE' RUN_ID='${{ github.run_id }}' EXPECTED_CHILD_AVATAR_COUNT='$CHILD_AVATAR_EXPECTED_COUNT' EXPECTED_CHILD_AVATAR_SHA256='$CHILD_AVATAR_EXPECTED_SHA256' bash -s" <<'REMOTE'
           set -euo pipefail
@@ -385,6 +387,7 @@ jobs:
           migration="$state_dir/avatar_upload_role_migration.sql"
           child_avatar_migration="$state_dir/child_avatar_access_migration.sql"
           payout_migration="$state_dir/department_payout_migration.sql"
+          publisher_authorization_migration="$state_dir/publisher_authorization_migration.sql"
           nginx_candidate="$state_dir/nginx-site.candidate"
           compose_dir="$(dirname "$COMPOSE_FILE")"
           otel_config="$compose_dir/otel-collector-config.yaml"
@@ -418,6 +421,7 @@ jobs:
           test -f "$migration"
           test -f "$child_avatar_migration"
           test -f "$payout_migration"
+          test -f "$publisher_authorization_migration"
           as_root mkdir -p "$backup_root"
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.transactions > "$transactions_backup_tmp"
@@ -428,6 +432,12 @@ jobs:
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
               -f /tmp/department_payout_migration.sql
           docker exec letovo-postgres-1 rm -f /tmp/department_payout_migration.sql
+          docker cp "$publisher_authorization_migration" \
+            letovo-postgres-1:/tmp/publisher_authorization_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
+              -f /tmp/publisher_authorization_migration.sql
+          docker exec letovo-postgres-1 rm -f /tmp/publisher_authorization_migration.sql
           docker rm -f "$smoke_name" >/dev/null 2>&1 || true
           cleanup_smoke() {
             docker rm -f "$smoke_name" >/dev/null 2>&1 || true

--- a/docs/psql_schema.sql
+++ b/docs/psql_schema.sql
@@ -18,36 +18,58 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: is_publishable_identity(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.is_publishable_identity(target_username text) RETURNS boolean
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO pg_catalog, public
+    AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public."user" AS target
+    WHERE target.username = target_username
+      AND target.active IS TRUE
+      AND target.registered IS TRUE
+      AND target.userrights IN ('admin', 'moder', 'author', 'public_author')
+  );
+$$;
+
+
+
+--
 -- Name: can_publish_as(text, text); Type: FUNCTION; Schema: public; Owner: -
 --
 
 CREATE FUNCTION public.can_publish_as(publisher_username text, target_username text) RETURNS boolean
     LANGUAGE plpgsql STABLE SECURITY DEFINER
+    SET search_path TO pg_catalog, public
     AS $$
 DECLARE
-  pub_rights TEXT;
-  tgt_rights TEXT;
+  publisher_rights text;
+  target_rights text;
+  target_is_active boolean;
+  target_is_registered boolean;
 BEGIN
-  -- достаём права первого
   SELECT userrights
-    INTO pub_rights
-    FROM "user"
+    INTO publisher_rights
+    FROM public."user"
    WHERE username = publisher_username;
 
-  -- достаём права второго
-  SELECT userrights
-    INTO tgt_rights
-    FROM "user"
+  SELECT userrights, active, registered
+    INTO target_rights, target_is_active, target_is_registered
+    FROM public."user"
    WHERE username = target_username;
 
-  -- логика проверки
-  IF pub_rights = 'admin' AND tgt_rights LIKE '%author%' THEN
-    RETURN TRUE;
-  ELSIF pub_rights = 'moder' AND tgt_rights = 'public_author' THEN
-    RETURN TRUE;
-  ELSE
-    RETURN FALSE;
+  IF publisher_rights = 'admin' THEN
+    RETURN public.is_publishable_identity(target_username);
+  ELSIF publisher_rights = 'moder' THEN
+    RETURN target_rights = 'public_author'
+      AND target_is_active IS TRUE
+      AND target_is_registered IS TRUE;
   END IF;
+
+  RETURN FALSE;
 END;
 $$;
 
@@ -82,29 +104,23 @@ CREATE TABLE public."user" (
 --
 
 CREATE FUNCTION public.get_users_by_role(requester_username text) RETURNS SETOF public."user"
-    LANGUAGE plpgsql STABLE
+    LANGUAGE sql STABLE
+    SET search_path TO pg_catalog, public
     AS $$
-BEGIN
-  RETURN QUERY
-    SELECT u.*
-    FROM "user" AS u
-    JOIN "user" AS r
-      ON r.username = requester_username
-    WHERE
-      (
-        r.userrights = 'admin'
-        AND u.userrights LIKE '%author%'
-      )
-      OR
-      (
-        r.userrights = 'moder'
-        AND u.userrights = 'public_author'
-      )
-      OR
-      (
-        r.username = u.username
-      );
-END;
+  SELECT target.*
+  FROM public."user" AS target
+  JOIN public."user" AS requester
+    ON requester.username = requester_username
+  WHERE target.active IS TRUE
+    AND target.registered IS TRUE
+    AND (
+      (requester.userrights = 'admin'
+        AND public.is_publishable_identity(target.username))
+      OR (requester.userrights = 'moder'
+        AND target.userrights = 'public_author')
+      OR requester.username = target.username
+    )
+  ORDER BY target.username;
 $$;
 
 

--- a/docs/publisher_authorization_migration.sql
+++ b/docs/publisher_authorization_migration.sql
@@ -1,0 +1,80 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.is_publishable_identity(target_username text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public."user" AS target
+    WHERE target.username = target_username
+      AND target.active IS TRUE
+      AND target.registered IS TRUE
+      AND target.userrights IN ('admin', 'moder', 'author', 'public_author')
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_publish_as(
+  publisher_username text,
+  target_username text
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  publisher_rights text;
+  target_rights text;
+  target_is_active boolean;
+  target_is_registered boolean;
+BEGIN
+  SELECT userrights
+    INTO publisher_rights
+    FROM public."user"
+   WHERE username = publisher_username;
+
+  SELECT userrights, active, registered
+    INTO target_rights, target_is_active, target_is_registered
+    FROM public."user"
+   WHERE username = target_username;
+
+  IF publisher_rights = 'admin' THEN
+    RETURN public.is_publishable_identity(target_username);
+  ELSIF publisher_rights = 'moder' THEN
+    RETURN target_rights = 'public_author'
+      AND target_is_active IS TRUE
+      AND target_is_registered IS TRUE;
+  END IF;
+
+  RETURN FALSE;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_users_by_role(requester_username text)
+RETURNS SETOF public."user"
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, public
+AS $$
+  SELECT target.*
+  FROM public."user" AS target
+  JOIN public."user" AS requester
+    ON requester.username = requester_username
+  WHERE target.active IS TRUE
+    AND target.registered IS TRUE
+    AND (
+      (requester.userrights = 'admin'
+        AND public.is_publishable_identity(target.username))
+      OR (requester.userrights = 'moder'
+        AND target.userrights = 'public_author')
+      OR requester.username = target.username
+    )
+  ORDER BY target.username;
+$$;
+
+COMMIT;

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -19,36 +19,58 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: is_publishable_identity(text); Type: FUNCTION; Schema: public; Owner: scv
+--
+
+CREATE FUNCTION public.is_publishable_identity(target_username text) RETURNS boolean
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO pg_catalog, public
+    AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public."user" AS target
+    WHERE target.username = target_username
+      AND target.active IS TRUE
+      AND target.registered IS TRUE
+      AND target.userrights IN ('admin', 'moder', 'author', 'public_author')
+  );
+$$;
+
+ALTER FUNCTION public.is_publishable_identity(target_username text) OWNER TO scv;
+
+--
 -- Name: can_publish_as(text, text); Type: FUNCTION; Schema: public; Owner: scv
 --
 
 CREATE FUNCTION public.can_publish_as(publisher_username text, target_username text) RETURNS boolean
     LANGUAGE plpgsql STABLE SECURITY DEFINER
+    SET search_path TO pg_catalog, public
     AS $$
 DECLARE
-  pub_rights TEXT;
-  tgt_rights TEXT;
+  publisher_rights text;
+  target_rights text;
+  target_is_active boolean;
+  target_is_registered boolean;
 BEGIN
-  -- достаём права первого
   SELECT userrights
-    INTO pub_rights
-    FROM "user"
+    INTO publisher_rights
+    FROM public."user"
    WHERE username = publisher_username;
 
-  -- достаём права второго
-  SELECT userrights
-    INTO tgt_rights
-    FROM "user"
+  SELECT userrights, active, registered
+    INTO target_rights, target_is_active, target_is_registered
+    FROM public."user"
    WHERE username = target_username;
 
-  -- логика проверки
-  IF pub_rights = 'admin' AND tgt_rights LIKE '%author%' THEN
-    RETURN TRUE;
-  ELSIF pub_rights = 'moder' AND tgt_rights = 'public_author' THEN
-    RETURN TRUE;
-  ELSE
-    RETURN FALSE;
+  IF publisher_rights = 'admin' THEN
+    RETURN public.is_publishable_identity(target_username);
+  ELSIF publisher_rights = 'moder' THEN
+    RETURN target_rights = 'public_author'
+      AND target_is_active IS TRUE
+      AND target_is_registered IS TRUE;
   END IF;
+
+  RETURN FALSE;
 END;
 $$;
 
@@ -88,29 +110,23 @@ ALTER TABLE public."user" OWNER TO scv;
 --
 
 CREATE FUNCTION public.get_users_by_role(requester_username text) RETURNS SETOF public."user"
-    LANGUAGE plpgsql STABLE
+    LANGUAGE sql STABLE
+    SET search_path TO pg_catalog, public
     AS $$
-BEGIN
-  RETURN QUERY
-    SELECT u.*
-    FROM "user" AS u
-    JOIN "user" AS r
-      ON r.username = requester_username
-    WHERE
-      (
-        r.userrights = 'admin'
-        AND u.userrights LIKE '%author%'
-      )
-      OR
-      (
-        r.userrights = 'moder'
-        AND u.userrights = 'public_author'
-      )
-      OR
-      (
-        r.username = u.username
-      );
-END;
+  SELECT target.*
+  FROM public."user" AS target
+  JOIN public."user" AS requester
+    ON requester.username = requester_username
+  WHERE target.active IS TRUE
+    AND target.registered IS TRUE
+    AND (
+      (requester.userrights = 'admin'
+        AND public.is_publishable_identity(target.username))
+      OR (requester.userrights = 'moder'
+        AND target.userrights = 'public_author')
+      OR requester.username = target.username
+    )
+  ORDER BY target.username;
 $$;
 
 

--- a/docs/sql_funcs.md
+++ b/docs/sql_funcs.md
@@ -1,66 +1,87 @@
-* get_users_by_role - получает список авторов по username, пример: SELECT * FROM get_users_by_role('scv-7');
+* `is_publishable_identity` — единое правило для аккаунтов, от имени которых администратор может публиковать. Аккаунт должен быть активным, зарегистрированным и иметь роль `admin`, `moder`, `author` или `public_author`.
 ```sql
-CREATE OR REPLACE FUNCTION get_users_by_role(requester_username TEXT)
-RETURNS SETOF "user" AS
-$$
-BEGIN
-  RETURN QUERY
-    SELECT u.*
-    FROM "user" AS u
-    JOIN "user" AS r
-      ON r.username = requester_username
-    WHERE
-      (
-        r.userrights = 'admin'
-        AND u.userrights LIKE '%author%'
-      )
-      OR
-      (
-        r.userrights = 'moder'
-        AND u.userrights = 'public_author'
-      )
-      OR
-      (
-        r.username = u.username
-      );
-END;
-$$
-LANGUAGE plpgsql STABLE;
+CREATE OR REPLACE FUNCTION public.is_publishable_identity(target_username TEXT)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public."user" AS target
+    WHERE target.username = target_username
+      AND target.active IS TRUE
+      AND target.registered IS TRUE
+      AND target.userrights IN ('admin', 'moder', 'author', 'public_author')
+  );
+$$;
 ```
-* can_publish_as - проверяет, может ли $1 публиковать от имени $2. пример: SELECT can_publish_as('ivan', 'sergey');
+
+* `get_users_by_role` — получает список доступных авторов по username, например `SELECT * FROM get_users_by_role('scv-7');`.
 ```sql
-CREATE OR REPLACE FUNCTION can_publish_as(
-  publisher_username TEXT, 
-  target_username    TEXT
+CREATE OR REPLACE FUNCTION public.get_users_by_role(requester_username TEXT)
+RETURNS SETOF public."user"
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, public
+AS $$
+  SELECT target.*
+  FROM public."user" AS target
+  JOIN public."user" AS requester
+    ON requester.username = requester_username
+  WHERE target.active IS TRUE
+    AND target.registered IS TRUE
+    AND (
+      (requester.userrights = 'admin'
+        AND public.is_publishable_identity(target.username))
+      OR (requester.userrights = 'moder'
+        AND target.userrights = 'public_author')
+      OR requester.username = target.username
+    )
+  ORDER BY target.username;
+$$;
+```
+
+* `can_publish_as` — проверяет, может ли первый пользователь публиковать от имени второго, например `SELECT can_publish_as('ivan', 'sergey');`.
+```sql
+CREATE OR REPLACE FUNCTION public.can_publish_as(
+  publisher_username TEXT,
+  target_username TEXT
 )
-RETURNS BOOLEAN AS
-$$
-DECLARE
-  pub_rights TEXT;
-  tgt_rights TEXT;
-BEGIN
-  SELECT userrights
-    INTO pub_rights
-    FROM "user"
-   WHERE username = publisher_username;
-
-  SELECT userrights
-    INTO tgt_rights
-    FROM "user"
-   WHERE username = target_username;
-
-  IF pub_rights = 'admin' AND tgt_rights LIKE '%author%' THEN
-    RETURN TRUE;
-  ELSIF pub_rights = 'moder' AND tgt_rights = 'public_author' THEN
-    RETURN TRUE;
-  ELSE
-    RETURN FALSE;
-  END IF;
-END;
-$$
+RETURNS BOOLEAN
 LANGUAGE plpgsql
 STABLE
-SECURITY DEFINER;
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  publisher_rights TEXT;
+  target_rights TEXT;
+  target_is_active BOOLEAN;
+  target_is_registered BOOLEAN;
+BEGIN
+  SELECT userrights
+    INTO publisher_rights
+    FROM public."user"
+   WHERE username = publisher_username;
+
+  SELECT userrights, active, registered
+    INTO target_rights, target_is_active, target_is_registered
+    FROM public."user"
+   WHERE username = target_username;
+
+  IF publisher_rights = 'admin' THEN
+    RETURN public.is_publishable_identity(target_username);
+  ELSIF publisher_rights = 'moder' THEN
+    RETURN target_rights = 'public_author'
+      AND target_is_active IS TRUE
+      AND target_is_registered IS TRUE;
+  END IF;
+
+  RETURN FALSE;
+END;
+$$;
 ```
 * normalize_post_categories - нормализует категории
 ```sql

--- a/test/e2e/live-platform-smoke.mjs
+++ b/test/e2e/live-platform-smoke.mjs
@@ -211,18 +211,20 @@ async function assertAdminSession(page) {
 }
 
 async function assertPublisherAuthorList(page) {
+  assert(
+    secondaryUsername,
+    'Publisher author-list verification requires LETOVO_E2E_SECONDARY_USERNAME',
+  );
   const authors = await fetchAuthenticated(page, '/letovo-api/authors_list');
   assert(authors.status === 200, `Authors API returned HTTP ${authors.status}: ${authors.text}`);
   const authorsJson = parseJsonResponse(authors, 'Authors API');
   assert(Array.isArray(authorsJson.result), `Authors API result is not an array: ${authors.text}`);
 
   const usernames = new Set(authorsJson.result.map(author => author.username));
-  for (const expectedUsername of ['Citizen_hearst', 'Portal_Administration']) {
-    assert(
-      usernames.has(expectedUsername),
-      `Admin authors list is missing ${expectedUsername}: ${authors.text}`,
-    );
-  }
+  assert(
+    usernames.has(secondaryUsername),
+    `Admin authors list is missing the secondary publisher fixture: ${authors.text}`,
+  );
 }
 
 async function assertUploaderSession(page) {

--- a/test/e2e/live-platform-smoke.mjs
+++ b/test/e2e/live-platform-smoke.mjs
@@ -210,6 +210,21 @@ async function assertAdminSession(page) {
   assert(adminJson.status === 't', `Configured e2e account is not admin: ${admin.text}`);
 }
 
+async function assertPublisherAuthorList(page) {
+  const authors = await fetchAuthenticated(page, '/letovo-api/authors_list');
+  assert(authors.status === 200, `Authors API returned HTTP ${authors.status}: ${authors.text}`);
+  const authorsJson = parseJsonResponse(authors, 'Authors API');
+  assert(Array.isArray(authorsJson.result), `Authors API result is not an array: ${authors.text}`);
+
+  const usernames = new Set(authorsJson.result.map(author => author.username));
+  for (const expectedUsername of ['Citizen_hearst', 'Portal_Administration']) {
+    assert(
+      usernames.has(expectedUsername),
+      `Admin authors list is missing ${expectedUsername}: ${authors.text}`,
+    );
+  }
+}
+
 async function assertUploaderSession(page) {
   const uploader = await fetchAuthenticated(page, '/letovo-api/auth/amiuploader/');
   assert(uploader.status === 200, `Uploader API returned HTTP ${uploader.status}`);
@@ -581,6 +596,7 @@ async function checkAuthenticatedBrowserFlow(page) {
   );
 
   await assertAdminSession(page);
+  await assertPublisherAuthorList(page);
   await assertUploaderSession(page);
   await checkMoneyTransfer(page, secondaryUsername);
   await editSmokeArticle(page);

--- a/test/e2e/live-platform-smoke.mjs
+++ b/test/e2e/live-platform-smoke.mjs
@@ -580,6 +580,8 @@ async function checkAuthenticatedBrowserFlow(page) {
   await loginAs(page, username, password);
   await assertAuthenticatedSession(page);
   await checkAccountSwitchCacheIsolation(page);
+  await assertAdminSession(page);
+  await assertPublisherAuthorList(page);
 
   if (!requireExtended) {
     console.log('Skipping extended authenticated flow because LIVE_E2E_REQUIRE_EXTENDED is not true.');
@@ -595,8 +597,6 @@ async function checkAuthenticatedBrowserFlow(page) {
     'LIVE_E2E_REQUIRE_EXTENDED=true requires LETOVO_E2E_SECONDARY_USERNAME and LETOVO_E2E_SECONDARY_PASSWORD',
   );
 
-  await assertAdminSession(page);
-  await assertPublisherAuthorList(page);
   await assertUploaderSession(page);
   await checkMoneyTransfer(page, secondaryUsername);
   await editSmokeArticle(page);

--- a/test/test_issue178_publisher_authorization_contract.py
+++ b/test/test_issue178_publisher_authorization_contract.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = (ROOT / "docs/publisher_authorization_migration.sql").read_text()
+
+
+def test_admin_author_list_and_publish_check_share_one_eligibility_rule():
+    assert "CREATE OR REPLACE FUNCTION public.is_publishable_identity" in MIGRATION
+    assert "public.is_publishable_identity(target_username)" in MIGRATION
+    assert "public.is_publishable_identity(target.username)" in MIGRATION
+    assert "userrights IN ('admin', 'moder', 'author', 'public_author')" in MIGRATION
+
+
+def test_publishable_identities_must_be_active_and_registered():
+    assert "target.active IS TRUE" in MIGRATION
+    assert "target.registered IS TRUE" in MIGRATION
+    assert "target_is_active IS TRUE" in MIGRATION
+    assert "target_is_registered IS TRUE" in MIGRATION
+
+
+def test_moderator_scope_remains_limited_to_public_authors():
+    assert "requester.userrights = 'moder'" in MIGRATION
+    assert "publisher_rights = 'moder'" in MIGRATION
+    assert "target.userrights = 'public_author'" in MIGRATION
+    assert "target_rights = 'public_author'" in MIGRATION
+
+
+def test_authorization_migration_is_applied_in_candidate_and_production_deploys():
+    for workflow_path in (
+        ROOT / ".github/workflows/docker-image.yml",
+        ROOT / ".github/workflows/production-release.yml",
+    ):
+        workflow = workflow_path.read_text()
+        assert "docs/publisher_authorization_migration.sql" in workflow
+        assert "publisher_authorization_migration.sql" in workflow
+        assert "-f /tmp/publisher_authorization_migration.sql" in workflow
+
+
+def test_schema_snapshots_match_migration_policy():
+    for schema_path in (ROOT / "docs/schema.sql", ROOT / "docs/psql_schema.sql"):
+        schema = schema_path.read_text()
+        assert "is_publishable_identity" in schema
+        assert "userrights IN ('admin', 'moder', 'author', 'public_author')" in schema
+        assert "target.active IS TRUE" in schema
+        assert "target.registered IS TRUE" in schema

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -55,6 +55,10 @@ def test_live_e2e_workflow_runs_after_deployable_images_are_published():
 
 def test_publisher_author_list_runs_on_default_candidate_and_production_smoke():
     script = _read(LIVE_SCRIPT)
+    publisher_assertion = script[
+        script.index("async function assertPublisherAuthorList") :
+        script.index("async function assertUploaderSession")
+    ]
     authenticated_flow = script[
         script.index("async function checkAuthenticatedBrowserFlow") :
         script.index("async function main")
@@ -66,8 +70,13 @@ def test_publisher_author_list_runs_on_default_candidate_and_production_smoke():
     assert authenticated_flow.index(
         "await assertPublisherAuthorList(page);"
     ) < authenticated_flow.index("if (!requireExtended)")
-    assert 'LIVE_E2E_REQUIRE_AUTH: "true"' in _read(BUILD_WORKFLOW)
-    assert 'LIVE_E2E_REQUIRE_AUTH: "true"' in _read(PRODUCTION_RELEASE_WORKFLOW)
+    assert "usernames.has(secondaryUsername)" in publisher_assertion
+    assert "Citizen_hearst" not in publisher_assertion
+    assert "Portal_Administration" not in publisher_assertion
+    for workflow_path in (BUILD_WORKFLOW, PRODUCTION_RELEASE_WORKFLOW):
+        workflow = _read(workflow_path)
+        assert 'LIVE_E2E_REQUIRE_AUTH: "true"' in workflow
+        assert "LETOVO_E2E_SECONDARY_USERNAME: ${{ secrets.LETOVO_E2E_SECONDARY_USERNAME }}" in workflow
 
 
 def test_pr_build_publishes_candidate_images_before_live_e2e_gate():

--- a/test/test_live_e2e_workflow_contract.py
+++ b/test/test_live_e2e_workflow_contract.py
@@ -53,6 +53,23 @@ def test_live_e2e_workflow_runs_after_deployable_images_are_published():
     assert "github.event.workflow_run.head_sha" in workflow
 
 
+def test_publisher_author_list_runs_on_default_candidate_and_production_smoke():
+    script = _read(LIVE_SCRIPT)
+    authenticated_flow = script[
+        script.index("async function checkAuthenticatedBrowserFlow") :
+        script.index("async function main")
+    ]
+
+    assert authenticated_flow.index("await assertAdminSession(page);") < authenticated_flow.index(
+        "if (!requireExtended)"
+    )
+    assert authenticated_flow.index(
+        "await assertPublisherAuthorList(page);"
+    ) < authenticated_flow.index("if (!requireExtended)")
+    assert 'LIVE_E2E_REQUIRE_AUTH: "true"' in _read(BUILD_WORKFLOW)
+    assert 'LIVE_E2E_REQUIRE_AUTH: "true"' in _read(PRODUCTION_RELEASE_WORKFLOW)
+
+
 def test_pr_build_publishes_candidate_images_before_live_e2e_gate():
     workflow = _read(BUILD_WORKFLOW)
 


### PR DESCRIPTION
## Summary
- define one active/registered publisher-identity rule shared by the admin author list and publication authorization
- include moderator publisher accounts such as Citizen_hearst and Portal_Administration while preserving moderator restrictions
- apply the function migration in candidate and production deployment workflows and verify a non-self publisher fixture in live smoke
- update the frontend submodule with searchable display-name and username author options

## Validation
- 15 targeted parent authorization/workflow tests passed
- 2 focused frontend author-search tests passed
- frontend production build passed
- live smoke script syntax check passed

Frontend PR: https://github.com/letovo-dev/letovo-all-frontend/pull/44

Closes #178