### PR TITLE
Add lightbox for news and article images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -345,6 +345,10 @@ jobs:
         working-directory: frontend
         run: npm run test:post-media-order
 
+      - name: Verify image lightbox interactions
+        working-directory: frontend
+        run: npm run test:image-lightbox
+
       - name: Build frontend
         working-directory: frontend
         env:


### PR DESCRIPTION
Closes #201\n\nUpdates the frontend submodule to add accessible lightbox viewing and original-file download for news and Markdown article images.