### PR TITLE
fix: normalize compatible MOV uploads to MP4

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -87,6 +87,11 @@ jobs:
           python3 -m pip install --disable-pip-version-check psycopg2-binary pytest
           python3 -m pytest -q test/test_issue193_department_payout_postgres.py test/test_issue179_media_order_postgres.py
 
+      - name: Run uploader unit tests
+        run: |
+          python3 -m pip install --disable-pip-version-check -r src/python-helpers/requirements.txt pytest
+          python3 -m pytest -q test/test_flask_uploader.py
+
       - name: Build registration backend image locally
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Run uploader unit tests
         run: |
           python3 -m pip install --disable-pip-version-check -r src/python-helpers/requirements.txt pytest
-          python3 -m pytest -q test/test_flask_uploader.py
+          python3 -m pytest -q test/test_flask_uploader.py test/test_migrate_mov_media.py
 
       - name: Build registration backend image locally
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -119,6 +119,11 @@ jobs:
       - name: Inspect uploader image
         run: docker image inspect letovo-flask-uploader:${{ github.sha }} >/dev/null
 
+      - name: Verify uploader video tools
+        run: |
+          docker run --rm letovo-flask-uploader:${{ github.sha }} ffmpeg -version
+          docker run --rm letovo-flask-uploader:${{ github.sha }} ffprobe -version
+
   publish-pr-candidate:
     if: github.event_name == 'pull_request'
     needs: [backend-pr, frontend-verify]

