### PR TITLE
Fix department payouts for all role IDs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,6 +28,20 @@ jobs:
   backend-pr:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: letovo_issue193
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d letovo_issue193"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout code with submodules
         uses: actions/checkout@v4
@@ -65,6 +79,13 @@ jobs:
           g++ -std=c++20 -fsanitize=address,undefined -fno-omit-frame-pointer \
             test/avatar_policy_regression.cc -o "$RUNNER_TEMP/avatar-policy-regression"
           "$RUNNER_TEMP/avatar-policy-regression"
+
+      - name: Run department payout PostgreSQL regression
+        env:
+          LETOVO_POSTGRES_DSN: postgresql://postgres@127.0.0.1:5432/letovo_issue193
+        run: |
+          python3 -m pip install --disable-pip-version-check psycopg2-binary pytest
+          python3 -m pytest -q test/test_issue193_department_payout_postgres.py
 
       - name: Build registration backend image locally
         uses: docker/build-push-action@v5

--- a/src/market/transactions.cc
+++ b/src/market/transactions.cc
@@ -5,6 +5,107 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+namespace {
+
+const std::string kDepartmentPayoutRecipientsCte = R"SQL(
+               recipients AS MATERIALIZED (
+                   SELECT u.username
+                   FROM "user" u
+                   JOIN "roles" r ON r.roleid = u.role
+                   CROSS JOIN department_row d
+                   WHERE r.departmentid = d.departmentid
+                     AND u.active = true
+                     AND u.registered = true
+               ))SQL";
+
+const std::string kDepartmentPayoutPreviewPrefix = R"SQL(
+            WITH department_row AS (
+                SELECT d.departmentid, d.departmentname
+                FROM "department" d
+                WHERE d.departmentid = $1::integer
+            ),)SQL";
+
+const std::string kDepartmentPayoutPreviewSuffix = R"SQL(
+            SELECT d.departmentid,
+                   d.departmentname,
+                   COUNT(r.username)::integer AS recipient_count,
+                   (COUNT(r.username) * $2::bigint)::bigint AS total
+            FROM department_row d
+            LEFT JOIN recipients r ON true
+            GROUP BY d.departmentid, d.departmentname)SQL";
+
+const std::string kDepartmentPayoutApplyPrefix = R"SQL(
+            WITH request_lock AS (
+                SELECT pg_advisory_xact_lock(hashtext($4))
+            ),
+            department_row AS (
+                SELECT d.departmentid, d.departmentname
+                FROM "department" d
+                CROSS JOIN request_lock
+                WHERE d.departmentid = $1::integer
+            ),)SQL";
+
+const std::string kDepartmentPayoutApplySuffix = R"SQL(
+            , recipient_totals AS (
+                SELECT COUNT(*)::integer AS recipient_count FROM recipients
+            ),
+            balance_guard AS (
+                SELECT COALESCE(
+                    BOOL_AND(u.balance <= 2147483647 - $2::integer), false
+                ) AS safe
+                FROM "user" u JOIN recipients r ON r.username = u.username
+            ),
+            existing AS (
+                SELECT COUNT(*)::integer AS recipient_count,
+                       COALESCE(SUM(amount), 0)::bigint AS total
+                FROM "transactions"
+                WHERE reason LIKE ('%; request ' || $4)
+            ),
+            updated AS (
+                UPDATE "user" u
+                SET balance = u.balance + $2::integer
+                FROM recipients r, recipient_totals totals, existing prior,
+                     balance_guard guard
+                WHERE u.username = r.username
+                  AND prior.recipient_count = 0
+                  AND totals.recipient_count = $5::integer
+                  AND guard.safe
+                RETURNING u.username
+            ),
+            inserted AS (
+                INSERT INTO "transactions" (sender, receiver, amount, reason)
+                SELECT $3::character varying, updated.username, $2::integer,
+                       'department payout: ' || d.departmentname ||
+                       '; issued by ' || $3::character varying || '; request ' || $4
+                FROM updated CROSS JOIN department_row d
+                RETURNING transactionid
+            )
+            SELECT d.departmentid, d.departmentname,
+                   totals.recipient_count AS eligible_count,
+                   CASE WHEN prior.recipient_count > 0
+                        THEN prior.recipient_count
+                        ELSE totals.recipient_count END AS recipient_count,
+                   CASE WHEN prior.recipient_count > 0
+                        THEN prior.total
+                        ELSE totals.recipient_count::bigint * $2::bigint END AS total,
+                   (SELECT COUNT(*)::integer FROM inserted) AS inserted_count,
+                   (prior.recipient_count > 0) AS duplicate
+            FROM department_row d
+            CROSS JOIN recipient_totals totals
+            CROSS JOIN existing prior)SQL";
+
+std::string department_payout_preview_sql() {
+    return kDepartmentPayoutPreviewPrefix + kDepartmentPayoutRecipientsCte +
+        kDepartmentPayoutPreviewSuffix;
+}
+
+std::string department_payout_apply_sql() {
+    return kDepartmentPayoutApplyPrefix + kDepartmentPayoutRecipientsCte +
+        kDepartmentPayoutApplySuffix;
+}
+
+} // namespace
+
 namespace transactions {
 
     RegisteredTransaction::RegisteredTransaction() {
@@ -275,21 +376,7 @@ namespace transactions {
         std::vector<std::string> params = {
             std::to_string(department_id), std::to_string(amount)};
         pqxx::result rows = con->execute_params(
-            R"(SELECT d.departmentid,
-                      d.departmentname,
-                      COUNT(u.username)::integer AS recipient_count,
-                      (COUNT(u.username) * $2::bigint)::bigint AS total
-               FROM "department" d
-               LEFT JOIN "roles" r
-                 ON r.departmentid = d.departmentid
-                AND r.roleid BETWEEN 1 AND 28
-               LEFT JOIN "user" u
-                 ON u.role = r.roleid
-                AND u.active = true
-                AND u.registered = true
-               WHERE d.departmentid = $1::integer
-               GROUP BY d.departmentid, d.departmentname)",
-            params);
+            department_payout_preview_sql(), params);
         pool_ptr->returnConnection(std::move(con));
 
         if (rows.empty()) {
@@ -319,79 +406,7 @@ namespace transactions {
             std::to_string(department_id), std::to_string(amount), actor,
             request_id, std::to_string(expected_recipient_count)};
         pqxx::result rows = con->execute_params_or_throw(
-            R"(WITH request_lock AS (
-                   SELECT pg_advisory_xact_lock(hashtext($4))
-               ),
-               department_row AS (
-                   SELECT d.departmentid, d.departmentname
-                   FROM "department" d
-                   CROSS JOIN request_lock
-                   WHERE d.departmentid = $1::integer
-               ),
-               recipients AS MATERIALIZED (
-                   SELECT u.username
-                   FROM "user" u
-                   JOIN "roles" r ON r.roleid = u.role
-                   CROSS JOIN department_row d
-                   WHERE r.departmentid = d.departmentid
-                     AND r.roleid BETWEEN 1 AND 28
-                     AND u.active = true
-                     AND u.registered = true
-               ),
-               recipient_totals AS (
-                   SELECT COUNT(*)::integer AS recipient_count
-                   FROM recipients
-               ),
-               balance_guard AS (
-                   SELECT COALESCE(
-                       BOOL_AND(u.balance <= 2147483647 - $2::integer), false
-                   ) AS safe
-                   FROM "user" u
-                   JOIN recipients r ON r.username = u.username
-               ),
-               existing AS (
-                   SELECT COUNT(*)::integer AS recipient_count,
-                          COALESCE(SUM(amount), 0)::bigint AS total
-                   FROM "transactions"
-                   WHERE reason LIKE ('%; request ' || $4)
-               ),
-               updated AS (
-                   UPDATE "user" u
-                   SET balance = u.balance + $2::integer
-                   FROM recipients r, recipient_totals totals, existing prior,
-                        balance_guard guard
-                   WHERE u.username = r.username
-                     AND prior.recipient_count = 0
-                     AND totals.recipient_count = $5::integer
-                     AND guard.safe
-                   RETURNING u.username
-               ),
-               inserted AS (
-                   INSERT INTO "transactions" (sender, receiver, amount, reason)
-                   SELECT $3::character varying,
-                          updated.username,
-                          $2::integer,
-                          'department payout: ' || d.departmentname ||
-                          '; issued by ' || $3::character varying || '; request ' || $4
-                   FROM updated
-                   CROSS JOIN department_row d
-                   RETURNING transactionid
-               )
-               SELECT d.departmentid,
-                      d.departmentname,
-                      totals.recipient_count AS eligible_count,
-                      CASE WHEN prior.recipient_count > 0
-                           THEN prior.recipient_count
-                           ELSE totals.recipient_count END AS recipient_count,
-                      CASE WHEN prior.recipient_count > 0
-                           THEN prior.total
-                           ELSE totals.recipient_count::bigint * $2::bigint END AS total,
-                      (SELECT COUNT(*)::integer FROM inserted) AS inserted_count,
-                      (prior.recipient_count > 0) AS duplicate
-               FROM department_row d
-               CROSS JOIN recipient_totals totals
-               CROSS JOIN existing prior)",
-            params, true);
+            department_payout_apply_sql(), params, true);
 
         if (rows.empty()) {
             std::vector<std::string> department_params = {

--- a/test/test_issue155_department_payout_contract.py
+++ b/test/test_issue155_department_payout_contract.py
@@ -17,8 +17,11 @@ def test_admin_only_endpoint_is_registered():
     assert "transactions::server::department_payout(router" in SERVER
 
 
-def test_recipient_policy_is_server_side_and_bounded_to_child_roles():
-    assert "r.roleid BETWEEN 1 AND 28" in TRANSACTIONS
+def test_recipient_policy_is_server_side_and_role_id_independent():
+    assert "r.roleid BETWEEN" not in TRANSACTIONS
+    assert "kDepartmentPayoutRecipientsCte" in TRANSACTIONS
+    assert "department_payout_preview_sql()" in TRANSACTIONS
+    assert "department_payout_apply_sql()" in TRANSACTIONS
     assert "u.active = true" in TRANSACTIONS
     assert "u.registered = true" in TRANSACTIONS
     assert "recipient" not in HEADER.split("struct DepartmentPayoutResult", 1)[0]

--- a/test/test_issue193_department_payout_postgres.py
+++ b/test/test_issue193_department_payout_postgres.py
@@ -1,0 +1,126 @@
+import os
+import re
+from pathlib import Path
+
+import psycopg2
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TRANSACTIONS = (ROOT / "src/market/transactions.cc").read_text()
+DSN = os.environ.get("LETOVO_POSTGRES_DSN")
+
+
+def _sql_constant(name):
+    match = re.search(
+        rf'const std::string {name} = R"SQL\((.*?)\)SQL";',
+        TRANSACTIONS,
+        re.DOTALL,
+    )
+    assert match, f"{name} must remain extractable for the PostgreSQL regression"
+    return match.group(1)
+
+
+RECIPIENTS_CTE = _sql_constant("kDepartmentPayoutRecipientsCte")
+PREVIEW_SQL = (_sql_constant("kDepartmentPayoutPreviewPrefix") + RECIPIENTS_CTE
+               + _sql_constant("kDepartmentPayoutPreviewSuffix"))
+APPLY_SQL = (_sql_constant("kDepartmentPayoutApplyPrefix") + RECIPIENTS_CTE
+             + _sql_constant("kDepartmentPayoutApplySuffix"))
+
+
+@pytest.fixture
+def database():
+    if not DSN:
+        pytest.skip("LETOVO_POSTGRES_DSN is required for PostgreSQL-backed tests")
+    connection = psycopg2.connect(DSN)
+    connection.autocommit = True
+    schema = "issue193_department_payout"
+    with connection.cursor() as cursor:
+        cursor.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        cursor.execute(f'CREATE SCHEMA "{schema}"')
+        cursor.execute(f'SET search_path TO "{schema}"')
+        cursor.execute("""
+            CREATE TABLE "department" (
+                departmentid integer PRIMARY KEY, departmentname text NOT NULL);
+            CREATE TABLE "roles" (
+                roleid integer PRIMARY KEY, departmentid integer NOT NULL);
+            CREATE TABLE "user" (
+                username character varying PRIMARY KEY, role integer NOT NULL,
+                active boolean NOT NULL, registered boolean NOT NULL,
+                balance integer NOT NULL);
+            CREATE TABLE "transactions" (
+                transactionid integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                sender character varying NOT NULL, receiver character varying NOT NULL,
+                amount integer NOT NULL, reason character varying NOT NULL);
+            INSERT INTO "department" VALUES (10, 'Дизайн'), (11, 'Новый департамент');
+            INSERT INTO "roles" VALUES (7, 10), (47, 10), (147, 11);
+            INSERT INTO "user" VALUES
+                ('eligible-low-role', 7, true, true, 100),
+                ('eligible-high-role', 47, true, true, 200),
+                ('inactive-high-role', 47, false, true, 300),
+                ('unregistered-high-role', 47, true, false, 400),
+                ('eligible-higher-role', 147, true, true, 500);
+        """)
+        cursor.execute(f"PREPARE issue193_preview(integer, integer) AS {PREVIEW_SQL}")
+        cursor.execute("PREPARE issue193_apply(integer, integer, character varying, "
+                       f"character varying, integer) AS {APPLY_SQL}")
+    try:
+        yield connection
+    finally:
+        with connection.cursor() as cursor:
+            cursor.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        connection.close()
+
+
+def test_high_role_ids_preview_apply_and_idempotency(database):
+    with database.cursor() as cursor:
+        cursor.execute("EXECUTE issue193_preview(10, 50)")
+        assert cursor.fetchone() == (10, "Дизайн", 2, 100)
+
+        cursor.execute("EXECUTE issue193_apply(10, 50, 'admin', "
+                       "'issue193-request-0001', 2)")
+        assert cursor.fetchone() == (10, "Дизайн", 2, 2, 100, 2, False)
+
+        cursor.execute('SELECT username, balance FROM "user" WHERE role IN (7, 47) '
+                       'ORDER BY username')
+        assert cursor.fetchall() == [
+            ("eligible-high-role", 250),
+            ("eligible-low-role", 150),
+            ("inactive-high-role", 300),
+            ("unregistered-high-role", 400),
+        ]
+        cursor.execute('SELECT receiver, amount FROM "transactions" ORDER BY receiver')
+        audit_rows = cursor.fetchall()
+        assert audit_rows == [("eligible-high-role", 50), ("eligible-low-role", 50)]
+
+        cursor.execute("EXECUTE issue193_apply(10, 50, 'admin', "
+                       "'issue193-request-0001', 2)")
+        assert cursor.fetchone() == (10, "Дизайн", 2, 2, 100, 0, True)
+        cursor.execute('SELECT COUNT(*) FROM "transactions"')
+        assert cursor.fetchone() == (2,)
+        cursor.execute('SELECT username, balance FROM "user" WHERE role IN (7, 47) '
+                       'ORDER BY username')
+        assert cursor.fetchall() == [
+            ("eligible-high-role", 250),
+            ("eligible-low-role", 150),
+            ("inactive-high-role", 300),
+            ("unregistered-high-role", 400),
+        ]
+
+        cursor.execute("WITH department_row AS (SELECT departmentid, departmentname "
+                       'FROM "department" WHERE departmentid = 10),'
+                       + RECIPIENTS_CTE
+                       + " SELECT username FROM recipients ORDER BY username")
+        assert [row[0] for row in cursor.fetchall()] == [row[0] for row in audit_rows]
+
+
+def test_eligibility_does_not_depend_on_numeric_role_id(database):
+    with database.cursor() as cursor:
+        cursor.execute("EXECUTE issue193_preview(11, 25)")
+        assert cursor.fetchone() == (11, "Новый департамент", 1, 25)
+        cursor.execute("EXECUTE issue193_apply(11, 25, 'admin', "
+                       "'issue193-request-0002', 1)")
+        assert cursor.fetchone() == (11, "Новый департамент", 1, 1, 25, 1, False)
+        cursor.execute('SELECT balance FROM "user" WHERE username = %s',
+                       ("eligible-higher-role",))
+        assert cursor.fetchone() == (525,)


### PR DESCRIPTION
Fixes #193

## Summary
- remove numeric role ID eligibility from department payouts
- reuse one recipient CTE in preview and apply
- add PostgreSQL 16 regression coverage for high role IDs, recipient parity, exclusions, audit rows, and idempotency

## Validation
- `12 passed` for focused contract and PostgreSQL tests
- full backend Docker image builds successfully