### PR TITLE
Preserve post media upload order

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -433,6 +433,7 @@ jobs:
           role_backup="$backup_root/role.before-avatar-migration.sql"
           user_backup="$backup_root/user.before-child-avatar-migration.sql"
           transactions_backup="$backup_root/transactions.before-department-payout-migration.sql"
+          post_media_backup="$backup_root/post-media.before-order-migration.sql"
           child_avatar_preview="$backup_root/child-avatar-migration-preview.csv"
 
           test -f "$migration"
@@ -441,6 +442,9 @@ jobs:
           test -f "$publisher_authorization_migration"
           test -f "$post_media_order_migration"
           mkdir -p "$backup_root"
+          docker exec letovo-postgres-1 \
+            pg_dump -U scv -d letovo_db -t public.post_media > "$post_media_backup"
+          test -s "$post_media_backup"
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.transactions > "$transactions_backup"
           test -s "$transactions_backup"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -320,6 +320,10 @@ jobs:
         working-directory: frontend
         run: npm run test:opentelemetry
 
+      - name: Verify post media upload ordering
+        working-directory: frontend
+        run: npm run test:post-media-order
+
       - name: Build frontend
         working-directory: frontend
         env:
@@ -409,6 +413,8 @@ jobs:
             "$remote:$state_dir/department_payout_migration.sql"
           scp -i ~/.ssh/live-e2e docs/publisher_authorization_migration.sql \
             "$remote:$state_dir/publisher_authorization_migration.sql"
+          scp -i ~/.ssh/live-e2e docs/post_media_order_migration.sql \
+            "$remote:$state_dir/post_media_order_migration.sql"
           ssh -i ~/.ssh/live-e2e "$remote" \
             "BACKEND_IMAGE='$BACKEND_CANDIDATE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_CANDIDATE_IMAGE' FRONTEND_IMAGE='$FRONTEND_CANDIDATE_IMAGE' UPLOADER_IMAGE='$UPLOADER_CANDIDATE_IMAGE' COMPOSE_FILE='$LETOVO_E2E_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_E2E_DEPLOY_PROJECT' RUN_ID='${{ github.run_id }}' bash -s" <<'REMOTE'
           set -euo pipefail
@@ -422,6 +428,7 @@ jobs:
           child_avatar_migration="$state_dir/child_avatar_access_migration.sql"
           payout_migration="$state_dir/department_payout_migration.sql"
           publisher_authorization_migration="$state_dir/publisher_authorization_migration.sql"
+          post_media_order_migration="$state_dir/post_media_order_migration.sql"
           backup_root="$HOME/backups/letovo-live-e2e-${RUN_ID}"
           role_backup="$backup_root/role.before-avatar-migration.sql"
           user_backup="$backup_root/user.before-child-avatar-migration.sql"
@@ -432,6 +439,7 @@ jobs:
           test -f "$child_avatar_migration"
           test -f "$payout_migration"
           test -f "$publisher_authorization_migration"
+          test -f "$post_media_order_migration"
           mkdir -p "$backup_root"
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.transactions > "$transactions_backup"
@@ -447,6 +455,12 @@ jobs:
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
               -f /tmp/publisher_authorization_migration.sql
           docker exec letovo-postgres-1 rm -f /tmp/publisher_authorization_migration.sql
+          docker cp "$post_media_order_migration" \
+            letovo-postgres-1:/tmp/post_media_order_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
+              -f /tmp/post_media_order_migration.sql
+          docker exec letovo-postgres-1 rm -f /tmp/post_media_order_migration.sql
 
           docker inspect -f 'letovo-server={{.Config.Image}}' letovo-server > "$restore"
           docker inspect -f 'letovo-registration-server={{.Config.Image}}' letovo-registration-server >> "$restore"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -80,12 +80,12 @@ jobs:
             test/avatar_policy_regression.cc -o "$RUNNER_TEMP/avatar-policy-regression"
           "$RUNNER_TEMP/avatar-policy-regression"
 