--- a/scripts/migrate_mov_media.py
+++ b/scripts/migrate_mov_media.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Safely remux legacy /docs/*.mov post media to /videos/uploaded/*.mp4.
+
+Run inside the uploader image/host with ffmpeg, ffprobe and psycopg installed:
+  migrate_mov_media.py --dsn "$DATABASE_URL" --media-root /srv/letovo/media --dry-run
+  migrate_mov_media.py --dsn "$DATABASE_URL" --media-root /srv/letovo/media --apply
+"""
+import argparse, hashlib, json, os, shutil, subprocess, sys
+from pathlib import Path
+
+
+def run(command):
+    return subprocess.run(command, capture_output=True, text=True, check=False, shell=False)
+
+
+def probe(path):
+    result = run(["ffprobe", "-v", "error", "-print_format", "json", "-show_format", "-show_streams", str(path)])
+    if result.returncode: raise ValueError("ffprobe failed")
+    data = json.loads(result.stdout)
+    streams = data.get("streams", [])
+    video = [s for s in streams if s.get("codec_type") == "video"]
+    audio = [s for s in streams if s.get("codec_type") == "audio"]
+    if len(video) != 1 or video[0].get("codec_name") != "h264" or video[0].get("pix_fmt") not in {"yuv420p", "yuvj420p"}:
+        raise ValueError("video must be H.264 8-bit 4:2:0")
+    if len(audio) > 1 or (audio and (audio[0].get("codec_name") != "aac" or audio[0].get("profile") != "LC")):
+        raise ValueError("audio must be AAC LC")
+    if float(data.get("format", {}).get("duration", 0)) <= 0: raise ValueError("invalid duration")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dsn", required=True)
+    parser.add_argument("--media-root", required=True, type=Path)
+    parser.add_argument("--backup-dir", type=Path, default=Path("mov-migration-backup"))
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true")
+    mode.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+    try:
+        import psycopg
+    except ImportError:
+        sys.exit("psycopg is required; run this from an environment with psycopg installed")
+    args.backup_dir.mkdir(parents=True, exist_ok=True)
+    report = []
+    with psycopg.connect(args.dsn) as db:
+        rows = db.execute("SELECT post_id, media FROM post_media WHERE media LIKE '/docs/%.mov' ORDER BY post_id, media").fetchall()
+        for post_id, media in rows:
+            source = args.media_root / media.lstrip("/")
+            stable_id = hashlib.sha256(media.encode()).hexdigest()
+            target_rel = f"/videos/uploaded/{stable_id}.mp4"
+            target = args.media_root / target_rel.lstrip("/")
+            entry = {"post_id": post_id, "source": media, "target": target_rel}
+            try:
+                if not source.is_file(): raise ValueError("source file is missing")
+                probe(source)
+                entry["status"] = "would-remux" if args.dry_run else "remuxed"
+                if args.apply:
+                    backup = args.backup_dir / source.name
+                    if not backup.exists(): shutil.copy2(source, backup)
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    part = target.with_suffix(".mp4.part")
+                    result = run(["ffmpeg", "-nostdin", "-hide_banner", "-loglevel", "error", "-y", "-i", str(source), "-map", "0:v:0", "-map", "0:a:0?", "-map_metadata", "0", "-c", "copy", "-movflags", "+faststart", "-f", "mp4", str(part)])
+                    if result.returncode or not part.is_file() or not part.stat().st_size: raise ValueError("remux failed")
+                    probe(part); os.replace(part, target)
+                    db.execute("UPDATE post_media SET media = %s WHERE post_id = %s AND media = %s", (target_rel, post_id, media))
+            except (OSError, ValueError, json.JSONDecodeError) as error:
+                entry.update(status="skipped", error=str(error))
+            report.append(entry)
+        if args.dry_run: db.rollback()
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+
+if __name__ == "__main__": main()

--- a/scripts/migrate_mov_media.py
+++ b/scripts/migrate_mov_media.py
@@ -5,7 +5,7 @@ First run --dry-run; then use an explicit durable backup location:
   migrate_mov_media.py --dsn "$DATABASE_URL" --media-root /srv/letovo/media --dry-run
   migrate_mov_media.py --dsn "$DATABASE_URL" --media-root /srv/letovo/media --backup-dir /srv/letovo/mov-backup --apply
 """
-import argparse, hashlib, json, os, shutil, subprocess, sys
+import argparse, hashlib, json, os, shutil, subprocess, sys, uuid
 from pathlib import Path
 
 
@@ -28,6 +28,13 @@ def probe(path, require_mp4=False):
         raise ValueError("remux result is not MP4")
 
 
+def create_backup_run(backup_root):
+    """Create an immutable per-run backup directory under an operator-owned root."""
+    run_dir = backup_root / ("run-" + uuid.uuid4().hex)
+    run_dir.mkdir(parents=True, exist_ok=False)
+    return run_dir
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--dsn", required=True); parser.add_argument("--media-root", required=True, type=Path)
@@ -42,9 +49,10 @@ def main():
             with db.cursor() as cursor:
                 cursor.execute("SELECT post_id, media FROM post_media WHERE media LIKE '/docs/%.mov' ORDER BY post_id, media FOR UPDATE")
                 rows = cursor.fetchall()
+                backup_run = None
                 if args.apply:
-                    args.backup_dir.mkdir(parents=True, exist_ok=True)
-                    (args.backup_dir / "post_media_rows.json").write_text(json.dumps([{"post_id": row[0], "media": row[1]} for row in rows], ensure_ascii=False, indent=2))
+                    backup_run = create_backup_run(args.backup_dir)
+                    (backup_run / "post_media_rows.json").write_text(json.dumps([{"post_id": row[0], "media": row[1]} for row in rows], ensure_ascii=False, indent=2))
                 for post_id, media in rows:
                     source = args.media_root / media.lstrip("/")
                     target_rel = "/videos/uploaded/" + hashlib.sha256(media.encode()).hexdigest() + ".mp4"
@@ -54,7 +62,7 @@ def main():
                         if not source.is_file(): raise ValueError("source file is missing")
                         probe(source)
                         if args.dry_run: entry["status"] = "would-remux"; report.append(entry); continue
-                        backup = args.backup_dir / "files" / source.relative_to(args.media_root)
+                        backup = backup_run / "files" / source.relative_to(args.media_root)
                         backup.parent.mkdir(parents=True, exist_ok=True)
                         if not backup.exists(): shutil.copy2(source, backup)
                         target.parent.mkdir(parents=True, exist_ok=True)
@@ -63,7 +71,7 @@ def main():
                         probe(part, require_mp4=True); os.replace(part, target); created.append(target)
                         cursor.execute("UPDATE post_media SET media = %s WHERE post_id = %s AND media = %s", (target_rel, post_id, media))
                         if cursor.rowcount != 1: raise ValueError("post_media row changed during migration")
-                        entry["status"] = "remuxed"
+                        entry["status"] = "remuxed"; entry["backup_run"] = str(backup_run)
                     except (OSError, ValueError, json.JSONDecodeError) as error:
                         entry.update(status="failed", error=str(error)); raise RuntimeError(json.dumps(entry, ensure_ascii=False))
                     finally:

--- a/scripts/migrate_mov_media.py
+++ b/scripts/migrate_mov_media.py
@@ -35,6 +35,33 @@ def create_backup_run(backup_root):
     return run_dir
 
 
+def _contained(path, root):
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def safe_source(media_root, media):
+    media_root = media_root.resolve()
+    docs_root = (media_root / "docs").resolve()
+    if not isinstance(media, str) or not media.startswith("/docs/"):
+        raise ValueError("media path is outside /docs")
+    source = (media_root / media.lstrip("/")).resolve()
+    if not _contained(source, docs_root):
+        raise ValueError("media path escapes media/docs")
+    return source, media_root
+
+
+def safe_backup_path(backup_run, media_root, source):
+    backup_run = backup_run.resolve()
+    target = (backup_run / "files" / source.relative_to(media_root)).resolve()
+    if not _contained(target, backup_run):
+        raise ValueError("backup path escapes backup run")
+    return target
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--dsn", required=True); parser.add_argument("--media-root", required=True, type=Path)
@@ -54,7 +81,7 @@ def main():
                     backup_run = create_backup_run(args.backup_dir)
                     (backup_run / "post_media_rows.json").write_text(json.dumps([{"post_id": row[0], "media": row[1]} for row in rows], ensure_ascii=False, indent=2))
                 for post_id, media in rows:
-                    source = args.media_root / media.lstrip("/")
+                    source, resolved_media_root = safe_source(args.media_root, media)
                     target_rel = "/videos/uploaded/" + hashlib.sha256(media.encode()).hexdigest() + ".mp4"
                     target = args.media_root / target_rel.lstrip("/"); part = target.with_suffix(".mp4.part")
                     entry = {"post_id": post_id, "source": media, "target": target_rel}
@@ -62,7 +89,7 @@ def main():
                         if not source.is_file(): raise ValueError("source file is missing")
                         probe(source)
                         if args.dry_run: entry["status"] = "would-remux"; report.append(entry); continue
-                        backup = backup_run / "files" / source.relative_to(args.media_root)
+                        backup = safe_backup_path(backup_run, resolved_media_root, source)
                         backup.parent.mkdir(parents=True, exist_ok=True)
                         if not backup.exists(): shutil.copy2(source, backup)
                         target.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/migrate_mov_media.py
+++ b/scripts/migrate_mov_media.py
@@ -1,23 +1,22 @@
 #!/usr/bin/env python3
-"""Safely remux legacy /docs/*.mov post media to /videos/uploaded/*.mp4.
+"""Migrate compatible legacy /docs/*.mov post media without transcoding.
 
-Run inside the uploader image/host with ffmpeg, ffprobe and psycopg installed:
+First run --dry-run; then use an explicit durable backup location:
   migrate_mov_media.py --dsn "$DATABASE_URL" --media-root /srv/letovo/media --dry-run
-  migrate_mov_media.py --dsn "$DATABASE_URL" --media-root /srv/letovo/media --apply
+  migrate_mov_media.py --dsn "$DATABASE_URL" --media-root /srv/letovo/media --backup-dir /srv/letovo/mov-backup --apply
 """
 import argparse, hashlib, json, os, shutil, subprocess, sys
 from pathlib import Path
 
 
-def run(command):
-    return subprocess.run(command, capture_output=True, text=True, check=False, shell=False)
+def command(args):
+    return subprocess.run(args, capture_output=True, text=True, check=False, shell=False)
 
 
-def probe(path):
-    result = run(["ffprobe", "-v", "error", "-print_format", "json", "-show_format", "-show_streams", str(path)])
+def probe(path, require_mp4=False):
+    result = command(["ffprobe", "-v", "error", "-print_format", "json", "-show_format", "-show_streams", str(path)])
     if result.returncode: raise ValueError("ffprobe failed")
-    data = json.loads(result.stdout)
-    streams = data.get("streams", [])
+    data = json.loads(result.stdout); streams = data.get("streams", [])
     video = [s for s in streams if s.get("codec_type") == "video"]
     audio = [s for s in streams if s.get("codec_type") == "audio"]
     if len(video) != 1 or video[0].get("codec_name") != "h264" or video[0].get("pix_fmt") not in {"yuv420p", "yuvj420p"}:
@@ -25,48 +24,55 @@ def probe(path):
     if len(audio) > 1 or (audio and (audio[0].get("codec_name") != "aac" or audio[0].get("profile") != "LC")):
         raise ValueError("audio must be AAC LC")
     if float(data.get("format", {}).get("duration", 0)) <= 0: raise ValueError("invalid duration")
+    if require_mp4 and data.get("format", {}).get("tags", {}).get("major_brand") not in {"isom", "iso2", "mp41", "mp42", "avc1"}:
+        raise ValueError("remux result is not MP4")
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--dsn", required=True)
-    parser.add_argument("--media-root", required=True, type=Path)
-    parser.add_argument("--backup-dir", type=Path, default=Path("mov-migration-backup"))
-    mode = parser.add_mutually_exclusive_group(required=True)
-    mode.add_argument("--dry-run", action="store_true")
-    mode.add_argument("--apply", action="store_true")
+    parser.add_argument("--dsn", required=True); parser.add_argument("--media-root", required=True, type=Path)
+    parser.add_argument("--backup-dir", type=Path)
+    mode = parser.add_mutually_exclusive_group(required=True); mode.add_argument("--dry-run", action="store_true"); mode.add_argument("--apply", action="store_true")
     args = parser.parse_args()
+    if args.apply and args.backup_dir is None: parser.error("--apply requires an explicit durable --backup-dir")
+    import psycopg2
+    report, created = [], []
     try:
-        import psycopg
-    except ImportError:
-        sys.exit("psycopg is required; run this from an environment with psycopg installed")
-    args.backup_dir.mkdir(parents=True, exist_ok=True)
-    report = []
-    with psycopg.connect(args.dsn) as db:
-        rows = db.execute("SELECT post_id, media FROM post_media WHERE media LIKE '/docs/%.mov' ORDER BY post_id, media").fetchall()
-        for post_id, media in rows:
-            source = args.media_root / media.lstrip("/")
-            stable_id = hashlib.sha256(media.encode()).hexdigest()
-            target_rel = f"/videos/uploaded/{stable_id}.mp4"
-            target = args.media_root / target_rel.lstrip("/")
-            entry = {"post_id": post_id, "source": media, "target": target_rel}
-            try:
-                if not source.is_file(): raise ValueError("source file is missing")
-                probe(source)
-                entry["status"] = "would-remux" if args.dry_run else "remuxed"
+        with psycopg2.connect(args.dsn) as db:
+            with db.cursor() as cursor:
+                cursor.execute("SELECT post_id, media FROM post_media WHERE media LIKE '/docs/%.mov' ORDER BY post_id, media FOR UPDATE")
+                rows = cursor.fetchall()
                 if args.apply:
-                    backup = args.backup_dir / source.name
-                    if not backup.exists(): shutil.copy2(source, backup)
-                    target.parent.mkdir(parents=True, exist_ok=True)
-                    part = target.with_suffix(".mp4.part")
-                    result = run(["ffmpeg", "-nostdin", "-hide_banner", "-loglevel", "error", "-y", "-i", str(source), "-map", "0:v:0", "-map", "0:a:0?", "-map_metadata", "0", "-c", "copy", "-movflags", "+faststart", "-f", "mp4", str(part)])
-                    if result.returncode or not part.is_file() or not part.stat().st_size: raise ValueError("remux failed")
-                    probe(part); os.replace(part, target)
-                    db.execute("UPDATE post_media SET media = %s WHERE post_id = %s AND media = %s", (target_rel, post_id, media))
-            except (OSError, ValueError, json.JSONDecodeError) as error:
-                entry.update(status="skipped", error=str(error))
-            report.append(entry)
-        if args.dry_run: db.rollback()
-    print(json.dumps(report, ensure_ascii=False, indent=2))
+                    args.backup_dir.mkdir(parents=True, exist_ok=True)
+                    (args.backup_dir / "post_media_rows.json").write_text(json.dumps([{"post_id": row[0], "media": row[1]} for row in rows], ensure_ascii=False, indent=2))
+                for post_id, media in rows:
+                    source = args.media_root / media.lstrip("/")
+                    target_rel = "/videos/uploaded/" + hashlib.sha256(media.encode()).hexdigest() + ".mp4"
+                    target = args.media_root / target_rel.lstrip("/"); part = target.with_suffix(".mp4.part")
+                    entry = {"post_id": post_id, "source": media, "target": target_rel}
+                    try:
+                        if not source.is_file(): raise ValueError("source file is missing")
+                        probe(source)
+                        if args.dry_run: entry["status"] = "would-remux"; report.append(entry); continue
+                        backup = args.backup_dir / "files" / source.relative_to(args.media_root)
+                        backup.parent.mkdir(parents=True, exist_ok=True)
+                        if not backup.exists(): shutil.copy2(source, backup)
+                        target.parent.mkdir(parents=True, exist_ok=True)
+                        result = command(["ffmpeg", "-nostdin", "-hide_banner", "-loglevel", "error", "-y", "-i", str(source), "-map", "0:v:0", "-map", "0:a:0?", "-map_metadata", "0", "-c", "copy", "-movflags", "+faststart", "-f", "mp4", str(part)])
+                        if result.returncode or not part.is_file() or not part.stat().st_size: raise ValueError("remux failed")
+                        probe(part, require_mp4=True); os.replace(part, target); created.append(target)
+                        cursor.execute("UPDATE post_media SET media = %s WHERE post_id = %s AND media = %s", (target_rel, post_id, media))
+                        if cursor.rowcount != 1: raise ValueError("post_media row changed during migration")
+                        entry["status"] = "remuxed"
+                    except (OSError, ValueError, json.JSONDecodeError) as error:
+                        entry.update(status="failed", error=str(error)); raise RuntimeError(json.dumps(entry, ensure_ascii=False))
+                    finally:
+                        part.unlink(missing_ok=True)
+                    report.append(entry)
+            if args.dry_run: db.rollback()
+    except Exception as error:
+        for target in created: target.unlink(missing_ok=True)
+        print(json.dumps(report + [{"status": "failed", "error": str(error)}], ensure_ascii=False, indent=2)); return 1
+    print(json.dumps(report, ensure_ascii=False, indent=2)); return 0
 
-if __name__ == "__main__": main()
+if __name__ == "__main__": sys.exit(main())

--- a/src/basic/media.cc
+++ b/src/basic/media.cc
@@ -185,6 +185,7 @@ std::unordered_map<std::string, std::string> content_types = {
     {".mp4", "video/mp4"},
     {".mkv", "video/x-matroska"},
     {".webm", "video/webm"},
+    {".ogg", "video/ogg"},
     {".mp3", "audio/mpeg"},
     {".mp4", "video/mp4"},
     {".mkv", "video/x-matroska"},
@@ -192,7 +193,7 @@ std::unordered_map<std::string, std::string> content_types = {
 };
 
 std::unordered_set<std::string> allowed_no_token = {
-    ".png", ".jpg", ".jpeg", ".gif", ".mp4", ".mp3", ".mkv", ".webm", ".svg",
+    ".png", ".jpg", ".jpeg", ".gif", ".mp4", ".mp3", ".mkv", ".webm", ".ogg", ".svg",
 };
 
 std::string save_file(std::string path, std::string file_name,

--- a/src/python-helpers/UploaderConfig.json
+++ b/src/python-helpers/UploaderConfig.json
@@ -4,6 +4,16 @@
     "ava_path": "images/admin_avatars",
     "personal_ava_path": "images/personal_avatars",
     "max_avatar_size": 5242880,
+    "video": {
+        "mov_input_enabled": true,
+        "max_bytes": 524288000,
+        "max_duration_seconds": 900,
+        "max_width": 3840,
+        "max_height": 2160,
+        "max_concurrent_jobs": 2,
+        "probe_timeout_seconds": 30,
+        "remux_timeout_seconds": 300
+    },
     "paths": {
         "images": "images/uploaded",
         "videos": "videos/uploaded",

--- a/src/python-helpers/dockerfile.uploader
+++ b/src/python-helpers/dockerfile.uploader
@@ -6,7 +6,10 @@ ENV UPLOADER_CAPABILITIES_URL=${UPLOADER_CAPABILITIES_URL}
 WORKDIR /app
 
 COPY . .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 8880
 

--- a/src/python-helpers/flask_uploader.py
+++ b/src/python-helpers/flask_uploader.py
@@ -1,4 +1,5 @@
 import flask
+from werkzeug.exceptions import RequestEntityTooLarge
 import json, os
 import logging
 import subprocess
@@ -34,7 +35,8 @@ VIDEO_PROBE_TIMEOUT = _video_setting("probe_timeout_seconds", 30)
 VIDEO_REMUX_TIMEOUT = _video_setting("remux_timeout_seconds", 300)
 VIDEO_MOV_ENABLED = _video_setting("mov_input_enabled", True)
 VIDEO_JOBS = threading.BoundedSemaphore(_video_setting("max_concurrent_jobs", 2))
-app.config['MAX_CONTENT_LENGTH'] = max(100 * 1024 * 1024 * 10, VIDEO_MAX_BYTES + 1024 * 1024)
+# Allow only the small multipart envelope beyond the configured media limit.
+app.config['MAX_CONTENT_LENGTH'] = VIDEO_MAX_BYTES + 1024 * 1024
 
 
 def _video_error(status, code, message):
@@ -57,6 +59,8 @@ def _validate_video_probe(probe, require_mp4=False):
     formats = set(str(probe.get("format", {}).get("format_name", "")).split(","))
     if not ({"mov", "mp4"} & formats):
         return 415, "unsupported_video_container", "Видео должно быть в контейнере MOV/MP4."
+    if require_mp4 and probe.get("format", {}).get("tags", {}).get("major_brand") not in {"isom", "iso2", "mp41", "mp42", "avc1"}:
+        return 415, "invalid_remuxed_video", "Обработанное видео не является MP4."
     streams = probe.get("streams")
     if not isinstance(streams, list):
         return 415, "invalid_video", "Видео не удалось распознать."
@@ -172,23 +176,29 @@ def _detect_image_extension(data: bytes):
         return "webp"
     return None
 
+@app.errorhandler(RequestEntityTooLarge)
+def request_too_large(_error):
+    return _video_error(413, "upload_too_large", "Размер файла превышает допустимый лимит.")
+
+
 @app.route('/', methods=['POST'])
 def upload_file():
+    # Do not trigger Werkzeug multipart parsing/spooling before authorization and
+    # the declared-size limit have been evaluated.
+    token = flask.request.headers.get('Bearer', None)
+    if not api_check_admin(token, flask.request.headers.get('Cookie', '')):
+        return "Forbidden", 403
+    if flask.request.content_length and flask.request.content_length > VIDEO_MAX_BYTES + 1024 * 1024:
+        return _video_error(413, "video_too_large", "Размер видео превышает допустимый лимит.")
     if 'file' not in flask.request.files:
         return "No file part", 400
     file = flask.request.files['file']
     if file.filename == '':
         return "No selected file", 400
-    token = flask.request.headers.get('Bearer', None)
-    if not api_check_admin(token, flask.request.headers.get('Cookie', '')):
-        return "Forbidden", 403
     extension = file.filename.rsplit('.', 1)[-1].lower() if '.' in file.filename else ""
     if extension == "mov":
         if not VIDEO_MOV_ENABLED:
             return _video_error(415, "mov_upload_disabled", "Загрузка MOV временно отключена.")
-        if flask.request.content_length and flask.request.content_length > VIDEO_MAX_BYTES + 1024 * 1024:
-            return _video_error(413, "video_too_large", "Размер видео превышает допустимый лимит.")
-        return _save_normalized_mov(file)
     filename = hashlib.md5(file.filename.encode() + str(datetime.now()).encode()).hexdigest() + "." + extension
     category = config["supported"].get(extension, "other")
     file_path = os.path.join(ROOT_PATH, config["paths"][category])

--- a/src/python-helpers/flask_uploader.py
+++ b/src/python-helpers/flask_uploader.py
@@ -1,5 +1,8 @@
 import flask
 import json, os
+import logging
+import subprocess
+import threading
 import requests
 from datetime import datetime
 import hashlib
@@ -8,14 +11,128 @@ import uuid
 # docker build -f dockerfile.uploader -t flask-uploader:latest .
 
 app = flask.Flask(__name__)
-app.config['MAX_CONTENT_LENGTH'] = 100 * 1024 * 1024 * 10
-
-
 ROOT_PATH = "/app/pages"
 current_path = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(current_path, 'UploaderConfig.json'), 'r') as f:
     config = json.load(f)
 MAX_AVATAR_SIZE = int(config.get("max_avatar_size", 5 * 1024 * 1024))
+
+
+
+def _video_setting(name, default):
+    value = os.environ.get("UPLOADER_VIDEO_" + name.upper(), config.get("video", {}).get(name, default))
+    if isinstance(default, bool):
+        return str(value).lower() in {"1", "true", "yes", "on"}
+    return int(value)
+
+
+VIDEO_MAX_BYTES = _video_setting("max_bytes", 524288000)
+VIDEO_MAX_DURATION = _video_setting("max_duration_seconds", 900)
+VIDEO_MAX_WIDTH = _video_setting("max_width", 3840)
+VIDEO_MAX_HEIGHT = _video_setting("max_height", 2160)
+VIDEO_PROBE_TIMEOUT = _video_setting("probe_timeout_seconds", 30)
+VIDEO_REMUX_TIMEOUT = _video_setting("remux_timeout_seconds", 300)
+VIDEO_MOV_ENABLED = _video_setting("mov_input_enabled", True)
+VIDEO_JOBS = threading.BoundedSemaphore(_video_setting("max_concurrent_jobs", 2))
+app.config['MAX_CONTENT_LENGTH'] = max(100 * 1024 * 1024 * 10, VIDEO_MAX_BYTES + 1024 * 1024)
+
+
+def _video_error(status, code, message):
+    return flask.jsonify(code=code, message=message), status
+
+
+def _probe(path, timeout):
+    completed = subprocess.run(
+        ["ffprobe", "-v", "error", "-print_format", "json", "-show_format", "-show_streams", path],
+        capture_output=True, text=True, timeout=timeout, check=False, shell=False)
+    if completed.returncode != 0:
+        raise ValueError("ffprobe failed")
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise ValueError("invalid ffprobe output") from error
+
+
+def _validate_video_probe(probe, require_mp4=False):
+    formats = set(str(probe.get("format", {}).get("format_name", "")).split(","))
+    if not ({"mov", "mp4"} & formats):
+        return 415, "unsupported_video_container", "Видео должно быть в контейнере MOV/MP4."
+    streams = probe.get("streams")
+    if not isinstance(streams, list):
+        return 415, "invalid_video", "Видео не удалось распознать."
+    videos = [stream for stream in streams if stream.get("codec_type") == "video"]
+    audios = [stream for stream in streams if stream.get("codec_type") == "audio"]
+    if len(videos) != 1:
+        return 415, "unsupported_video_streams", "Видео должно содержать один видеопоток."
+    video = videos[0]
+    if video.get("codec_name") != "h264":
+        return 415, "unsupported_video_codec", "Видео использует неподдерживаемый кодек. Экспортируйте его как MP4: H.264, звук AAC."
+    if video.get("pix_fmt") not in {"yuv420p", "yuvj420p"}:
+        return 415, "unsupported_video_pixel_format", "Поддерживается только 8-битное видео H.264 4:2:0."
+    if len(audios) > 1 or (audios and (audios[0].get("codec_name") != "aac" or audios[0].get("profile") != "LC")):
+        return 415, "unsupported_audio_codec", "Поддерживается только звук AAC LC."
+    try:
+        width, height = int(video["width"]), int(video["height"])
+        duration = float(probe.get("format", {}).get("duration", video.get("duration", 0)))
+    except (KeyError, TypeError, ValueError):
+        return 415, "invalid_video", "Видео не удалось распознать."
+    if duration <= 0:
+        return 415, "invalid_video", "Видео не удалось распознать."
+    if duration > VIDEO_MAX_DURATION or width > VIDEO_MAX_WIDTH or height > VIDEO_MAX_HEIGHT:
+        return 422, "video_limits_exceeded", "Видео превышает допустимую длительность или разрешение."
+    return None
+
+
+def _save_normalized_mov(file):
+    if not VIDEO_JOBS.acquire(blocking=False):
+        response, status = _video_error(429, "video_queue_busy", "Очередь обработки видео занята. Попробуйте позже.")
+        response.headers["Retry-After"] = "30"
+        return response, status
+    incoming = output_part = None
+    try:
+        incoming_dir = os.path.join(ROOT_PATH, config["paths"]["videos"], ".incoming")
+        os.makedirs(incoming_dir, exist_ok=True)
+        identifier = uuid.uuid4().hex
+        incoming = os.path.join(incoming_dir, identifier + ".mov")
+        output_part = os.path.join(incoming_dir, identifier + ".mp4.part")
+        relative = os.path.join(config["paths"]["videos"], identifier + ".mp4").replace(os.sep, "/")
+        final = os.path.join(ROOT_PATH, relative)
+        os.makedirs(os.path.dirname(final), exist_ok=True)
+        file.save(incoming)
+        if os.path.getsize(incoming) > VIDEO_MAX_BYTES:
+            return _video_error(413, "video_too_large", "Размер видео превышает допустимый лимит.")
+        try:
+            error = _validate_video_probe(_probe(incoming, VIDEO_PROBE_TIMEOUT))
+        except (OSError, subprocess.TimeoutExpired, ValueError) as exc:
+            logging.warning("MOV probe failed: %s", exc)
+            return _video_error(415, "invalid_video", "Видео не удалось распознать. Экспортируйте его как MP4: H.264, звук AAC.")
+        if error:
+            return _video_error(*error)
+        try:
+            completed = subprocess.run(
+                ["ffmpeg", "-nostdin", "-hide_banner", "-loglevel", "error", "-y", "-i", incoming,
+                 "-map", "0:v:0", "-map", "0:a:0?", "-map_metadata", "0", "-c", "copy",
+                 "-movflags", "+faststart", "-f", "mp4", output_part],
+                capture_output=True, text=True, timeout=VIDEO_REMUX_TIMEOUT, check=False, shell=False)
+            if completed.returncode != 0 or not os.path.isfile(output_part) or os.path.getsize(output_part) == 0:
+                raise ValueError("ffmpeg failed")
+            error = _validate_video_probe(_probe(output_part, VIDEO_PROBE_TIMEOUT), require_mp4=True)
+            if error:
+                return _video_error(*error)
+        except (OSError, subprocess.TimeoutExpired, ValueError) as exc:
+            logging.exception("MOV remux failed: %s", exc)
+            return _video_error(500, "video_processing_failed", "Не удалось обработать видео. Попробуйте снова.")
+        os.replace(output_part, final)
+        output_part = None
+        return flask.jsonify(file="/" + relative, normalized=True)
+    finally:
+        for path in (incoming, output_part):
+            if path:
+                try:
+                    os.remove(path)
+                except FileNotFoundError:
+                    pass
+        VIDEO_JOBS.release()
 
 def api_get_upload_capabilities(token: str, cookie: str = ""):
     if not config["check_admin"]:
@@ -62,18 +179,23 @@ def upload_file():
     file = flask.request.files['file']
     if file.filename == '':
         return "No selected file", 400
-    file.filename.replace(" ", "_")
-    extention = file.filename.split('.')[-1].lower()
-    file.filename = hashlib.md5(file.filename.encode() + str(datetime.now()).encode()).hexdigest() + "." + extention
-    upload_category = config["supported"].get(extention, "other")
-    file_path = os.path.join(ROOT_PATH, config["paths"][upload_category])
     token = flask.request.headers.get('Bearer', None)
     if not api_check_admin(token, flask.request.headers.get('Cookie', '')):
         return "Forbidden", 403
-    
-    file.save(os.path.join(file_path, file.filename))
+    extension = file.filename.rsplit('.', 1)[-1].lower() if '.' in file.filename else ""
+    if extension == "mov":
+        if not VIDEO_MOV_ENABLED:
+            return _video_error(415, "mov_upload_disabled", "Загрузка MOV временно отключена.")
+        if flask.request.content_length and flask.request.content_length > VIDEO_MAX_BYTES + 1024 * 1024:
+            return _video_error(413, "video_too_large", "Размер видео превышает допустимый лимит.")
+        return _save_normalized_mov(file)
+    filename = hashlib.md5(file.filename.encode() + str(datetime.now()).encode()).hexdigest() + "." + extension
+    category = config["supported"].get(extension, "other")
+    file_path = os.path.join(ROOT_PATH, config["paths"][category])
+    os.makedirs(file_path, exist_ok=True)
+    file.save(os.path.join(file_path, filename))
+    return flask.jsonify(file="/" + os.path.join(config["paths"][category], filename).replace(os.sep, "/"))
 
-    return '{"file": "/' + str(os.path.join(config["paths"][upload_category], file.filename)) + '"}'
 
 @app.route('/avatar', methods=['POST'])
 def upload_avatar():

--- a/src/python-helpers/flask_uploader.py
+++ b/src/python-helpers/flask_uploader.py
@@ -199,6 +199,7 @@ def upload_file():
     if extension == "mov":
         if not VIDEO_MOV_ENABLED:
             return _video_error(415, "mov_upload_disabled", "Загрузка MOV временно отключена.")
+        return _save_normalized_mov(file)
     filename = hashlib.md5(file.filename.encode() + str(datetime.now()).encode()).hexdigest() + "." + extension
     category = config["supported"].get(extension, "other")
     file_path = os.path.join(ROOT_PATH, config["paths"][category])

--- a/test/test_flask_uploader.py
+++ b/test/test_flask_uploader.py
@@ -87,3 +87,51 @@ def test_generic_upload_accepts_legacy_auth_response(monkeypatch, tmp_path):
         "/", data={"file": (io.BytesIO(PNG), "legacy.png")},
         headers={"Bearer": "legacy"})
     assert response.status_code == 200
+
+
+
+def mov_probe(codec="h264", pix_fmt="yuv420p", audio="aac", profile="LC"):
+    streams = [{"codec_type": "video", "codec_name": codec, "pix_fmt": pix_fmt, "width": 848, "height": 464}]
+    if audio:
+        streams.append({"codec_type": "audio", "codec_name": audio, "profile": profile})
+    return {"format": {"format_name": "mov,mp4,m4a,3gp,3g2,mj2", "duration": "11.77"}, "streams": streams}
+
+
+def test_mov_is_remuxed_to_mp4_and_never_published_as_mov(client, monkeypatch):
+    c, root = client
+    monkeypatch.setattr(uploader, "api_check_admin", lambda *args: True)
+    monkeypatch.setattr(uploader, "_probe", lambda *args: mov_probe())
+
+    def fake_run(args, **kwargs):
+        assert isinstance(args, list) and kwargs["shell"] is False
+        if args[0] == "ffmpeg":
+            Path(args[-1]).write_bytes(b"remuxed")
+        return type("Result", (), {"returncode": 0, "stdout": "{}"})()
+
+    monkeypatch.setattr(uploader.subprocess, "run", fake_run)
+    response = c.post("/", data={"file": (io.BytesIO(b"mov data"), "camera.mov")}, headers={"Bearer": "x"})
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["normalized"] is True and body["file"].endswith(".mp4")
+    assert (root / body["file"].lstrip("/")).is_file()
+    assert not list(root.rglob("*.mov"))
+    assert not list(root.rglob("*.part"))
+
+
+def test_mov_rejects_unsupported_codec_without_publishing(client, monkeypatch):
+    c, root = client
+    monkeypatch.setattr(uploader, "api_check_admin", lambda *args: True)
+    monkeypatch.setattr(uploader, "_probe", lambda *args: mov_probe(codec="hevc"))
+    response = c.post("/", data={"file": (io.BytesIO(b"mov data"), "camera.mov")}, headers={"Bearer": "x"})
+    assert response.status_code == 415
+    assert response.get_json()["code"] == "unsupported_video_codec"
+    assert not list(root.rglob("*.mov")) and not list(root.rglob("*.mp4"))
+
+
+def test_unauthorized_mov_does_not_start_processing(client, monkeypatch):
+    c, root = client
+    monkeypatch.setattr(uploader, "api_check_admin", lambda *args: False)
+    monkeypatch.setattr(uploader, "_probe", lambda *args: pytest.fail("must not probe"))
+    response = c.post("/", data={"file": (io.BytesIO(b"mov data"), "camera.mov")}, headers={"Bearer": "x"})
+    assert response.status_code == 403
+    assert not root.exists() or not list(root.rglob("*"))

--- a/test/test_flask_uploader.py
+++ b/test/test_flask_uploader.py
@@ -94,7 +94,7 @@ def mov_probe(codec="h264", pix_fmt="yuv420p", audio="aac", profile="LC"):
     streams = [{"codec_type": "video", "codec_name": codec, "pix_fmt": pix_fmt, "width": 848, "height": 464}]
     if audio:
         streams.append({"codec_type": "audio", "codec_name": audio, "profile": profile})
-    return {"format": {"format_name": "mov,mp4,m4a,3gp,3g2,mj2", "duration": "11.77"}, "streams": streams}
+    return {"format": {"format_name": "mov,mp4,m4a,3gp,3g2,mj2", "duration": "11.77", "tags": {"major_brand": "isom"}}, "streams": streams}
 
 
 def test_mov_is_remuxed_to_mp4_and_never_published_as_mov(client, monkeypatch):

--- a/test/test_migrate_mov_media.py
+++ b/test/test_migrate_mov_media.py
@@ -20,3 +20,27 @@ def test_backup_manifests_are_immutable_across_reruns(tmp_path):
     assert current != previous
     assert manifest.read_text() == '[{"post_id": 2838, "media": "/docs/original.mov"}]'
     assert current_manifest.read_text() == "[]"
+
+
+def test_migration_rejects_traversal_and_symlink_escape(tmp_path):
+    media_root = tmp_path / "media"
+    docs = media_root / "docs"
+    docs.mkdir(parents=True)
+    outside = tmp_path / "outside.mov"
+    outside.write_bytes(b"outside")
+    (docs / "linked.mov").symlink_to(outside)
+    for media in ("/docs/../../outside.mov", "/docs/linked.mov", "/tmp/odd.mov"):
+        try:
+            migration.safe_source(media_root, media)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"unsafe path accepted: {media}")
+
+
+def test_backup_path_stays_inside_immutable_run(tmp_path):
+    run = migration.create_backup_run(tmp_path / "backups")
+    source = tmp_path / "media" / "docs" / "safe.mov"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"safe")
+    assert migration.safe_backup_path(run, (tmp_path / "media").resolve(), source.resolve()).is_relative_to(run.resolve())

--- a/test/test_migrate_mov_media.py
+++ b/test/test_migrate_mov_media.py
@@ -1,0 +1,22 @@
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).parents[1] / "scripts/migrate_mov_media.py"
+spec = importlib.util.spec_from_file_location("migrate_mov_media", MODULE_PATH)
+migration = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(migration)
+
+
+def test_backup_manifests_are_immutable_across_reruns(tmp_path):
+    previous = tmp_path / "run-previous"
+    previous.mkdir()
+    manifest = previous / "post_media_rows.json"
+    manifest.write_text('[{"post_id": 2838, "media": "/docs/original.mov"}]')
+
+    current = migration.create_backup_run(tmp_path)
+    current_manifest = current / "post_media_rows.json"
+    current_manifest.write_text("[]")
+
+    assert current != previous
+    assert manifest.read_text() == '[{"post_id": 2838, "media": "/docs/original.mov"}]'
+    assert current_manifest.read_text() == "[]"


### PR DESCRIPTION
Closes #205.\n\nPaired frontend change: letovo-dev/letovo-all-frontend#52.\n\n- validate MOV content with ffprobe before publishing\n- remux only compatible H.264/AAC-LC video to a server-generated MP4 path\n- bound video jobs and clean temporary files\n- add ffmpeg/ffprobe to the uploader image and CI verification\n- align OGG public media support with existing uploader/frontend policy