### PR TITLE
feat: два режима редактора статей с переключателем (#209)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -349,6 +349,10 @@ jobs:
         working-directory: frontend
         run: npm run test:image-lightbox
 
+      - name: Verify article editor modes
+        working-directory: frontend
+        run: npm run test:article-editor-modes
+
       - name: Build frontend
         working-directory: frontend
         env:


### PR DESCRIPTION
Closes #209.

Вместо «выбрать один вариант редактора» — оба режима доступны автору статьи, переключатель прямо над текстом. Реализация во фронтовом сабмодуле: letovo-dev/letovo-all-frontend#54.

## Что в этом PR

- бамп gitlink `frontend`: `f4d6b5d` → `c6e9cef`;
- новый шаг в `frontend-verify`: `npm run test:article-editor-modes`.

## Что делает фронтовый PR

**Общий рендерер статьи.** `pages_fsd/articles/ReactMd.tsx` и стили статьи переехали в `shared/ui/article-content/`. Раньше страница `/articles` и превью редактора были двумя независимыми пайплайнами — из-за этого превью и не совпадало с публикацией. Теперь это один компонент и один набор стилей.

**Режим «Разметка».** Свой редактор вместо `@uiw/react-md-editor`: панель форматирования в стилистике сайта (заголовки, жирный/курсив/зачёркнутый, код, списки, цитата, таблица, ссылка, картинка, видео), Ctrl+B / Ctrl+I, подсказка по синтаксису. Справа — живое превью в контейнере ширины статьи (519px десктоп / 390px мобильный, переключатель в превью).

**Режим «Как на сайте».** `contenteditable` поверх уже отрисованной статьи: разметку набирать не нужно. На каждое изменение DOM сериализуется обратно в Markdown — формат хранения (`.md`) и серверное API не меняются, старые статьи открываются и пересохраняются. Вставка из Word / Google Docs очищается до текста.

**Мелочи.** Выбранный режим запоминается в `localStorage`; адреса из диалогов вставки проверяются, `javascript:` в статью не попадает; `@uiw/react-md-editor` удалён из зависимостей.

## Проверено

В сабмодуле: `npm run test:article-editor-modes` — 6/6, `npm run test:image-lightbox` — 3/3, `tsc --noEmit` чисто, `next lint` без предупреждений, `npm run build` успешно.

Живого прогона в задеплоенном приложении под учёткой автора статей не было — проверка на тестах, типах и сборке.

## Чего здесь нет

HTML-макеты редактора (две версии на выбор) остались в закрытом #210 — при подходе «оба режима сразу» выбирать нечего. Если они нужны как справочник по оформлению, ветка `feat/issue-209-article-editor-prototypes` на месте.

🤖 Generated with [Claude Code](https://claude.com/claude-code)