### PR TITLE
Fix personal avatar string lifetime

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Inspect backend image
         run: docker image inspect letovo-server:${{ github.sha }} >/dev/null
 
+      - name: Run avatar policy regression with sanitizers
+        run: |
+          g++ -std=c++20 -fsanitize=address,undefined -fno-omit-frame-pointer \
+            test/avatar_policy_regression.cc -o "$RUNNER_TEMP/avatar-policy-regression"
+          "$RUNNER_TEMP/avatar-policy-regression"
+
       - name: Build registration backend image locally
         uses: docker/build-push-action@v5
         with:

--- a/src/basic/avatar_policy.h
+++ b/src/basic/avatar_policy.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <string>
 #include <string_view>
 
 namespace avatar_policy {
@@ -21,16 +22,39 @@ inline constexpr std::array<std::string_view, 30> approved_for_children = {
     "images/avatars/28.png", "images/avatars/29.png", "images/avatars/30.png",
 };
 
-inline std::string_view normalize(std::string_view path) {
+inline std::string normalize(std::string_view path) {
   while (!path.empty() && path.front() == '/')
     path.remove_prefix(1);
-  return path;
+  return std::string(path);
 }
 
 inline bool is_approved_for_child(std::string_view path) {
-  path = normalize(path);
+  const auto normalized = normalize(path);
   return std::find(approved_for_children.begin(), approved_for_children.end(),
-                   path) != approved_for_children.end();
+                   normalized) != approved_for_children.end();
+}
+
+inline bool can_use_path(std::string_view avatar, std::string_view shared_path,
+                         std::string_view admin_path,
+                         std::string_view personal_path, bool is_admin,
+                         bool is_child, bool can_upload_personal) {
+  if (avatar.empty() || avatar.find("..") != std::string_view::npos ||
+      avatar.find('\\') != std::string_view::npos) {
+    return false;
+  }
+
+  const auto normalized = normalize(avatar);
+  const auto shared = normalize(shared_path);
+  const auto admin = normalize(admin_path);
+  const auto personal = normalize(personal_path);
+
+  if (is_child) {
+    return is_approved_for_child(normalized);
+  }
+
+  return normalized.rfind(shared, 0) == 0 ||
+         (is_admin && normalized.rfind(admin, 0) == 0) ||
+         (can_upload_personal && normalized.rfind(personal, 0) == 0);
 }
 
 } // namespace avatar_policy

