### PR TITLE
fix: derive career chapters from camp shifts

### DIFF
--- a/src/letovo-soc-net/achivements.cc
+++ b/src/letovo-soc-net/achivements.cc
@@ -190,12 +190,11 @@ namespace achivements {
                               AND COALESCE(EXTRACT(YEAR FROM upo.datetime)::int, 0) = grp.year_val
                               AND COALESCE(
                                   (
-                                      SELECT c.chapter
-                                      FROM "calendar" c
+                                      SELECT cd.name
+                                      FROM "camp_dates" cd
                                       WHERE upo.datetime IS NOT NULL
-                                        AND upo.datetime >= c.start
-                                        AND upo.datetime <= c."end"
-                                      ORDER BY c.start
+                                        AND upo.datetime::date BETWEEN cd.start_date AND cd.end_date
+                                      ORDER BY cd.start_date
                                       LIMIT 1
                                   ),
                                   ''::text
@@ -213,12 +212,11 @@ namespace achivements {
                               AND COALESCE(EXTRACT(YEAR FROM ubr.datetime)::int, 0) = grp.year_val
                               AND COALESCE(
                                   (
-                                      SELECT c.chapter
-                                      FROM "calendar" c
+                                      SELECT cd.name
+                                      FROM "camp_dates" cd
                                       WHERE ubr.datetime IS NOT NULL
-                                        AND ubr.datetime >= c.start
-                                        AND ubr.datetime <= c."end"
-                                      ORDER BY c.start
+                                        AND ubr.datetime::date BETWEEN cd.start_date AND cd.end_date
+                                      ORDER BY cd.start_date
                                       LIMIT 1
                                   ),
                                   ''::text
@@ -257,12 +255,11 @@ namespace achivements {
                     INNER JOIN "achivements" ach ON ua.achivement_id = ach.achivement_id
                     INNER JOIN "department" d ON d.departmentid = ach.departmentid
                     LEFT JOIN LATERAL (
-                        SELECT c.chapter
-                        FROM "calendar" c
+                        SELECT cd.name AS chapter
+                        FROM "camp_dates" cd
                         WHERE ua.datetime IS NOT NULL
-                          AND ua.datetime >= c.start
-                          AND ua.datetime <= c."end"
-                        ORDER BY c.start
+                          AND ua.datetime::date BETWEEN cd.start_date AND cd.end_date
+                        ORDER BY cd.start_date
                         LIMIT 1
                     ) cal ON true
                     LEFT JOIN LATERAL (
@@ -302,10 +299,10 @@ namespace achivements {
         auto con = std::move(pool_ptr->getConnection());
 
         pqxx::result result = con->execute(
-            R"(SELECT chapter, start, "end", (CURRENT_DATE - start::date) + 1 AS day_of_segment
-               FROM "calendar"
-               WHERE NOW() >= start AND NOW() <= "end"
-               ORDER BY start
+            R"(SELECT name AS chapter, start_date AS start, end_date AS "end", (CURRENT_DATE - start_date) + 1 AS day_of_segment
+               FROM "camp_dates"
+               WHERE CURRENT_DATE BETWEEN start_date AND end_date
+               ORDER BY start_date
                LIMIT 1;)");
 
         pool_ptr->returnConnection(std::move(con));

--- a/test/test_camp_dates_shift_day.py
+++ b/test/test_camp_dates_shift_day.py
@@ -28,3 +28,26 @@ def test_backend_serializes_shift_day_from_camp_dates():
     assert 'FROM "camp_dates"' in source
     assert '"shift_day"' in source
     assert "(dt_day - shift_day) / 86400" in source
+
+
+def test_career_chapters_use_camp_dates_consistently():
+    source = read("src/letovo-soc-net/achivements.cc")
+    start = source.index("std::string user_achivements_by_department_json")
+    end = source.index("std::string current_segment_day", start)
+    query = source[start:end]
+
+    assert chr(34) + "calendar" + chr(34) not in query
+    assert query.count("FROM " + chr(34) + "camp_dates" + chr(34)) == 3
+    assert query.count("::date BETWEEN cd.start_date AND cd.end_date") == 3
+    assert "SELECT cd.name AS chapter" in query
+
+
+def test_calendar_day_uses_the_same_shift_source():
+    source = read("src/letovo-soc-net/achivements.cc")
+    start = source.index("std::string current_segment_day")
+    end = source.index("} // namespace achivements", start)
+    query = source[start:end]
+
+    assert "FROM " + chr(34) + "camp_dates" + chr(34) in query
+    assert "CURRENT_DATE BETWEEN start_date AND end_date" in query
+    assert "name AS chapter" in query


### PR DESCRIPTION
## Summary
- derive achievement, post, and brigade chapters from the single non-overlapping `camp_dates` source
- use inclusive date boundaries so all timestamps on a shift's final date stay in that shift
- make `/calendar/day` use the same source
- retain an empty chapter for dates outside configured shifts, including historical records until authoritative periods are loaded

## Verification
- `python -m pytest -q test/test_camp_dates_shift_day.py` (4 passed)
- `python -m py_compile test/test_camp_dates_shift_day.py`
- `cmake --build src --target server_starter -j2` could not run because this checkout has no configured CMake cache

Fixes #198