-      - name: Run department payout PostgreSQL regression
+      - name: Run PostgreSQL regressions
         env:
           LETOVO_POSTGRES_DSN: postgresql://postgres@127.0.0.1:5432/letovo_issue193
         run: |
           python3 -m pip install --disable-pip-version-check psycopg2-binary pytest
-          python3 -m pytest -q test/test_issue193_department_payout_postgres.py
+          python3 -m pytest -q test/test_issue193_department_payout_postgres.py test/test_issue179_media_order_postgres.py
 
       - name: Build registration backend image locally
         uses: docker/build-push-action@v5

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -403,6 +403,8 @@ jobs:
           user_backup_tmp="$state_dir/user.before-child-avatar-migration.sql"
           transactions_backup="$backup_root/transactions.before-department-payout-migration.sql"
           transactions_backup_tmp="$state_dir/transactions.before-department-payout-migration.sql"
+          post_media_backup="$backup_root/post-media.before-order-migration.sql"
+          post_media_backup_tmp="$state_dir/post-media.before-order-migration.sql"
           child_avatar_preview="$backup_root/child-avatar-migration-preview.csv"
           child_avatar_preview_tmp="$state_dir/child-avatar-migration-preview.csv"
 
@@ -427,6 +429,10 @@ jobs:
           test -f "$publisher_authorization_migration"
           test -f "$post_media_order_migration"
           as_root mkdir -p "$backup_root"
+          docker exec letovo-postgres-1 \
+            pg_dump -U scv -d letovo_db -t public.post_media > "$post_media_backup_tmp"
+          test -s "$post_media_backup_tmp"
+          as_root install -m 0600 "$post_media_backup_tmp" "$post_media_backup"
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.transactions > "$transactions_backup_tmp"
           test -s "$transactions_backup_tmp"

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -367,6 +367,8 @@ jobs:
             "$remote:$state_dir/department_payout_migration.sql"
           scp -i ~/.ssh/letovo-production-release docs/publisher_authorization_migration.sql \
             "$remote:$state_dir/publisher_authorization_migration.sql"
+          scp -i ~/.ssh/letovo-production-release docs/post_media_order_migration.sql \
+            "$remote:$state_dir/post_media_order_migration.sql"
           ssh -i ~/.ssh/letovo-production-release "$remote" \
             "BACKEND_IMAGE='$BACKEND_RELEASE_IMAGE' REGISTRATION_IMAGE='$REGISTRATION_RELEASE_IMAGE' FRONTEND_IMAGE='$FRONTEND_RELEASE_IMAGE' UPLOADER_IMAGE='$UPLOADER_RELEASE_IMAGE' RELEASE_SHA='${{ steps.release.outputs.release_sha }}' COMPOSE_FILE='$LETOVO_PROD_DEPLOY_COMPOSE' PROJECT_NAME='$LETOVO_PROD_DEPLOY_PROJECT' NGINX_SITE='$LETOVO_PROD_NGINX_SITE' RUN_ID='${{ github.run_id }}' EXPECTED_CHILD_AVATAR_COUNT='$CHILD_AVATAR_EXPECTED_COUNT' EXPECTED_CHILD_AVATAR_SHA256='$CHILD_AVATAR_EXPECTED_SHA256' bash -s" <<'REMOTE'
           set -euo pipefail
@@ -388,6 +390,7 @@ jobs:
           child_avatar_migration="$state_dir/child_avatar_access_migration.sql"
           payout_migration="$state_dir/department_payout_migration.sql"
           publisher_authorization_migration="$state_dir/publisher_authorization_migration.sql"
+          post_media_order_migration="$state_dir/post_media_order_migration.sql"
           nginx_candidate="$state_dir/nginx-site.candidate"
           compose_dir="$(dirname "$COMPOSE_FILE")"
           otel_config="$compose_dir/otel-collector-config.yaml"
@@ -422,6 +425,7 @@ jobs:
           test -f "$child_avatar_migration"
           test -f "$payout_migration"
           test -f "$publisher_authorization_migration"