--- a/src/basic/user_data.cc
+++ b/src/basic/user_data.cc
@@ -525,22 +525,15 @@ std::vector<std::string> all_avatars(const std::string &username, bool is_admin,
 
 bool can_use_avatar(const std::string &username, const std::string &avatar,
                     bool is_admin, const AvatarAccess &access) {
-  if (avatar.empty() || avatar.find("..") != std::string::npos ||
-      avatar.find('\\') != std::string::npos) return false;
-  const auto normalized = avatar_policy::normalize(avatar);
-  const auto shared = avatar_policy::normalize(
-      Config::giveMe().pages_config.user_avatars_path.relative);
-  const auto admin = avatar_policy::normalize(
-      Config::giveMe().pages_config.admin_avatars_path.relative);
-  const auto personal = avatar_policy::normalize(personal_avatar_relative(username));
-  if (access.is_child) {
-    if (!avatar_policy::is_approved_for_child(normalized)) return false;
-  } else if (normalized.rfind(shared, 0) != 0 &&
-             !(is_admin && normalized.rfind(admin, 0) == 0) &&
-             !(access.can_upload_personal &&
-               normalized.rfind(personal, 0) == 0)) {
+  const auto personal_path = personal_avatar_relative(username);
+  if (!avatar_policy::can_use_path(
+          avatar, Config::giveMe().pages_config.user_avatars_path.relative,
+          Config::giveMe().pages_config.admin_avatars_path.relative,
+          personal_path, is_admin, access.is_child,
+          access.can_upload_personal)) {
     return false;
   }
+  const auto normalized = avatar_policy::normalize(avatar);
   std::error_code ec;
   const auto root = std::filesystem::weakly_canonical(media_root(), ec);
   const auto file =

--- a/test/avatar_policy_regression.cc
+++ b/test/avatar_policy_regression.cc
@@ -1,0 +1,99 @@
+#include "../src/basic/avatar_policy.h"
+
+#include <string>
+
+namespace {
+
+int require(bool condition, int failure) { return condition ? 0 : failure; }
+
+} // namespace
+
+int main() {
+  const std::string owner(64, 'a');
+  const std::string foreign_owner(64, 'b');
+  const std::string owner_root = "/images/personal_avatars/" + owner + "/";
+  const std::string owner_avatar = owner_root + "avatar.png";
+  const std::string foreign_avatar =
+      "/images/personal_avatars/" + foreign_owner + "/avatar.png";
+
+  // This temporary used to leave normalize() returning a dangling string_view.
+  const auto normalized =
+      avatar_policy::normalize(std::string("/") + owner_avatar);
+  if (const int failure = require(normalized == owner_avatar.substr(1), 1)) {
+    return failure;
+  }
+
+  if (const int failure =
+          require(avatar_policy::can_use_path(owner_avatar, "/images/avatars/",
+                                              "/images/admin_avatars/",
+                                              owner_root, false, false, true),
+                  2)) {
+    return failure;
+  }
+  if (const int failure =
+          require(!avatar_policy::can_use_path(owner_avatar, "/images/avatars/",
+                                               "/images/admin_avatars/",
+                                               owner_root, false, false, false),
+                  3)) {
+    return failure;
+  }
+  if (const int failure =
+          require(!avatar_policy::can_use_path(
+                      foreign_avatar, "/images/avatars/",
+                      "/images/admin_avatars/", owner_root, false, false, true),
+                  4)) {
+    return failure;
+  }
+  if (const int failure =
+          require(!avatar_policy::can_use_path(
+                      "/images/admin_avatars/admin.png", "/images/avatars/",
+                      "/images/admin_avatars/", owner_root, false, false, true),
+                  5)) {
+    return failure;
+  }
+  if (const int failure =
+          require(avatar_policy::can_use_path(
+                      "/images/admin_avatars/admin.png", "/images/avatars/",
+                      "/images/admin_avatars/", owner_root, true, false, false),
+                  6)) {
+    return failure;
+  }
+  if (const int failure =
+          require(avatar_policy::can_use_path(
+                      "/images/avatars/1.png", "/images/avatars/",
+                      "/images/admin_avatars/", owner_root, false, true, false),
+                  7)) {
+    return failure;
+  }
+  if (const int failure =
+          require(!avatar_policy::can_use_path(owner_avatar, "/images/avatars/",
+                                               "/images/admin_avatars/",
+                                               owner_root, false, true, true),
+                  8)) {
+    return failure;
+  }
+  if (const int failure =
+          require(!avatar_policy::can_use_path(
+                      "/images/avatars/31.png", "/images/avatars/",
+                      "/images/admin_avatars/", owner_root, false, true, false),
+                  9)) {
+    return failure;
+  }
+  if (const int failure =
+          require(!avatar_policy::can_use_path(
+                      "/images/personal_avatars/../admin_avatars/admin.png",
+                      "/images/avatars/", "/images/admin_avatars/", owner_root,
+                      true, false, true),
+                  10)) {
+    return failure;
+  }
+  if (const int failure = require(
+          !avatar_policy::can_use_path(
+              R"(images\personal_avatars\avatar.png)", "/images/avatars/",
+              "/images/admin_avatars/", owner_root, true, false, true),
+          11)) {
+    return failure;
+  }
+
+  return 0;
+}

--- a/test/test_issue153_avatar_access_contract.py
+++ b/test/test_issue153_avatar_access_contract.py
@@ -27,11 +27,16 @@ def test_child_allowlist_and_fallback_match_approved_production_batch():
 
 def test_backend_enforces_child_policy_on_list_and_direct_selection():
     source = USER_DATA.read_text()
+    policy = POLICY.read_text()
 
     assert "COALESCE(u.userrights = 'child', false) AS is_child" in source
     assert "avatar_policy::is_approved_for_child(avatar)" in source
-    assert "if (access.is_child)" in source
-    assert "avatar_policy::is_approved_for_child(normalized)" in source
+    assert "avatar_policy::can_use_path(" in source
+    assert (
+        "const auto personal_path = personal_avatar_relative(username);" in source
+    )
+    assert "if (is_child)" in policy
+    assert "is_approved_for_child(normalized)" in policy
     assert "access.can_upload_personal" in source
     assert "user::avatar_access(username, pool_ptr)" in source
     assert "restinio::status_forbidden()" in source


### PR DESCRIPTION
Closes #186

## Summary
- make avatar path normalization return owned storage
- keep the personal namespace path alive and centralize path authorization without weakening admin, child, traversal, or ownership checks
- run an executable C++ regression under ASan/UBSan in PR CI

## Validation
- sanitizer regression executable (owner, foreign owner, admin, child, traversal)
- existing issue #153 avatar policy contracts
- existing issue #174 uploader deployment contracts
- full production backend Docker build