### PR TITLE
Fix saved post counter consistency

### DIFF
--- a/src/letovo-soc-net/page_server.cc
+++ b/src/letovo-soc-net/page_server.cc
@@ -235,11 +235,11 @@ namespace page {
         con->execute_params("DELETE FROM \"posts\" WHERE \"post_id\"=($1);", params, true);
         pool_ptr->returnConnection(std::move(con));
     }
-    void update_post(int post_id, bool is_secret, int likes, int dislikes, int saved_count, std::string title, std::string author, std::string text, std::string category, std::string post_path, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
+    void update_post(int post_id, bool is_secret, int likes, int dislikes, std::string title, std::string author, std::string text, std::string category, std::string post_path, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
         auto con = std::move(pool_ptr->getConnection());
-        std::vector<std::string> params = {std::to_string(is_secret), std::to_string(likes), std::to_string(dislikes), std::to_string(saved_count), title, author, text, category, post_path, std::to_string(post_id)};
+        std::vector<std::string> params = {std::to_string(is_secret), std::to_string(likes), std::to_string(dislikes), title, author, text, category, post_path, std::to_string(post_id)};
 
-        con->execute_params("UPDATE \"posts\" SET \"is_secret\"=($1), \"likes\"=($2), \"dislikes\"=($3), \"saved_count\"=($4), \"title\"=($5), \"author\"=($6), \"text\"=($7), \"category_name\"=($8), \"post_path\"=($9) WHERE \"post_id\"=($10);", params, true);
+        con->execute_params("UPDATE \"posts\" SET \"is_secret\"=($1), \"likes\"=($2), \"dislikes\"=($3), \"title\"=($4), \"author\"=($5), \"text\"=($6), \"category_name\"=($7), \"post_path\"=($8) WHERE \"post_id\"=($9);", params, true);
         normalize_article_categories(con);
         pool_ptr->returnConnection(std::move(con));
     }
@@ -703,8 +703,7 @@ namespace page::server {
                 auto is_secret = new_body.HasMember("is_secret") ? json_bool_value(new_body["is_secret"]) : std::optional<bool>(row_bool_or_false(old_post[0], "is_secret"));
                 auto likes = new_body.HasMember("likes") ? json_int_value(new_body["likes"]) : std::optional<int>(row_int_or_zero(old_post[0], "likes"));
                 auto dislikes = new_body.HasMember("dislikes") ? json_int_value(new_body["dislikes"]) : std::optional<int>(row_int_or_zero(old_post[0], "dislikes"));
-                auto saved_count = new_body.HasMember("saved_count") ? json_int_value(new_body["saved_count"]) : std::optional<int>(row_int_or_zero(old_post[0], "saved_count"));
-                if (!is_secret.has_value() || !likes.has_value() || !dislikes.has_value() || !saved_count.has_value()) {
+                if (!is_secret.has_value() || !likes.has_value() || !dislikes.has_value()) {
                     return req->create_response(restinio::status_bad_request()).done();
                 }
 
@@ -720,7 +719,6 @@ namespace page::server {
                     *is_secret,
                     *likes,
                     *dislikes,
-                    *saved_count,
                     title,
                     author,
                     text,

--- a/src/letovo-soc-net/page_server.h
+++ b/src/letovo-soc-net/page_server.h
@@ -38,7 +38,7 @@ namespace page {
 
     void delete_post(int post_id, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
 
-    void update_post(int post_id, bool is_secret, int likes, int dislikes, int saved, std::string title, std::string author, std::string text, std::string category, std::string post_path, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
+    void update_post(int post_id, bool is_secret, int likes, int dislikes, std::string title, std::string author, std::string text, std::string category, std::string post_path, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
 
     void add_media(int post_id, std::vector<std::string> &media_paths, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
 

--- a/src/letovo-soc-net/social.cc
+++ b/src/letovo-soc-net/social.cc
@@ -354,18 +354,30 @@ LEFT JOIN comment_preview cp ON cp.post_id = vp.post_id;
     void save_post(std::string post_id, std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
         auto con = std::move(pool_ptr->getConnection());
         std::vector<std::string> params = {post_id, username};
-        con->execute_params("INSERT INTO \"user_saved\" (\"post_id\", \"username\") VALUES ($1, $2);", params, true);
-        params = {post_id};
-        con->execute_params("UPDATE \"posts\" SET saved_count = saved_count + 1 WHERE post_id=($1);", params, true);
+        con->execute_params(
+            "WITH inserted AS ("
+            "INSERT INTO \"user_saved\" (\"post_id\", \"username\") VALUES ($1, $2) "
+            "ON CONFLICT DO NOTHING RETURNING \"post_id\""
+            ") "
+            "UPDATE \"posts\" SET \"saved_count\" = \"saved_count\" + 1 "
+            "WHERE \"post_id\" IN (SELECT \"post_id\" FROM inserted);",
+            params, true
+        );
         pool_ptr->returnConnection(std::move(con));
     }
 
     void delete_saved_post(std::string post_id, std::string username, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
         auto con = std::move(pool_ptr->getConnection());
         std::vector<std::string> params = {post_id, username};
-        con->execute_params("DELETE FROM \"user_saved\" WHERE post_id=($1) AND username=($2);", params, true);
-        params = {post_id};
-        con->execute_params("UPDATE \"posts\" SET saved_count = saved_count - 1 WHERE post_id=($1);", params, true);
+        con->execute_params(
+            "WITH deleted AS ("
+            "DELETE FROM \"user_saved\" WHERE \"post_id\"=($1) AND \"username\"=($2) "
+            "RETURNING \"post_id\""
+            ") "
+            "UPDATE \"posts\" SET \"saved_count\" = GREATEST(\"saved_count\" - 1, 0) "
+            "WHERE \"post_id\" IN (SELECT \"post_id\" FROM deleted);",
+            params, true
+        );
         pool_ptr->returnConnection(std::move(con));
     }
 

--- a/test/test_issue181_saved_count_contract.py
+++ b/test/test_issue181_saved_count_contract.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8").replace('\\"', '"')
+
+
+def test_save_and_unsave_update_the_counter_only_when_the_relation_changes():
+    source = read("src/letovo-soc-net/social.cc")
+
+    assert "WITH inserted AS (" in source
+    assert 'ON CONFLICT DO NOTHING RETURNING "post_id"' in source
+    assert '"saved_count" = "saved_count" + 1' in source
+    assert 'SELECT "post_id" FROM inserted' in source
+
+    assert "WITH deleted AS (" in source
+    assert 'DELETE FROM "user_saved"' in source
+    assert 'RETURNING "post_id"' in source
+    assert '"saved_count" = GREATEST("saved_count" - 1, 0)' in source
+    assert 'SELECT "post_id" FROM deleted' in source
+
+
+def test_post_edits_cannot_overwrite_saved_count():
+    source = read("src/letovo-soc-net/page_server.cc")
+    header = read("src/letovo-soc-net/page_server.h")
+    update_post = source.split("void update_post(", 1)[1].split("void add_media(", 1)[0]
+    update_route = source.split('http_put("/post/update"', 1)[1]
+
+    assert "saved_count" not in update_post
+    assert 'new_body.HasMember("saved_count")' not in update_route
+    update_post_decl = header.split("void update_post(", 1)[1].split(";", 1)[0]
+    assert "int saved" not in update_post_decl

--- a/test/test_pages.py
+++ b/test/test_pages.py
@@ -318,3 +318,72 @@ def test_update_post_rejects_malformed_post_id_without_upstream_close(admin_toke
     )
 
     assert response.status_code == 400
+
+
+def test_saved_count_survives_reload_duplicate_requests_and_post_edit(admin_token):
+    page_id = _create_test_article(admin_token, "issue 181 saved count")
+    headers = {"Bearer": admin_token}
+    save_payload = {"post_id": str(page_id)}
+
+    # Start from a known state even when a persistent test database is reused.
+    response = requests.delete(
+        f"{BASE_URL}/social/save",
+        json=save_payload,
+        headers=headers,
+        verify=False,
+    )
+    assert response.status_code == 200
+
+    response = requests.post(
+        f"{BASE_URL}/social/save",
+        json=save_payload,
+        headers=headers,
+        verify=False,
+    )
+    assert response.status_code == 200
+    response = requests.get(f"{BASE_URL}/post/{page_id}", verify=False)
+    assert response.status_code == 200
+    assert response.json()["result"][0]["saved_count"] == "1"
+
+    # A duplicate save must not increment the denormalized counter again.
+    response = requests.post(
+        f"{BASE_URL}/social/save",
+        json=save_payload,
+        headers=headers,
+        verify=False,
+    )
+    assert response.status_code == 200
+    response = requests.get(f"{BASE_URL}/post/{page_id}", verify=False)
+    assert response.json()["result"][0]["saved_count"] == "1"
+
+    # A stale editor payload must not overwrite the server-owned counter.
+    response = requests.put(
+        f"{BASE_URL}/post/update",
+        json={
+            "post_id": str(page_id),
+            "saved_count": 0,
+            "title": "issue 181 saved count edited",
+        },
+        headers=headers,
+        verify=False,
+    )
+    assert response.status_code == 200
+    response = requests.get(f"{BASE_URL}/post/{page_id}", verify=False)
+    assert response.json()["result"][0]["saved_count"] == "1"
+
+    response = requests.delete(
+        f"{BASE_URL}/social/save",
+        json=save_payload,
+        headers=headers,
+        verify=False,
+    )
+    assert response.status_code == 200
+    response = requests.delete(
+        f"{BASE_URL}/social/save",
+        json=save_payload,
+        headers=headers,
+        verify=False,
+    )
+    assert response.status_code == 200
+    response = requests.get(f"{BASE_URL}/post/{page_id}", verify=False)
+    assert response.json()["result"][0]["saved_count"] == "0"


### PR DESCRIPTION
Closes #181

## Summary
- update saved relations and `saved_count` atomically in one SQL statement
- make duplicate save/unsave requests idempotent
- keep `saved_count` server-owned during post edits
- cover reload, duplicate requests, stale edits, and SQL contracts

## Validation
- `python3 -B` contract assertions
- `python3 -B -m py_compile test/test_pages.py test/test_issue181_saved_count_contract.py`
- `g++ -std=c++20 -fsyntax-only -Isrc src/letovo-soc-net/social.cc src/letovo-soc-net/page_server.cc`
- `git diff --check`

Existing production counter reconciliation remains a separate approval-gated data operation, as requested in the issue diagnosis.