+          test -f "$post_media_order_migration"
           as_root mkdir -p "$backup_root"
           docker exec letovo-postgres-1 \
             pg_dump -U scv -d letovo_db -t public.transactions > "$transactions_backup_tmp"
@@ -438,6 +442,12 @@ jobs:
             psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
               -f /tmp/publisher_authorization_migration.sql
           docker exec letovo-postgres-1 rm -f /tmp/publisher_authorization_migration.sql
+          docker cp "$post_media_order_migration" \
+            letovo-postgres-1:/tmp/post_media_order_migration.sql
+          docker exec letovo-postgres-1 \
+            psql -v ON_ERROR_STOP=1 -U scv -d letovo_db \
+              -f /tmp/post_media_order_migration.sql
+          docker exec letovo-postgres-1 rm -f /tmp/post_media_order_migration.sql
           docker rm -f "$smoke_name" >/dev/null 2>&1 || true
           cleanup_smoke() {
             docker rm -f "$smoke_name" >/dev/null 2>&1 || true

--- a/docs/post_media_order_migration.sql
+++ b/docs/post_media_order_migration.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+LOCK TABLE public.post_media IN SHARE ROW EXCLUSIVE MODE;
+
+ALTER TABLE public.post_media
+    ADD COLUMN IF NOT EXISTS "position" integer;
+
+WITH ranked_media AS (
+    SELECT
+        ctid,
+        ROW_NUMBER() OVER (
+            PARTITION BY post_id
+            ORDER BY media NULLS LAST, is_pic NULLS LAST, is_secret NULLS LAST, ctid
+        ) - 1 AS backfilled_position
+    FROM public.post_media
+    WHERE "position" IS NULL
+)
+UPDATE public.post_media AS target
+SET "position" = ranked_media.backfilled_position
+FROM ranked_media
+WHERE target.ctid = ranked_media.ctid;
+
+ALTER TABLE public.post_media
+    ALTER COLUMN "position" SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_post_media_post_id_position
+    ON public.post_media (post_id, "position");
+
+COMMIT;

--- a/docs/post_media_order_migration.sql
+++ b/docs/post_media_order_migration.sql
@@ -26,4 +26,31 @@ ALTER TABLE public.post_media
 CREATE UNIQUE INDEX IF NOT EXISTS idx_post_media_post_id_position
     ON public.post_media (post_id, "position");
 
+CREATE OR REPLACE FUNCTION public.assign_post_media_position()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Keep the legacy writer and the ordered writer serialized per post.
+    PERFORM 1
+    FROM public.posts
+    WHERE post_id::text = NEW.post_id
+    FOR UPDATE;
+
+    IF NEW."position" IS NULL THEN
+        SELECT COALESCE(MAX(pm."position"), -1) + 1
+        INTO NEW."position"
+        FROM public.post_media AS pm
+        WHERE pm.post_id = NEW.post_id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS assign_post_media_position ON public.post_media;
+CREATE TRIGGER assign_post_media_position
+BEFORE INSERT ON public.post_media
+FOR EACH ROW
+EXECUTE FUNCTION public.assign_post_media_position();
 COMMIT;

--- a/docs/psql_schema.sql
+++ b/docs/psql_schema.sql
@@ -529,7 +529,8 @@ CREATE TABLE public.post_media (
     post_id character varying NOT NULL,
     media character varying,
     is_pic boolean,
-    is_secret boolean DEFAULT false
+    is_secret boolean DEFAULT false,
+    "position" integer NOT NULL
 );
 
 

--- a/docs/psql_schema.sql
+++ b/docs/psql_schema.sql
@@ -533,6 +533,8 @@ CREATE TABLE public.post_media (
     "position" integer NOT NULL
 );
 
+CREATE UNIQUE INDEX idx_post_media_post_id_position ON public.post_media USING btree (post_id, "position");
+
 
 --
 -- Name: camp_dates; Type: TABLE; Schema: public; Owner: -

--- a/docs/psql_schema.sql
+++ b/docs/psql_schema.sql
@@ -535,7 +535,28 @@ CREATE TABLE public.post_media (
 
 CREATE UNIQUE INDEX idx_post_media_post_id_position ON public.post_media USING btree (post_id, "position");
 
+CREATE FUNCTION public.assign_post_media_position() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    PERFORM 1
+    FROM public.posts
+    WHERE post_id::text = NEW.post_id
+    FOR UPDATE;
 
+    IF NEW."position" IS NULL THEN
+        SELECT COALESCE(MAX(pm."position"), -1) + 1
+        INTO NEW."position"
+        FROM public.post_media AS pm
+        WHERE pm.post_id = NEW.post_id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+
+CREATE TRIGGER assign_post_media_position BEFORE INSERT ON public.post_media FOR EACH ROW EXECUTE FUNCTION public.assign_post_media_position();
 --
 -- Name: camp_dates; Type: TABLE; Schema: public; Owner: -
 --

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -629,6 +629,8 @@ CREATE TABLE public.post_media (
 
 ALTER TABLE public.post_media OWNER TO scv;
 
+CREATE UNIQUE INDEX idx_post_media_post_id_position ON public.post_media USING btree (post_id, "position");
+
 --
 -- Name: posts; Type: TABLE; Schema: public; Owner: scv
 --

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -622,7 +622,8 @@ CREATE TABLE public.post_media (
     post_id character varying NOT NULL,
     media character varying,
     is_pic boolean,
-    is_secret boolean DEFAULT false
+    is_secret boolean DEFAULT false,
+    "position" integer NOT NULL
 );
 
 

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -631,7 +631,30 @@ ALTER TABLE public.post_media OWNER TO scv;
 
 CREATE UNIQUE INDEX idx_post_media_post_id_position ON public.post_media USING btree (post_id, "position");
 
+CREATE FUNCTION public.assign_post_media_position() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    PERFORM 1
+    FROM public.posts
+    WHERE post_id::text = NEW.post_id
+    FOR UPDATE;
+
+    IF NEW."position" IS NULL THEN
+        SELECT COALESCE(MAX(pm."position"), -1) + 1
+        INTO NEW."position"
+        FROM public.post_media AS pm
+        WHERE pm.post_id = NEW.post_id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.assign_post_media_position() OWNER TO scv;
+
 --
+CREATE TRIGGER assign_post_media_position BEFORE INSERT ON public.post_media FOR EACH ROW EXECUTE FUNCTION public.assign_post_media_position();
 -- Name: posts; Type: TABLE; Schema: public; Owner: scv
 --
 

--- a/src/letovo-soc-net/page_server.cc
+++ b/src/letovo-soc-net/page_server.cc
@@ -244,15 +244,73 @@ namespace page {
         pool_ptr->returnConnection(std::move(con));
     }
 
-    void add_media(int post_id, std::vector<std::string> &media_paths, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
+    void add_media(int post_id, std::vector<std::string> &media_paths, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr, bool replace_existing) {
         auto con = std::move(pool_ptr->getConnection());
-        std::vector<std::string> params(2);
-        for (const auto& media_path : media_paths) {
-            params[0] = std::to_string(post_id);
-            params[1] = media_path;
-            // could commit after cycle, but idk how
-            con->execute_params("INSERT INTO \"post_media\" (\"post_id\", \"media\") VALUES ($1, $2);", params, true);
+        std::vector<std::string> params = {std::to_string(post_id)};
+
+        if (media_paths.empty()) {
+            if (replace_existing) {
+                con->execute_params(R"SQL(
+WITH locked_post AS (
+    SELECT "post_id" FROM "posts" WHERE "post_id"=($1)::int FOR UPDATE
+)
+DELETE FROM "post_media"
+USING locked_post
+WHERE "post_media"."post_id"=locked_post."post_id"::text;
+)SQL", params, true);
+            }
+            pool_ptr->returnConnection(std::move(con));
+            return;
         }
+
+        std::string values;
+        params.reserve(media_paths.size() + 1);
+        for (std::size_t i = 0; i < media_paths.size(); ++i) {
+            if (!values.empty()) {
+                values += ", ";
+            }
+            values += fmt::format("((${})::varchar, {})", i + 2, i);
+            params.emplace_back(media_paths[i]);
+        }
+
+        const std::string query = replace_existing
+            ? fmt::format(R"SQL(
+WITH locked_post AS (
+    SELECT "post_id" FROM "posts" WHERE "post_id"=($1)::int FOR UPDATE
+),
+deleted AS (
+    DELETE FROM "post_media"
+    USING locked_post
+    WHERE "post_media"."post_id"=locked_post."post_id"::text
+),
+input_media("media", "position") AS (
+    VALUES {}
+)
+INSERT INTO "post_media" ("post_id", "media", "position")
+SELECT locked_post."post_id"::text, input_media."media", input_media."position"
+FROM input_media
+CROSS JOIN locked_post
+ORDER BY input_media."position";
+)SQL", values)
+            : fmt::format(R"SQL(
+WITH locked_post AS (
+    SELECT "post_id" FROM "posts" WHERE "post_id"=($1)::int FOR UPDATE
+),
+input_media("media", "offset") AS (
+    VALUES {}
+),
+first_position AS (
+    SELECT COALESCE(MAX("post_media"."position"), -1) + 1 AS "position"
+    FROM locked_post
+    LEFT JOIN "post_media" ON "post_media"."post_id"=locked_post."post_id"::text
+)
+INSERT INTO "post_media" ("post_id", "media", "position")
+SELECT ($1), input_media."media", first_position."position" + input_media."offset"
+FROM input_media
+CROSS JOIN first_position
+ORDER BY input_media."offset";
+)SQL", values);
+        con->execute_params(query, params, true);
         pool_ptr->returnConnection(std::move(con));
     }
 
@@ -730,10 +788,10 @@ namespace page::server {
                 );
                 logger_ptr->info([post_id] { return fmt::format("post {} database row updated", *post_id); });
 
-                std::vector<std::string> media_paths;
-                page::med_to_vec(new_body, media_paths);
-                if (!media_paths.empty()) {
-                    page::add_media(*post_id, media_paths, pool_ptr, logger_ptr);
+                if (new_body.HasMember("media") && new_body["media"].IsArray()) {
+                    std::vector<std::string> media_paths;
+                    page::med_to_vec(new_body, media_paths);
+                    page::add_media(*post_id, media_paths, pool_ptr, logger_ptr, true);
                     logger_ptr->info([post_id] { return fmt::format("post {} media updated", *post_id); });
                 }
 

--- a/src/letovo-soc-net/page_server.h
+++ b/src/letovo-soc-net/page_server.h
@@ -40,7 +40,7 @@ namespace page {
 
     void update_post(int post_id, bool is_secret, int likes, int dislikes, int saved, std::string title, std::string author, std::string text, std::string category, std::string post_path, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
 
-    void add_media(int post_id, std::vector<std::string> &media_paths, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
+    void add_media(int post_id, std::vector<std::string> &media_paths, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr, bool replace_existing = false);
 
     void delete_media(int post_id, std::vector<std::string> &media_paths, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr);
 

--- a/src/letovo-soc-net/social.cc
+++ b/src/letovo-soc-net/social.cc
@@ -133,7 +133,7 @@ namespace social {
         if(!include_secret) {
             query += " and COALESCE(p.is_secret, false) = false";
         }
-        query += ";";
+        query += " ORDER BY \"post_media\".\"position\" ASC;";
         result = con->execute_params(query, params);
         
         pool_ptr->returnConnection(std::move(con));
@@ -174,7 +174,7 @@ media_rows AS (
                    'is_secret', pm.is_secret,
                    'post_id', pm.post_id
                )
-               ORDER BY pm.media
+               ORDER BY pm."position"
            ) AS media
     FROM "post_media" pm
     JOIN visible_posts vp ON vp.post_id::text = pm.post_id

--- a/test/test_issue179_media_order_contract.py
+++ b/test/test_issue179_media_order_contract.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_media_order_migration_backfills_and_enforces_position():
+    migration = read("docs/post_media_order_migration.sql")
+
+    assert 'ADD COLUMN IF NOT EXISTS "position" integer' in migration
+    assert "ROW_NUMBER() OVER (" in migration
+    assert "PARTITION BY post_id" in migration
+    assert "ORDER BY media NULLS LAST" in migration
+    assert 'ALTER COLUMN "position" SET NOT NULL' in migration
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS idx_post_media_post_id_position" in migration
+
+
+def test_create_and_edit_write_array_order_instead_of_filename_order():
+    source = read("src/letovo-soc-net/page_server.cc")
+    upload_order = ["/images/z-last.jpg", "/images/a-first.jpg", "/images/m-middle.jpg"]
+
+    assert upload_order != sorted(upload_order)
+    assert 'input_media("media", "position")' in source
+    assert 'SELECT locked_post."post_id"::text' in source
+    assert 'input_media("media", "offset")' in source
+    assert 'first_position."position" + input_media."offset"' in source
+    assert "FOR UPDATE" in source
+    assert "page::add_media(*post_id, media_paths, pool_ptr, logger_ptr, true);" in source
+
+
+def test_both_media_api_paths_read_explicit_position_order():
+    source = read("src/letovo-soc-net/social.cc")
+
+    assert r'ORDER BY \"post_media\".\"position\" ASC' in source
+    assert 'ORDER BY pm."position"' in source
+    assert "ORDER BY pm.media" not in source
+
+
+def test_candidate_and_production_deploy_apply_media_order_migration():
+    for workflow_path in (
+        ROOT / ".github/workflows/docker-image.yml",
+        ROOT / ".github/workflows/production-release.yml",
+    ):
+        workflow = workflow_path.read_text(encoding="utf-8")
+        assert "docs/post_media_order_migration.sql" in workflow
+        assert "post_media_order_migration.sql" in workflow
+        assert "-f /tmp/post_media_order_migration.sql" in workflow

--- a/test/test_issue179_media_order_contract.py
+++ b/test/test_issue179_media_order_contract.py
@@ -49,3 +49,8 @@ def test_candidate_and_production_deploy_apply_media_order_migration():
         assert "docs/post_media_order_migration.sql" in workflow
         assert "post_media_order_migration.sql" in workflow
         assert "-f /tmp/post_media_order_migration.sql" in workflow
+        assert "pg_dump -U scv -d letovo_db -t public.post_media" in workflow
+        assert 'test -s "$post_media_backup' in workflow
+
+    production_workflow = read(".github/workflows/production-release.yml")
+    assert 'install -m 0600 "$post_media_backup_tmp" "$post_media_backup"' in production_workflow

--- a/test/test_issue179_media_order_contract.py
+++ b/test/test_issue179_media_order_contract.py
@@ -19,6 +19,18 @@ def test_media_order_migration_backfills_and_enforces_position():
     assert "CREATE UNIQUE INDEX IF NOT EXISTS idx_post_media_post_id_position" in migration
 
 
+def test_bootstrap_schemas_enforce_unique_media_positions():
+    expected_index = (
+        "CREATE UNIQUE INDEX idx_post_media_post_id_position "
+        'ON public.post_media USING btree (post_id, "position");'
+    )
+
+    for schema_path in ("docs/schema.sql", "docs/psql_schema.sql"):
+        schema = read(schema_path)
+        assert '"position" integer NOT NULL' in schema
+        assert expected_index in schema
+
+
 def test_create_and_edit_write_array_order_instead_of_filename_order():
     source = read("src/letovo-soc-net/page_server.cc")
     upload_order = ["/images/z-last.jpg", "/images/a-first.jpg", "/images/m-middle.jpg"]

--- a/test/test_issue179_media_order_contract.py
+++ b/test/test_issue179_media_order_contract.py
@@ -15,6 +15,8 @@ def test_media_order_migration_backfills_and_enforces_position():
     assert "ROW_NUMBER() OVER (" in migration
     assert "PARTITION BY post_id" in migration
     assert "ORDER BY media NULLS LAST" in migration
+    assert "CREATE OR REPLACE FUNCTION public.assign_post_media_position()" in migration
+    assert "CREATE TRIGGER assign_post_media_position" in migration
     assert 'ALTER COLUMN "position" SET NOT NULL' in migration
     assert "CREATE UNIQUE INDEX IF NOT EXISTS idx_post_media_post_id_position" in migration
 
@@ -28,6 +30,8 @@ def test_bootstrap_schemas_enforce_unique_media_positions():
     for schema_path in ("docs/schema.sql", "docs/psql_schema.sql"):
         schema = read(schema_path)
         assert '"position" integer NOT NULL' in schema
+        assert "CREATE FUNCTION public.assign_post_media_position()" in schema
+        assert "CREATE TRIGGER assign_post_media_position" in schema
         assert expected_index in schema
 
 

--- a/test/test_issue179_media_order_postgres.py
+++ b/test/test_issue179_media_order_postgres.py
@@ -1,0 +1,57 @@
+import os
+from pathlib import Path
+
+import psycopg2
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = (ROOT / "docs/post_media_order_migration.sql").read_text()
+DSN = os.environ.get("LETOVO_POSTGRES_DSN")
+
+
+@pytest.fixture
+def database():
+    if not DSN:
+        pytest.skip("LETOVO_POSTGRES_DSN is required for PostgreSQL-backed tests")
+    connection = psycopg2.connect(DSN)
+    connection.autocommit = True
+    schema = "issue179_media_order"
+    with connection.cursor() as cursor:
+        cursor.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        cursor.execute(f'CREATE SCHEMA "{schema}"')
+        cursor.execute(f'SET search_path TO "{schema}", public')
+        cursor.execute("""
+            CREATE TABLE posts (post_id integer PRIMARY KEY);
+            CREATE TABLE post_media (
+                post_id character varying NOT NULL,
+                media character varying,
+                is_pic boolean,
+                is_secret boolean DEFAULT false);
+            INSERT INTO posts VALUES (1);
+            INSERT INTO post_media (post_id, media) VALUES ('1', 'before-migration');
+        """)
+        cursor.execute(MIGRATION.replace("public.", ""))
+    try:
+        yield connection
+    finally:
+        with connection.cursor() as cursor:
+            cursor.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        connection.close()
+
+
+def test_legacy_media_insert_remains_compatible_after_order_migration(database):
+    with database.cursor() as cursor:
+        cursor.execute('INSERT INTO post_media (post_id, media) VALUES (%s, %s)',
+                       ('1', 'legacy-after-rollback'))
+        cursor.execute('INSERT INTO post_media (post_id, media, "position") '
+                       'VALUES (%s, %s, %s)', ('1', 'ordered-writer', 2))
+        cursor.execute('SELECT media, "position" FROM post_media ORDER BY "position"')
+        assert cursor.fetchall() == [
+            ('before-migration', 0),
+            ('legacy-after-rollback', 1),
+            ('ordered-writer', 2),
+        ]
+        with pytest.raises(psycopg2.errors.UniqueViolation):
+            cursor.execute('INSERT INTO post_media (post_id, media, "position") '
+                           'VALUES (%s, %s, %s)', ('1', 'duplicate', 2))


### PR DESCRIPTION
## Summary
- add a non-null per-post media position with deterministic backfill and a unique `(post_id, position)` index
- serialize ordered create/edit/add writes per post and read both media API paths by explicit position
- apply the migration in PR-candidate and production deployment workflows
- advance the frontend submodule to letovo-dev/letovo-all-frontend#45, which preserves selection order across parallel upload completion and submits authoritative ordered edit payloads

## Validation
- issue #179 backend contract checks
- `npm run test:post-media-order`
- production `npm run build`
- CI-equivalent backend Docker build
- migration executed against disposable PostgreSQL 16, including deterministic backfill and unique-index assertions
- modified workflow YAML parsed locally

Closes #179